### PR TITLE
refactor(server-protocol): serve repositories without root sessions

### DIFF
--- a/.changenotes/lix-opened-session-bind.md
+++ b/.changenotes/lix-opened-session-bind.md
@@ -4,4 +4,4 @@ type: patch
 
 Added a vendor-neutral `lix.repository.opened` engine span when a client session binds to a Lix.
 
-In-process `open_lix()` and protocol handshake session creation each emit one span. Protocol roots and cached runtimes opened with `as_protocol_root()` attach a telemetry sink without emitting. Hosts that mint a session against an already-open runtime call `Lix::bind_session()` or `lix::bind_session`.
+In-process `open_lix()` and protocol handshake session creation each emit one span. Protocol servers opened with `open_lix().serve()` attach their telemetry sink while creating no application session and emitting no opened span. Hosts that mint a session against an already-open runtime call `Lix::bind_session()` or `lix::bind_session`.

--- a/.changenotes/serve-protocol-engine.md
+++ b/.changenotes/serve-protocol-engine.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Open a Lix Server Protocol authority with `open_lix().with_storage(storage).serve().await`.
+
+Serving now owns the repository engine directly and retains one application session per successful handshake. The former `OpenLixBuilder::as_protocol_root()`, `LixServerProtocol::new()`, and `LixServerProtocol::with_options()` APIs were removed. Configure limits with `open_lix().serve().with_options(options).await`.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -80,13 +80,14 @@ lix = { version = "0.11", features = ["server-protocol"] }
 Open a repository and keep one `LixServerProtocol` for as long as it is hosted:
 
 ```rust
-use std::sync::Arc;
 use lix::server_protocol::{
-    LixServerProtocol, ServerProtocolContext, ServerProtocolPrincipal,
+    ServerProtocolContext, ServerProtocolPrincipal,
 };
 
-let repository = Arc::new(lix::open_lix().await?);
-let protocol = LixServerProtocol::new(repository);
+let protocol = lix::open_lix()
+    .with_storage(storage)
+    .serve()
+    .await?;
 
 // Your host authenticates first, then calls the protocol.
 let context = ServerProtocolContext {

--- a/packages/e2e/tests/crash_consistency_qualification.rs
+++ b/packages/e2e/tests/crash_consistency_qualification.rs
@@ -92,8 +92,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use lix::server_protocol::{
-    FILE_UPLOAD_ID_HEADER, LixServerProtocol, SESSION_ID_HEADER, ServerProtocolBody,
-    ServerProtocolContext,
+    FILE_UPLOAD_ID_HEADER, SESSION_ID_HEADER, ServerProtocolBody, ServerProtocolContext,
 };
 use lix::storage::{
     CommitResult, Key, KeyRange, PutBatch, ReadOptions, Storage, StorageError, StorageSpace,
@@ -1325,14 +1324,11 @@ fn await_durable_publication_round_trips_through_the_resumable_upload_path() {
     block_on(move || async move {
         {
             let storage = RocksDB::open(&path).expect("open durable round-trip store");
-            let lix = Arc::new(
-                open_lix()
-                    .with_storage(storage.clone())
-                    .as_protocol_root()
-                    .await
-                    .expect("open durable round-trip Lix"),
-            );
-            let server = LixServerProtocol::new(Arc::clone(&lix));
+            let server = open_lix()
+                .with_storage(storage.clone())
+                .serve()
+                .await
+                .expect("serve durable round-trip Lix");
             let handshake = server
                 .handle(
                     http::Request::builder()

--- a/packages/e2e/tests/server_protocol_durable_idempotency.rs
+++ b/packages/e2e/tests/server_protocol_durable_idempotency.rs
@@ -162,14 +162,11 @@ async fn open_server() -> (
     String,
 ) {
     let storage = PostCommitUnknownSlateDB::new();
-    let lix = Arc::new(
-        lix::open_lix()
-            .with_storage(storage.clone())
-            .as_protocol_root()
-            .await
-            .expect("open Lix"),
-    );
-    let server = LixServerProtocol::new(lix);
+    let server = lix::open_lix()
+        .with_storage(storage.clone())
+        .serve()
+        .await
+        .expect("serve Lix");
     let handshake = request(&server, "GET", "/lix/v1", None, None, None).await;
     assert_eq!(handshake.status(), StatusCode::OK);
     let session_id = json_body(handshake).await["sessionId"]

--- a/packages/e2e/tests/server_protocol_plugin_convergence.rs
+++ b/packages/e2e/tests/server_protocol_plugin_convergence.rs
@@ -1,20 +1,22 @@
 use std::io::{Cursor, Write as _};
 use std::path::Path;
-use std::sync::Arc;
-
 use http::{Request, StatusCode, header::CONTENT_TYPE};
 use http_body_util::BodyExt as _;
 use lix::server_protocol::{
     LixServerProtocol, SESSION_ID_HEADER, ServerProtocolBody, ServerProtocolContext,
     ServerProtocolResponse, TRANSACTION_ID_HEADER,
 };
-use lix::{Value, open_lix};
+use lix::{Memory, Value, open_lix};
 use serde_json::{Value as JsonValue, json};
 
 #[tokio::test]
 async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
-    let root = Arc::new(open_lix().as_protocol_root().await.expect("open Lix"));
-    root.execute(
+    let storage = Memory::new();
+    let setup = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open setup Lix");
+    setup.execute(
         "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
         &[
             Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
@@ -23,14 +25,19 @@ async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
     )
     .await
     .expect("install JSON plugin");
-    root.execute(
+    setup.execute(
         "INSERT INTO lix_file (path, content) VALUES ('/remote-conflict.json', $1)",
         &[Value::Blob(br#"{"value":"base"}"#.to_vec().into())],
     )
     .await
     .expect("write base JSON file");
 
-    let protocol = LixServerProtocol::new(Arc::clone(&root));
+    setup.close().await.expect("close setup Lix");
+    let protocol = open_lix()
+        .with_storage(storage.clone())
+        .serve()
+        .await
+        .expect("serve Lix");
     let sessions = [
         open_session(&protocol).await,
         open_session(&protocol).await,
@@ -75,7 +82,11 @@ async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
     }
 
-    let forks = root
+    let verifier = open_lix()
+        .with_storage(storage)
+        .await
+        .expect("open verification Lix");
+    let forks = verifier
         .execute(
             "SELECT parent_id, COUNT(*) AS children FROM lix_commit_edge \
              GROUP BY parent_id HAVING COUNT(*) > 1",
@@ -84,6 +95,7 @@ async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
         .await
         .unwrap();
     assert_eq!(forks.len(), 0, "remote writers must not fork history");
+    verifier.close().await.expect("close verification Lix");
 
     let mut visible = Vec::new();
     for session in &sessions {
@@ -106,7 +118,7 @@ async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
     protocol.close().await.unwrap();
 }
 
-async fn open_session(protocol: &LixServerProtocol<lix::Memory>) -> String {
+async fn open_session(protocol: &LixServerProtocol<Memory>) -> String {
     let response = request(protocol, "GET", "/lix/v1", None, None, None).await;
     assert_eq!(response.status(), StatusCode::OK);
     response_json(response).await["sessionId"]
@@ -115,7 +127,7 @@ async fn open_session(protocol: &LixServerProtocol<lix::Memory>) -> String {
         .to_owned()
 }
 
-async fn begin_transaction(protocol: &LixServerProtocol<lix::Memory>, session: &str) -> String {
+async fn begin_transaction(protocol: &LixServerProtocol<Memory>, session: &str) -> String {
     let response = request(
         protocol,
         "POST",
@@ -133,7 +145,7 @@ async fn begin_transaction(protocol: &LixServerProtocol<lix::Memory>, session: &
 }
 
 async fn commit(
-    protocol: &LixServerProtocol<lix::Memory>,
+    protocol: &LixServerProtocol<Memory>,
     session: &str,
     transaction: &str,
 ) -> ServerProtocolResponse {
@@ -149,7 +161,7 @@ async fn commit(
 }
 
 async fn transaction_request(
-    protocol: &LixServerProtocol<lix::Memory>,
+    protocol: &LixServerProtocol<Memory>,
     method: &str,
     path: &str,
     session: &str,
@@ -168,7 +180,7 @@ async fn transaction_request(
 }
 
 async fn request(
-    protocol: &LixServerProtocol<lix::Memory>,
+    protocol: &LixServerProtocol<Memory>,
     method: &str,
     path: &str,
     session: Option<&str>,

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -17,8 +17,9 @@ use lix::server_protocol::{
     LixServerProtocol, ServerProtocolBody, ServerProtocolContext, ServerProtocolPrincipal,
 };
 use lix::storage::Storage;
-use lix::{ExecuteBatchStatement, Lix, Memory, ServerOptions, Value, open_lix};
+use lix::{ExecuteBatchStatement, Lix, Memory, ServerOptions, Value, WireValue, open_lix};
 use lix_storage_filesystem::FilesystemStorage;
+use serde_json::{Value as JsonValue, json};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 
@@ -47,7 +48,7 @@ struct HttpProbe {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn synced_partial_file_checkpoint_stays_off_cold_history() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     for index in 0..50 {
         put_value(
             &authority,
@@ -60,9 +61,10 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
         .create_checkpoint()
         .await
         .expect("checkpoint cold snapshot baseline");
+    authority.close().await.expect("close authority setup");
 
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
     probe.set_push_offline(true);
@@ -158,12 +160,11 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
     probe.set_push_offline(false);
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn first_local_write_pushes_before_deferred_history_is_read() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/shared.md', CAST('Hello world' AS BYTEA))",
@@ -172,8 +173,10 @@ async fn first_local_write_pushes_before_deferred_history_is_read() {
         .await
         .expect("seed shared file");
     put_value(&authority, "head", "visible").await;
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
 
@@ -191,38 +194,21 @@ async fn first_local_write_pushes_before_deferred_history_is_read() {
         )
         .await
         .expect("edit file before reading history");
-    tokio::time::timeout(WAIT_TIMEOUT, async {
-        loop {
-            let result = authority
-                .execute(
-                    "SELECT content FROM lix_file WHERE path = '/shared.md'",
-                    &[],
-                )
-                .await
-                .expect("read authority file");
-            if result.rows()[0]
-                .get::<Vec<u8>>("content")
-                .expect("file content decodes")
-                == b"Hello worlds"
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("file edit reaches authority");
+    protocol_authority
+        .wait_for_file_content("/shared.md", b"Hello worlds")
+        .await;
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn sync_runtime_outlives_the_primary_session() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     put_value(&authority, "seed", "authority").await;
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::default()).await;
+    authority.close().await.expect("close authority setup");
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::default()).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let primary = open_replica(replica_dir.path(), &url).await;
     let child = primary
@@ -232,14 +218,17 @@ async fn sync_runtime_outlives_the_primary_session() {
 
     primary.close().await.expect("close primary session");
     put_value(&child, "from-child", "after-primary-close").await;
-    wait_for_value(&authority, "from-child", "after-primary-close").await;
+    protocol_authority
+        .wait_for_value("from-child", "after-primary-close")
+        .await;
 
-    put_value(&authority, "from-authority", "child-still-live").await;
+    protocol_authority
+        .put_value("from-authority", "child-still-live")
+        .await;
     wait_for_value(&child, "from-authority", "child-still-live").await;
 
     child.close().await.expect("close final session");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 impl HttpProbe {
@@ -280,14 +269,16 @@ impl HttpProbe {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fresh_bootstrap_reads_authority_then_local_write_reaches_server() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let authority_lix_id = authority.lix_id().to_owned();
     put_value(&authority, "bootstrap-parent", "lazy-history").await;
     let history_parent = active_head(&authority).await;
     put_value(&authority, "bootstrap", "from-authority").await;
     let history_head = active_head(&authority).await;
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
 
@@ -349,28 +340,12 @@ async fn fresh_bootstrap_reads_authority_then_local_write_reaches_server() {
             .expect("new file content should decode"),
         b"works",
     );
-    wait_for_value(&authority, "local", "from-replica").await;
-    tokio::time::timeout(WAIT_TIMEOUT, async {
-        loop {
-            let rows = authority
-                .execute(
-                    "SELECT content FROM lix_file WHERE path = '/after-bootstrap.txt'",
-                    &[],
-                )
-                .await
-                .expect("authority file query succeeds");
-            if rows
-                .rows()
-                .first()
-                .is_some_and(|row| row.get::<Vec<u8>>("content").ok().as_deref() == Some(b"works"))
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("timed out waiting for first synchronized file");
+    protocol_authority
+        .wait_for_value("local", "from-replica")
+        .await;
+    protocol_authority
+        .wait_for_file_content("/after-bootstrap.txt", b"works")
+        .await;
 
     replica.close().await.expect("close replica");
     drop(replica);
@@ -382,12 +357,11 @@ async fn fresh_bootstrap_reads_authority_then_local_write_reaches_server() {
     );
     reopened.close().await.expect("close reopened replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_pages() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/gone.md', CAST('version one' AS BYTEA))",
@@ -439,9 +413,10 @@ async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_p
         put_value(&authority, &format!("history-page-{index:03}"), "value").await;
     }
     let head = active_head(&authority).await;
+    authority.close().await.expect("close authority setup");
 
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
 
@@ -492,12 +467,11 @@ async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_p
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let inserted = authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/bounded.md', CAST('version-00' AS BYTEA)) RETURNING id",
@@ -546,9 +520,10 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
             .expect("authority history content decodes"),
         b"version-31",
     );
+    authority.close().await.expect("close authority setup");
 
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
     let history_before = probe.history_gets.load(Ordering::Acquire);
@@ -584,12 +559,11 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn sparse_checkpoint_history_hydrates_missing_bodies_concurrently() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let inserted = authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/checkpoint.md', CAST('version-00' AS BYTEA)) RETURNING id",
@@ -621,9 +595,10 @@ async fn sparse_checkpoint_history_hydrates_missing_bodies_concurrently() {
         );
     }
     let latest_checkpoint = latest_checkpoint.expect("latest checkpoint captured");
+    authority.close().await.expect("close authority setup");
 
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
     probe.set_round_trip_delay(Duration::from_millis(500));
@@ -651,12 +626,11 @@ async fn sparse_checkpoint_history_hydrates_missing_bodies_concurrently() {
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fresh_bootstrap_pages_more_than_one_window_of_hot_rows() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let statements = (0..OFFLINE_COMMIT_COUNT)
         .map(|index| ExecuteBatchStatement {
             label: None,
@@ -671,8 +645,9 @@ async fn fresh_bootstrap_pages_more_than_one_window_of_hot_rows() {
         .execute_batch(&statements)
         .await
         .expect("seed more hot rows than one snapshot page");
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
 
@@ -691,14 +666,14 @@ async fn fresh_bootstrap_pages_more_than_one_window_of_hot_rows() {
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn warm_filesystem_replica_reopens_and_writes_while_offline() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     put_value(&authority, "cached", "durable").await;
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::default()).await;
+    authority.close().await.expect("close authority setup");
+    let (url, server_task) = serve(authority_storage.clone(), Arc::default()).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
     assert_eq!(
@@ -728,20 +703,20 @@ async fn warm_filesystem_replica_reopens_and_writes_while_offline() {
     );
 
     offline.close().await.expect("close offline replica");
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn authenticated_identity_survives_fresh_push_and_offline_reopen() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     put_value(&authority, "authenticated-seed", "server").await;
     let principal = ServerProtocolPrincipal::Authenticated {
         account_id: lix::SYSTEM_ACCOUNT_ID.to_owned(),
         idempotency_scope: "sync-mode-authenticated-e2e".to_owned(),
     };
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve_as(
-        Arc::clone(&authority),
+    let (url, server_task, protocol_authority) = serve_as_with_authority_session(
+        authority_storage.clone(),
         Arc::clone(&probe),
         principal.clone(),
     )
@@ -751,7 +726,9 @@ async fn authenticated_identity_survives_fresh_push_and_offline_reopen() {
 
     assert_eq!(active_account(&replica).await, lix::SYSTEM_ACCOUNT_ID);
     put_value(&replica, "authenticated-fresh", "accepted").await;
-    wait_for_value(&authority, "authenticated-fresh", "accepted").await;
+    protocol_authority
+        .wait_for_value("authenticated-fresh", "accepted")
+        .await;
     assert!(
         probe.pushes.load(Ordering::Acquire) > 0,
         "authenticated fresh write should reach the authority through sync push",
@@ -783,15 +760,16 @@ async fn authenticated_identity_survives_fresh_push_and_offline_reopen() {
         .close()
         .await
         .expect("close authenticated offline replica");
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn more_than_one_offline_push_window_drains_after_reconnect() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let commits_before = commit_count(&authority).await;
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
     wait_for_counter(&probe.delta_pulls, 1).await;
@@ -824,7 +802,11 @@ async fn more_than_one_offline_push_window_drains_after_reconnect() {
     probe.set_offline(false);
     tokio::time::timeout(Duration::from_secs(60), async {
         loop {
-            if read_value(&authority, "offline-window").await.as_deref() == Some(expected.as_str())
+            if protocol_authority
+                .read_value("offline-window")
+                .await
+                .as_deref()
+                == Some(expected.as_str())
             {
                 break;
             }
@@ -834,7 +816,7 @@ async fn more_than_one_offline_push_window_drains_after_reconnect() {
     .await
     .expect("offline outbox should drain after reconnect");
     assert_eq!(
-        commit_count(&authority).await,
+        protocol_authority.commit_count().await,
         commits_before + OFFLINE_COMMIT_COUNT as i64,
     );
     assert!(
@@ -844,15 +826,16 @@ async fn more_than_one_offline_push_window_drains_after_reconnect() {
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_clients_receive_remote_writes_through_a_held_long_poll() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     put_value(&authority, "seed", "ready").await;
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::clone(&probe)).await;
     let alice_dir = TempDir::new().expect("alice tempdir");
     let bob_dir = TempDir::new().expect("bob tempdir");
     let alice = open_replica(alice_dir.path(), &url).await;
@@ -861,9 +844,13 @@ async fn two_clients_receive_remote_writes_through_a_held_long_poll() {
     wait_for_counter(&probe.delta_pulls, 2).await;
     put_value(&alice, "shared", "from-alice").await;
     wait_for_value(&bob, "shared", "from-alice").await;
-    wait_for_value(&authority, "shared", "from-alice").await;
+    protocol_authority
+        .wait_for_value("shared", "from-alice")
+        .await;
     wait_for_counter(&probe.delta_pulls, 3).await;
-    put_value(&authority, "server-originated", "from-authority").await;
+    protocol_authority
+        .put_value("server-originated", "from-authority")
+        .await;
     wait_for_value(&alice, "server-originated", "from-authority").await;
     wait_for_value(&bob, "server-originated", "from-authority").await;
 
@@ -871,20 +858,23 @@ async fn two_clients_receive_remote_writes_through_a_held_long_poll() {
         put_value(&alice, "concurrent-alice", "alice"),
         put_value(&bob, "concurrent-bob", "bob"),
     );
-    wait_for_value(&authority, "concurrent-alice", "alice").await;
-    wait_for_value(&authority, "concurrent-bob", "bob").await;
+    protocol_authority
+        .wait_for_value("concurrent-alice", "alice")
+        .await;
+    protocol_authority
+        .wait_for_value("concurrent-bob", "bob")
+        .await;
     wait_for_value(&alice, "concurrent-bob", "bob").await;
     wait_for_value(&bob, "concurrent-alice", "alice").await;
 
     alice.close().await.expect("close alice");
     bob.close().await.expect("close bob");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_file_insert_and_edit_reconcile_after_one_stale_push() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/existing.md', CAST('base' AS BYTEA))",
@@ -892,8 +882,10 @@ async fn concurrent_file_insert_and_edit_reconcile_after_one_stale_push() {
         )
         .await
         .expect("seed existing file");
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::clone(&probe)).await;
     let alice_dir = TempDir::new().expect("alice tempdir");
     let bob_dir = TempDir::new().expect("bob tempdir");
     let alice = open_replica(alice_dir.path(), &url).await;
@@ -923,8 +915,12 @@ async fn concurrent_file_insert_and_edit_reconcile_after_one_stale_push() {
     created.expect("Alice creates a file locally");
     edited.expect("Bob edits the existing file locally");
 
-    wait_for_file_content(&authority, "/created.md", b"created").await;
-    wait_for_file_content(&authority, "/existing.md", b"edited").await;
+    protocol_authority
+        .wait_for_file_content("/created.md", b"created")
+        .await;
+    protocol_authority
+        .wait_for_file_content("/existing.md", b"edited")
+        .await;
     wait_for_file_content(&alice, "/created.md", b"created").await;
     wait_for_file_content(&alice, "/existing.md", b"edited").await;
     wait_for_file_content(&bob, "/created.md", b"created").await;
@@ -939,7 +935,9 @@ async fn concurrent_file_insert_and_edit_reconcile_after_one_stale_push() {
     // clients consume this authority-only event without another push, their
     // durable outboxes were empty after reconciliation.
     let pushes_after_convergence = probe.pushes.load(Ordering::Acquire);
-    put_value(&authority, "outbox-sentinel", "authority-only").await;
+    protocol_authority
+        .put_value("outbox-sentinel", "authority-only")
+        .await;
     wait_for_value(&alice, "outbox-sentinel", "authority-only").await;
     wait_for_value(&bob, "outbox-sentinel", "authority-only").await;
     assert_eq!(
@@ -951,12 +949,11 @@ async fn concurrent_file_insert_and_edit_reconcile_after_one_stale_push() {
     alice.close().await.expect("close alice");
     bob.close().await.expect("close bob");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn small_file_observer_receives_remote_edit_without_a_chunk_round_trip() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/shared.md', CAST('Hello world' AS BYTEA))",
@@ -964,9 +961,10 @@ async fn small_file_observer_receives_remote_edit_without_a_chunk_round_trip() {
         )
         .await
         .expect("seed shared file");
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
     probe.set_round_trip_delay(Duration::from_millis(100));
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let alice_dir = TempDir::new().expect("alice tempdir");
     let bob_dir = TempDir::new().expect("bob tempdir");
     let alice = open_replica(alice_dir.path(), &url).await;
@@ -1029,16 +1027,16 @@ async fn small_file_observer_receives_remote_edit_without_a_chunk_round_trip() {
     alice.close().await.expect("close alice");
     bob.close().await.expect("close bob");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn held_long_poll_stays_realtime_with_one_hundred_millisecond_rtt() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     put_value(&authority, "seed", "ready").await;
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
     probe.set_round_trip_delay(Duration::from_millis(100));
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let alice_dir = TempDir::new().expect("alice tempdir");
     let bob_dir = TempDir::new().expect("bob tempdir");
     let alice = open_replica(alice_dir.path(), &url).await;
@@ -1065,22 +1063,23 @@ async fn held_long_poll_stays_realtime_with_one_hundred_millisecond_rtt() {
     alice.close().await.expect("close alice");
     bob.close().await.expect("close bob");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn lost_push_ack_retries_the_same_commit_idempotently() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let commits_before = commit_count(&authority).await;
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task, protocol_authority) =
+        serve_with_authority_session(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
     wait_for_counter(&probe.delta_pulls, 1).await;
 
     probe.drop_next_push_ack();
     put_value(&replica, "lost-ack", "once").await;
-    wait_for_value(&authority, "lost-ack", "once").await;
+    protocol_authority.wait_for_value("lost-ack", "once").await;
     replica
         .close()
         .await
@@ -1088,7 +1087,7 @@ async fn lost_push_ack_retries_the_same_commit_idempotently() {
     drop(replica);
     let replica = open_replica(replica_dir.path(), &url).await;
     wait_for_counter(&probe.pushes, 2).await;
-    assert_eq!(commit_count(&authority).await, commits_before + 1);
+    assert_eq!(protocol_authority.commit_count().await, commits_before + 1);
     assert_eq!(
         read_value(&replica, "lost-ack").await.as_deref(),
         Some("once")
@@ -1096,12 +1095,11 @@ async fn lost_push_ack_retries_the_same_commit_idempotently() {
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn binary_chunks_remain_lazy_until_file_content_is_read() {
-    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let (authority_storage, authority) = open_authority().await;
     let payload = (0..5 * 1024 * 1024 + 19)
         .map(|index| (index % 251) as u8)
         .collect::<Vec<_>>();
@@ -1112,8 +1110,9 @@ async fn binary_chunks_remain_lazy_until_file_content_is_read() {
         )
         .await
         .expect("write authority binary file");
+    authority.close().await.expect("close authority setup");
     let probe = Arc::new(HttpProbe::default());
-    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let (url, server_task) = serve(authority_storage.clone(), Arc::clone(&probe)).await;
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
 
@@ -1128,7 +1127,6 @@ async fn binary_chunks_remain_lazy_until_file_content_is_read() {
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
-    authority.close().await.expect("close authority");
 }
 
 async fn open_replica(path: &Path, url: &str) -> Lix<FilesystemStorage> {
@@ -1274,19 +1272,235 @@ async fn wait_for_counter(counter: &AtomicU64, expected: u64) {
     .expect("timed out waiting for HTTP protocol activity");
 }
 
-async fn serve(
-    authority: Arc<Lix<Memory>>,
-    probe: Arc<HttpProbe>,
-) -> (String, tokio::task::JoinHandle<()>) {
-    serve_as(authority, probe, ServerProtocolPrincipal::Anonymous).await
+async fn open_authority() -> (Memory, Arc<Lix<Memory>>) {
+    let storage = Memory::new();
+    let authority = Arc::new(
+        open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("open authority"),
+    );
+    (storage, authority)
+}
+
+async fn serve(storage: Memory, probe: Arc<HttpProbe>) -> (String, tokio::task::JoinHandle<()>) {
+    serve_as(storage, probe, ServerProtocolPrincipal::Anonymous).await
 }
 
 async fn serve_as(
-    authority: Arc<Lix<Memory>>,
+    storage: Memory,
     probe: Arc<HttpProbe>,
     principal: ServerProtocolPrincipal,
 ) -> (String, tokio::task::JoinHandle<()>) {
-    let protocol = LixServerProtocol::new(authority);
+    let protocol = open_lix()
+        .with_storage(storage)
+        .serve()
+        .await
+        .expect("serve authority");
+    spawn_http_server(protocol, probe, principal).await
+}
+
+async fn serve_with_authority_session(
+    storage: Memory,
+    probe: Arc<HttpProbe>,
+) -> (String, tokio::task::JoinHandle<()>, ProtocolAuthority) {
+    serve_as_with_authority_session(storage, probe, ServerProtocolPrincipal::Anonymous).await
+}
+
+async fn serve_as_with_authority_session(
+    storage: Memory,
+    probe: Arc<HttpProbe>,
+    principal: ServerProtocolPrincipal,
+) -> (String, tokio::task::JoinHandle<()>, ProtocolAuthority) {
+    let protocol = open_lix()
+        .with_storage(storage)
+        .serve()
+        .await
+        .expect("serve authority");
+    let authority = ProtocolAuthority::open(protocol.clone(), principal.clone()).await;
+    let (url, task) = spawn_http_server(protocol, probe, principal).await;
+    (url, task, authority)
+}
+
+struct ProtocolAuthority {
+    protocol: LixServerProtocol<Memory>,
+    context: ServerProtocolContext,
+    session_id: String,
+    next_idempotency_key: AtomicU64,
+}
+
+impl ProtocolAuthority {
+    async fn open(protocol: LixServerProtocol<Memory>, principal: ServerProtocolPrincipal) -> Self {
+        let context = ServerProtocolContext {
+            principal,
+            durable_terminal_storage_notifier: None,
+        };
+        let response = protocol
+            .handle(
+                Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1")
+                    .body(ServerProtocolBody::empty())
+                    .expect("build authority handshake"),
+                context.clone(),
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect authority handshake")
+            .to_bytes();
+        let body: JsonValue = serde_json::from_slice(&body).expect("decode authority handshake");
+        Self {
+            protocol,
+            context,
+            session_id: body["sessionId"]
+                .as_str()
+                .expect("authority session id")
+                .to_owned(),
+            next_idempotency_key: AtomicU64::new(0),
+        }
+    }
+
+    async fn execute(&self, sql: &str, params: &[Value]) -> Vec<Vec<Value>> {
+        let idempotency_key = self.next_idempotency_key.fetch_add(1, Ordering::AcqRel);
+        let params = params
+            .iter()
+            .map(WireValue::try_from_engine)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("encode authority execute params");
+        let response = self
+            .protocol
+            .handle(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/execute")
+                    .header("lix-session-id", &self.session_id)
+                    .header(
+                        "idempotency-key",
+                        format!("test-authority-{idempotency_key}"),
+                    )
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(ServerProtocolBody::from(
+                        json!({ "sql": sql, "params": params }).to_string(),
+                    ))
+                    .expect("build authority execute"),
+                self.context.clone(),
+            )
+            .await;
+        let status = response.status();
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect authority execute")
+            .to_bytes();
+        let body: JsonValue = serde_json::from_slice(&body).expect("decode authority execute");
+        assert_eq!(status, StatusCode::OK, "authority execute failed: {body}");
+        serde_json::from_value::<Vec<Vec<WireValue>>>(body["rows"].clone())
+            .expect("decode authority execute rows")
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(WireValue::try_into_engine)
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("decode authority row values")
+            })
+            .collect()
+    }
+
+    async fn put_value(&self, key: &str, value: &str) {
+        self.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) \
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+            &[Value::Text(key.to_owned()), Value::Text(value.to_owned())],
+        )
+        .await;
+    }
+
+    async fn read_value(&self, key: &str) -> Option<String> {
+        self.execute(
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            &[Value::Text(key.to_owned())],
+        )
+        .await
+        .into_iter()
+        .next()
+        .and_then(|row| row.into_iter().next())
+        .and_then(|value| match value {
+            Value::Jsonb(value) => value.as_json_string(),
+            Value::Text(value) => Some(value),
+            _ => None,
+        })
+    }
+
+    async fn read_file_content(&self, path: &str) -> Option<Vec<u8>> {
+        self.execute(
+            "SELECT content FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_owned())],
+        )
+        .await
+        .into_iter()
+        .next()
+        .and_then(|row| row.into_iter().next())
+        .and_then(|value| match value {
+            Value::Blob(value) => Some(value.to_vec()),
+            _ => None,
+        })
+    }
+
+    async fn commit_count(&self) -> i64 {
+        self.execute("SELECT COUNT(*) AS count FROM lix_commit", &[])
+            .await
+            .into_iter()
+            .next()
+            .and_then(|row| row.into_iter().next())
+            .and_then(|value| match value {
+                Value::Integer(value) => Some(value),
+                _ => None,
+            })
+            .expect("integer authority commit count")
+    }
+
+    async fn wait_for_value(&self, key: &str, expected: &str) {
+        tokio::time::timeout(WAIT_TIMEOUT, async {
+            loop {
+                if self.read_value(key).await.as_deref() == Some(expected) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for authoritative value");
+    }
+
+    async fn wait_for_file_content(&self, path: &str, expected: &[u8]) {
+        tokio::time::timeout(WAIT_TIMEOUT, async {
+            loop {
+                if self.read_file_content(path).await.as_deref() == Some(expected) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "timed out waiting for authoritative file content at {path}: {:?}",
+                String::from_utf8_lossy(expected),
+            )
+        });
+    }
+}
+
+async fn spawn_http_server(
+    protocol: LixServerProtocol<Memory>,
+    probe: Arc<HttpProbe>,
+    principal: ServerProtocolPrincipal,
+) -> (String, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind HTTP protocol listener");

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -380,6 +380,39 @@ where
         .await
     }
 
+    /// Creates an active global account if it does not exist.
+    ///
+    /// Account bootstrap is an engine operation because protocol authorities
+    /// have no root application session. The short-lived system session is
+    /// always closed after the write attempt.
+    pub(crate) async fn ensure_account(
+        &self,
+        id: &str,
+        name: &str,
+        kind: &str,
+    ) -> Result<(), LixError> {
+        let system = self
+            .open_session_at_with_account(GLOBAL_BRANCH_ID, crate::SYSTEM_ACCOUNT_ID)
+            .await?;
+        let execute_result = system
+            .execute(
+                "INSERT INTO lix_account \
+                 (id, name, kind, status, lixcol_global, lixcol_untracked) \
+                 VALUES ($1, $2, $3, 'active', true, false) \
+                 ON CONFLICT (id) \
+                 DO NOTHING",
+                &[
+                    crate::Value::Text(id.to_string()),
+                    crate::Value::Text(name.to_string()),
+                    crate::Value::Text(kind.to_string()),
+                ],
+            )
+            .await;
+        let close_result = system.close().await;
+        execute_result?;
+        close_result
+    }
+
     /// Repairs the private working-diff projection produced by the former
     /// partial-checkpoint publication path. The branch control is the durable
     /// authority for `(head, checkpoint)`; HOT rows and their sparse epoch are

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1,7 +1,3 @@
-// The hard-cut keeps a small set of crate-internal transport and profiling
-// helpers that no longer have enabled in-crate callers.
-#![cfg_attr(test, allow(dead_code))]
-
 use lix::plugin::runtime::WasmRuntime;
 use lix::storage::Storage;
 use lix::telemetry::TelemetrySink;
@@ -9,8 +5,7 @@ use lix::{
     Blob, CreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt, ExecuteBatchStatement,
     ExecuteIdempotency, ExecuteResult, ExecuteStatementMetadata, ExecutionDisposition, LixError,
     Memory, MergeBranchOptions, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
-    ObserveEvents, PreparedDmlParameterBatch, RedoReceipt, SwitchBranchOptions,
-    SwitchBranchReceipt, UndoReceipt, Value,
+    ObserveEvents, RedoReceipt, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt, Value,
 };
 use std::{
     future::{Future, IntoFuture},
@@ -72,7 +67,6 @@ pub struct OpenLixBuilder<StorageImpl = Memory> {
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
     telemetry: Option<Arc<dyn TelemetrySink>>,
     server: Option<ServerOptions>,
-    skip_session_bind: bool,
 }
 
 impl Default for OpenLixBuilder<Memory> {
@@ -82,7 +76,6 @@ impl Default for OpenLixBuilder<Memory> {
             wasm_runtime: None,
             telemetry: None,
             server: None,
-            skip_session_bind: false,
         }
     }
 }
@@ -98,7 +91,6 @@ impl<StorageImpl> OpenLixBuilder<StorageImpl> {
             wasm_runtime: self.wasm_runtime,
             telemetry: self.telemetry,
             server: self.server,
-            skip_session_bind: self.skip_session_bind,
         }
     }
 
@@ -120,14 +112,50 @@ impl<StorageImpl> OpenLixBuilder<StorageImpl> {
         self
     }
 
-    /// Attaches a sink (if any) without emitting `lix.repository.opened`.
+    /// Opens the repository as a canonical Lix Server Protocol session factory.
     ///
-    /// Use this when the handle is only a protocol root or cached runtime
-    /// that later protocol sessions inherit. Handshake session creation and
-    /// explicit [`Lix::bind_session`] remain the client bind.
-    pub fn as_protocol_root(mut self) -> Self {
-        self.skip_session_bind = true;
-        self
+    /// Serving owns the repository engine directly and creates no application
+    /// session. Each successful protocol handshake retains exactly one
+    /// application session.
+    #[cfg(feature = "server-protocol")]
+    pub fn serve(self) -> crate::server_protocol::ServeLixBuilder<StorageImpl> {
+        crate::server_protocol::ServeLixBuilder::new(self)
+    }
+}
+
+#[cfg(feature = "server-protocol")]
+impl<StorageImpl> OpenLixBuilder<StorageImpl>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    pub(crate) async fn open_protocol_engine(self) -> Result<Engine<StorageImpl>, LixError> {
+        if self.server.is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "a Lix Server Protocol authority cannot also be a sync replica",
+            ));
+        }
+        let engine = retry_expired_read(|| {
+            open_or_initialize_engine(
+                self.storage.clone(),
+                self.wasm_runtime.clone(),
+                self.telemetry.clone(),
+                None,
+                None,
+            )
+        })
+        .await?;
+        let storage = engine.storage();
+        let read = storage
+            .begin_read(crate::storage_adapter::StorageReadOptions::default())
+            .await?;
+        if crate::sync::has_any_sync_replica_state(&read).await? {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "a persisted sync replica cannot be served as a protocol authority",
+            ));
+        }
+        Ok(engine)
     }
 }
 
@@ -167,7 +195,6 @@ where
                     self.wasm_runtime,
                     self.telemetry,
                     self.server,
-                    self.skip_session_bind,
                 )
                 .await
             })
@@ -389,7 +416,6 @@ async fn open_lix_inner<StorageImpl>(
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
     telemetry: Option<Arc<dyn TelemetrySink>>,
     server: Option<ServerOptions>,
-    skip_session_bind: bool,
 ) -> Result<Lix<StorageImpl>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -450,9 +476,7 @@ where
             }
         }
     }
-    if !skip_session_bind {
-        lix.bind_session();
-    }
+    lix.bind_session();
     Ok(lix)
 }
 
@@ -495,6 +519,44 @@ impl<StorageImpl> Lix<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    #[cfg(feature = "server-protocol")]
+    pub(crate) async fn open_protocol_session(
+        engine: Arc<Engine<StorageImpl>>,
+        active_branch_id: Option<String>,
+        active_account_id: String,
+    ) -> Result<Self, LixError> {
+        let session = match active_branch_id {
+            Some(active_branch_id) => {
+                if engine
+                    .load_branch_head_commit_id(&active_branch_id)
+                    .await?
+                    .is_none()
+                {
+                    return Err(LixError::branch_not_found(
+                        active_branch_id,
+                        "open_protocol_session",
+                        "target",
+                    ));
+                }
+                engine
+                    .open_session_at_with_account(active_branch_id, active_account_id)
+                    .await?
+            }
+            None => {
+                engine
+                    .open_session_with_account(active_account_id)
+                    .await?
+            }
+        };
+        Ok(Self {
+            engine,
+            session: Arc::new(session),
+            primary_switch_gate: None,
+            sync_lease: None,
+            sync_demand_tx: None,
+        })
+    }
+
     async fn retry_sync_demands<T, Operation, OperationFuture>(
         &self,
         mut operation: Operation,
@@ -746,24 +808,6 @@ where
             .await
     }
 
-    pub(crate) async fn execute_with_options_and_metadata(
-        &self,
-        sql: &str,
-        params: &[Value],
-        options: ExecuteOptions,
-        metadata: ExecuteStatementMetadata,
-    ) -> Result<ExecuteResult, LixError> {
-        self.retry_sync_demands(|| {
-            self.session.execute_with_options_and_metadata(
-                sql,
-                params,
-                options.clone(),
-                metadata.clone(),
-            )
-        })
-        .await
-    }
-
     pub(crate) fn execute_with_idempotency_and_options_and_metadata(
         self: Arc<Self>,
         sql: String,
@@ -823,21 +867,6 @@ where
         Arc::clone(&self.session).execute_coherent_read_batch_owned(statements)
     }
 
-    /// Executes one prepared DML statement shape for a rectangular parameter
-    /// page in one atomic transaction. The SQL is planned once and each
-    /// parameter row produces one result in input order. This is the public
-    /// bulk-write contract used by generated/transport callers; unsupported
-    /// shapes fail closed rather than degrading to per-row SQL execution.
-    pub(crate) async fn execute_prepared_dml_batch(
-        &self,
-        sql: Arc<str>,
-        parameter_batch: PreparedDmlParameterBatch,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.session
-            .execute_prepared_dml_batch(sql, parameter_batch)
-            .await
-    }
-
     /// Classifies an atomic SQL batch for a caller that owns its transport
     /// lifecycle.
     pub(crate) fn execute_batch_disposition(
@@ -845,22 +874,6 @@ where
         statements: &[ExecuteBatchStatement],
     ) -> Result<ExecutionDisposition, LixError> {
         self.session.execute_batch_disposition(statements)
-    }
-
-    pub(crate) async fn execute_batch_with_options_and_metadata(
-        &self,
-        statements: &[ExecuteBatchStatement],
-        options: ExecuteOptions,
-        statement_metadata: Vec<ExecuteStatementMetadata>,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.retry_sync_demands(|| {
-            self.session.execute_batch_with_options_and_metadata(
-                statements,
-                options.clone(),
-                statement_metadata.clone(),
-            )
-        })
-        .await
     }
 
     pub(crate) fn execute_batch_with_idempotency_and_options_and_metadata(
@@ -936,11 +949,8 @@ where
     /// Records that this handle's session has bound to the repository.
     ///
     /// In-process [`open_lix`] and protocol handshake session creation call
-    /// this once. Protocol roots opened with
-    /// [`OpenLixBuilder::as_protocol_root`] skip it so attaching a sink does
-    /// not emit for the internal handle. Hosts that mint a session against an
-    /// already-open runtime should call the same helper instead of opening
-    /// another engine.
+    /// this once. Hosts that mint a session against an already-open runtime
+    /// should call the same helper instead of opening another engine.
     pub fn bind_session(&self) {
         let Ok(branch_id) = self.session.bound_branch_id() else {
             return;
@@ -961,25 +971,7 @@ where
         name: &str,
         kind: &str,
     ) -> Result<(), LixError> {
-        let system = Box::pin(
-            self.open_internal_session(lix::GLOBAL_BRANCH_ID.to_string(), lix::SYSTEM_ACCOUNT_ID),
-        )
-        .await?;
-        system
-            .execute(
-                "INSERT INTO lix_account \
-                 (id, name, kind, status, lixcol_global, lixcol_untracked) \
-                 VALUES ($1, $2, $3, 'active', true, false) \
-                 ON CONFLICT (id) \
-                 DO NOTHING",
-                &[
-                    Value::Text(id.to_string()),
-                    Value::Text(name.to_string()),
-                    Value::Text(kind.to_string()),
-                ],
-            )
-            .await?;
-        Box::pin(system.close()).await
+        self.engine.ensure_account(id, name, kind).await
     }
 
     pub async fn create_branch(
@@ -1027,15 +1019,6 @@ where
         options: MergeBranchOptions,
     ) -> Result<MergeBranchReceipt, LixError> {
         self.retry_sync_demands(|| self.session.merge_branch(options.clone()))
-            .await
-    }
-
-    pub(crate) async fn replay_execute_idempotency_result(
-        &self,
-        idempotency: &ExecuteIdempotency,
-    ) -> Result<Option<ExecuteResult>, LixError> {
-        self.session
-            .replay_execute_idempotency_result(idempotency)
             .await
     }
 
@@ -1220,28 +1203,12 @@ where
         self.inner.execute_with_options(sql, params, options)
     }
 
-    /// Executes one prepared DML page atomically inside this transaction.
-    /// Shape changes and dependency barriers remain explicit `execute` calls.
-    pub(crate) async fn execute_prepared_dml_batch(
-        &mut self,
-        sql: Arc<str>,
-        parameter_batch: PreparedDmlParameterBatch,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.inner
-            .execute_prepared_dml_batch(sql, parameter_batch)
-            .await
-    }
-
     #[cfg(test)]
     pub(crate) async fn stage_test_row(
         &mut self,
         row: TransactionWriteRow,
     ) -> Result<(), LixError> {
         self.inner.stage_test_row(row).await
-    }
-
-    pub(crate) fn active_branch_id(&self) -> Result<&str, LixError> {
-        self.inner.active_branch_id()
     }
 
     pub async fn commit(self) -> Result<(), LixError> {
@@ -1471,51 +1438,6 @@ mod tests {
         let started = sink.started.lock().expect("started");
         assert!(started.iter().all(|name| *name != "lix.repository.opened"));
         assert!(started.contains(&"lix.sql.query"));
-    }
-
-    #[tokio::test]
-    async fn protocol_root_open_attaches_sink_without_emitting_opened() {
-        let spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
-        let captured = Arc::clone(&spans);
-        let telemetry = Arc::new(CallbackTelemetrySink::new(move |span| {
-            captured.lock().expect("spans").push(span);
-        }));
-        let lix = open_lix()
-            .with_telemetry(telemetry)
-            .as_protocol_root()
-            .await
-            .expect("open protocol root");
-        lix.execute("SELECT 1", &[]).await.expect("execute");
-
-        assert!(lix.telemetry().is_some());
-        let spans = spans.lock().expect("spans");
-        assert!(opened_spans(&spans).is_empty());
-        assert!(
-            spans.iter().any(|span| span.start.name == "lix.sql.query"),
-            "SQL spans still work on a protocol root"
-        );
-    }
-
-    #[tokio::test]
-    async fn protocol_root_then_explicit_bind_emits_one_opened_span() {
-        let spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
-        let captured = Arc::clone(&spans);
-        let telemetry = Arc::new(CallbackTelemetrySink::new(move |span| {
-            captured.lock().expect("spans").push(span);
-        }));
-        let lix = open_lix()
-            .with_telemetry(telemetry)
-            .as_protocol_root()
-            .await
-            .expect("open protocol root");
-        assert!(opened_spans(&spans.lock().expect("spans")).is_empty());
-
-        lix.bind_session();
-        let spans = spans.lock().expect("spans");
-        let opened = opened_spans(&spans);
-        assert_eq!(opened.len(), 1);
-        assert_eq!(opened[0].start.name, "lix.repository.opened");
-        assert_eq!(attribute_string(opened[0], "lix.id"), Some(lix.lix_id()));
     }
 
     #[tokio::test]
@@ -2019,13 +1941,7 @@ mod assume_send_future_proofs {
         wasm_runtime: Option<Arc<dyn WasmRuntime>>,
         telemetry: Option<Arc<dyn TelemetrySink>>,
     ) {
-        is_send(&open_lix_inner(
-            storage,
-            wasm_runtime,
-            telemetry,
-            None,
-            false,
-        ));
+        is_send(&open_lix_inner(storage, wasm_runtime, telemetry, None));
     }
 
     // handle.rs -- Lix::switch_branch (body mirrored verbatim)

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(test, allow(clippy::large_futures))]
 
+use crate::engine::Engine;
 use crate::session::ExecuteOptions;
 #[cfg(test)]
 use crate::session::media_upload::FILE_UPLOAD_PART_BYTES;
@@ -21,14 +22,14 @@ use lix::storage::Storage;
 use lix::{
     Blob, CreateBranchOptions, ExecuteBatchStatement, ExecuteIdempotency, ExecuteResult,
     ExecuteStatementMetadata, ExecutionDisposition, Lix, LixError, LixTransaction, ObserveEvent,
-    ObserveEvents, SwitchBranchOptions, Value, VerifiedRequestBlob, WireValue,
+    ObserveEvents, OpenLixBuilder, SwitchBranchOptions, Value, VerifiedRequestBlob, WireValue,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
-    future::Future,
+    future::{Future, IntoFuture},
     io,
     mem::size_of,
     pin::Pin,
@@ -425,11 +426,57 @@ impl Default for ServerProtocolOptions {
     }
 }
 
+/// Configures opening a repository as a Lix Server Protocol session factory.
+///
+/// Await directly for default limits, or set protocol-specific limits first
+/// with [`Self::with_options`].
+#[expect(missing_debug_implementations)]
+pub struct ServeLixBuilder<S> {
+    open: OpenLixBuilder<S>,
+    options: ServerProtocolOptions,
+}
+
+impl<S> ServeLixBuilder<S> {
+    pub(crate) fn new(open: OpenLixBuilder<S>) -> Self {
+        Self {
+            open,
+            options: ServerProtocolOptions::default(),
+        }
+    }
+
+    /// Sets resource limits for this repository's protocol sessions.
+    pub fn with_options(mut self, options: ServerProtocolOptions) -> Self {
+        self.options = options;
+        self
+    }
+}
+
+impl<S> IntoFuture for ServeLixBuilder<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    type Output = Result<LixServerProtocol<S>, LixError>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(unsafe {
+            crate::session::AssumeSendFuture::new(async move {
+                validate_server_protocol_options(self.options)?;
+                let engine = self.open.open_protocol_engine().await?;
+                Ok(LixServerProtocol::from_engine(
+                    Arc::new(engine),
+                    self.options,
+                ))
+            })
+        })
+    }
+}
+
 /// Persistent canonical protocol server for one Lix repository.
 ///
-/// A server owns one root [`Lix`] and opens every remote client as an
-/// independent branch-pinned session on that root's existing engine. Clones
-/// share the same bounded in-memory session registry.
+/// A server owns the repository engine and opens every remote client as an
+/// independent branch-pinned session. Server construction itself creates no
+/// application session. Clones share the same bounded in-memory session registry.
 #[expect(missing_debug_implementations)]
 pub struct LixServerProtocol<S>
 where
@@ -453,7 +500,7 @@ struct ServerInner<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    root: Arc<Lix<S>>,
+    engine: Arc<Engine<S>>,
     options: ServerProtocolOptions,
     registry: AsyncMutex<HashMap<String, Arc<SessionRecord<S>>>>,
     request_blob_budget: Arc<RequestBlobCacheBudget>,
@@ -1340,50 +1387,15 @@ impl<S> LixServerProtocol<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    /// Creates a protocol server with the default session limits.
-    ///
-    /// Open `root` with [`lix::OpenLixBuilder::as_protocol_root`] so attaching
-    /// a sink does not emit `lix.repository.opened` for the internal handle. Handshake
-    /// session creation remains the client bind.
-    pub fn new(root: Arc<Lix<S>>) -> Self {
-        Self::with_options(root, ServerProtocolOptions::default())
-            .expect("default protocol server options must be valid")
-    }
-
-    /// Creates a protocol server with explicit per-repository session limits.
-    pub fn with_options(
-        root: Arc<Lix<S>>,
+    fn from_engine(
+        engine: Arc<Engine<S>>,
         options: ServerProtocolOptions,
-    ) -> Result<Self, LixError> {
-        if options.max_sessions == 0 {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                "protocol max_sessions must be greater than zero",
-            ));
-        }
-        if options.max_sessions > SESSION_OPEN_GATE_COUNT_MASK {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                "protocol max_sessions exceeds the supported session-open limit",
-            ));
-        }
-        if options.max_request_body_bytes == 0 {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                "protocol max_request_body_bytes must be greater than zero",
-            ));
-        }
-        if options.max_request_blob_cache_bytes == 0 {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                "protocol max_request_blob_cache_bytes must be greater than zero",
-            ));
-        }
-        root.set_sync_role(crate::sync::SyncRole::Authority)?;
+    ) -> Self {
+        engine.sync_mode().set_role(crate::sync::SyncRole::Authority);
         let (close_result, _) = watch::channel(None);
-        Ok(Self {
+        Self {
             inner: Arc::new(ServerInner {
-                root,
+                engine,
                 options,
                 registry: AsyncMutex::new(HashMap::new()),
                 request_blob_budget: Arc::new(RequestBlobCacheBudget::new(
@@ -1393,7 +1405,7 @@ where
                 close_started: Once::new(),
                 close_result,
             }),
-        })
+        }
     }
 
     /// Handles one canonical protocol request.
@@ -1662,7 +1674,7 @@ where
             .all(|record| record.is_idle_expired(now, self.inner.options.session_idle_timeout))
     }
 
-    /// Closes every child session and finally the root repository session.
+    /// Closes every client session and rejects future handshakes.
     /// Repeated calls are safe.
     pub async fn close(&self) -> Result<(), LixError> {
         let mut close_result = self.inner.close_result.subscribe();
@@ -1713,11 +1725,6 @@ where
                 first_error = Some(error);
             }
         }
-        if let Err(error) = self.inner.root.close().await
-            && first_error.is_none()
-        {
-            first_error = Some(error);
-        }
         first_error.map_or(Ok(()), Err)
     }
 
@@ -1728,33 +1735,78 @@ where
         principal: Option<ServerProtocolPrincipal>,
         durable_terminal_storage_notifier: Option<DurableTerminalStorageNotifier>,
     ) -> Result<SessionLease<S>, ApiError> {
-        let _pending_open = self
+        let pending_open = self
             .inner
             .session_open_gate
             .reserve(self.inner.options.max_sessions)?;
-
-        let active_branch_id = match initial_active_branch_id {
-            Some(active_branch_id) => active_branch_id,
-            None => match self.inner.root.active_branch_id().await {
-                Ok(active_branch_id) => active_branch_id,
-                Err(error) => {
-                    if let Some(notifier) = &durable_terminal_storage_notifier {
-                        notifier.signal_if_terminal(&error);
-                    }
-                    return Err(error.into());
-                }
-            },
+        // Session opening may cross a durable storage boundary while creating
+        // an authenticated account. Own the entire lifecycle in a server task:
+        // dropping an HTTP request then detaches the join handle, while the
+        // task keeps its bounded reservation until storage and session cleanup
+        // reach a terminal result.
+        let server = self.clone();
+        let parent = tracing::Span::current();
+        // SAFETY: the task owns the protocol server and every session-open
+        // argument. Storage adapters and Engine are Send + Sync by this impl's
+        // bounds; the compiler cannot prove that across generic read lifetimes.
+        let opening = unsafe {
+            crate::session::AssumeSendFuture::new(async move {
+                server
+                    .create_session_tracked(
+                        pending_open,
+                        initial_active_branch_id,
+                        initial_active_account_id,
+                        principal,
+                        durable_terminal_storage_notifier,
+                    )
+                    .await
+            })
         };
+        tokio::spawn(
+            opening.instrument(parent).with_current_subscriber(),
+        )
+        .await
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("join Lix protocol session open: {error}"),
+            )
+        })?
+    }
+
+    async fn create_session_tracked(
+        &self,
+        _pending_open: PendingSessionOpen,
+        initial_active_branch_id: Option<String>,
+        initial_active_account_id: Option<String>,
+        principal: Option<ServerProtocolPrincipal>,
+        durable_terminal_storage_notifier: Option<DurableTerminalStorageNotifier>,
+    ) -> Result<SessionLease<S>, ApiError> {
         // Validate and open the pinned child before evicting any idle session.
         // An invalid requested branch therefore cannot consume capacity or
         // evict another client.
         let active_account_id =
             initial_active_account_id.unwrap_or_else(|| lix::ANONYMOUS_ACCOUNT_ID.to_string());
-        let child = match self
+        if matches!(
+            &principal,
+            Some(ServerProtocolPrincipal::Authenticated { .. })
+        ) && let Err(error) = self
             .inner
-            .root
-            .open_internal_session(active_branch_id, active_account_id)
+            .engine
+            .ensure_account(&active_account_id, &active_account_id, "human")
             .await
+        {
+            if let Some(notifier) = &durable_terminal_storage_notifier {
+                notifier.signal_if_terminal(&error);
+            }
+            return Err(error.into());
+        }
+        let child = match Lix::open_protocol_session(
+            Arc::clone(&self.inner.engine),
+            initial_active_branch_id,
+            active_account_id,
+        )
+        .await
         {
             Ok(child) => child,
             Err(error) => {
@@ -1868,6 +1920,34 @@ where
         }
         Ok(())
     }
+}
+
+fn validate_server_protocol_options(options: ServerProtocolOptions) -> Result<(), LixError> {
+    if options.max_sessions == 0 {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "protocol max_sessions must be greater than zero",
+        ));
+    }
+    if options.max_sessions > SESSION_OPEN_GATE_COUNT_MASK {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "protocol max_sessions exceeds the supported session-open limit",
+        ));
+    }
+    if options.max_request_body_bytes == 0 {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "protocol max_request_body_bytes must be greater than zero",
+        ));
+    }
+    if options.max_request_blob_cache_bytes == 0 {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "protocol max_request_blob_cache_bytes must be greater than zero",
+        ));
+    }
+    Ok(())
 }
 
 async fn close_session_record<S>(record: &SessionRecord<S>) -> Result<(), LixError>
@@ -2018,17 +2098,6 @@ where
                 None => None,
             };
             let active_account_id = context.principal.account_id().to_owned();
-            if matches!(
-                context.principal,
-                ServerProtocolPrincipal::Authenticated { .. }
-            ) {
-                Box::pin(server.inner.root.ensure_account(
-                    &active_account_id,
-                    &active_account_id,
-                    "human",
-                ))
-                .await?;
-            }
             server
                 .create_session(
                     active_branch_id,
@@ -5178,7 +5247,6 @@ mod tests {
     }
 
     struct TestApp {
-        lix: Arc<Lix<Memory>>,
         server: LixServerProtocol<Memory>,
         router: Router<Memory>,
     }
@@ -5715,14 +5783,11 @@ mod tests {
     #[tokio::test]
     async fn fenced_storage_does_not_affect_resumed_cached_handshake() {
         let storage = FencedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let router = handler(server.clone());
         let lease = server
             .create_session(None, None, None, None)
@@ -5762,14 +5827,12 @@ mod tests {
     #[tokio::test]
     async fn fenced_new_handshake_reports_terminal_storage_signal() {
         let storage = FencedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let router = handler(LixServerProtocol::new(root));
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
+        let router = handler(server);
 
         storage.fence_reads();
         let (notifier, signal) = durable_terminal_storage_signal();
@@ -5796,18 +5859,21 @@ mod tests {
     #[tokio::test]
     async fn fenced_new_handshake_with_explicit_branch_reports_terminal_storage_signal() {
         let storage = FencedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let active_branch_id = root
+        let lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("open Lix");
+        let active_branch_id = lix
             .active_branch_id()
             .await
             .expect("read initial active branch");
-        let router = handler(LixServerProtocol::new(root));
+        lix.close().await.expect("close setup session");
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
+        let router = handler(server);
 
         storage.fence_reads();
         let (notifier, signal) = durable_terminal_storage_signal();
@@ -5834,14 +5900,11 @@ mod tests {
     #[tokio::test]
     async fn fenced_observe_next_reports_terminal_storage_before_returning_error() {
         let storage = FencedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let lease = server
             .create_session(None, None, None, None)
             .await
@@ -6026,14 +6089,11 @@ mod tests {
     #[tokio::test]
     async fn fenced_observe_after_headers_signals_and_ends_stream() {
         let storage = FencedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
@@ -6080,14 +6140,11 @@ mod tests {
     #[tokio::test]
     async fn fenced_external_observe_watcher_signals_and_ends_stream() {
         let storage = FencedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
@@ -6164,14 +6221,11 @@ mod tests {
     #[tokio::test]
     async fn fenced_multiplex_observe_aborts_live_sibling_before_next_body_poll() {
         let storage = FailOneBlockedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
@@ -6255,14 +6309,11 @@ mod tests {
     #[tokio::test]
     async fn dropped_multiplex_response_aborts_unpolled_workers() {
         let storage = FailOneBlockedReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
@@ -6338,29 +6389,25 @@ mod tests {
     }
 
     async fn app_with_options(options: ServerProtocolOptions) -> TestApp {
-        let lix = Arc::new(open_lix().as_protocol_root().await.expect("open lix"));
-        let server =
-            LixServerProtocol::with_options(lix.clone(), options).expect("protocol server");
+        let server = open_lix()
+            .serve()
+            .with_options(options)
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
-        TestApp {
-            lix,
-            server,
-            router,
-        }
+        TestApp { server, router }
     }
 
     async fn router_with_storage<S>(storage: S) -> Router<S>
     where
         S: Storage + Clone + Send + Sync + 'static,
     {
-        let lix = Arc::new(
-            open_lix()
-                .with_storage(storage)
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        handler(LixServerProtocol::new(lix))
+        let server = open_lix()
+            .with_storage(storage)
+            .serve()
+            .await
+            .expect("serve Lix");
+        handler(server)
     }
 
     #[tokio::test]
@@ -6504,7 +6551,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn idempotent_batch_hydrates_sparse_history_then_replays_one_durable_result() {
+    async fn batch_hydrates_sparse_history_before_applying_its_write() {
         let authority = open_lix().await.expect("open history authority");
         authority
             .execute(
@@ -6617,7 +6664,7 @@ mod tests {
         }
 
         let storage = DurableMemoryStorage::new();
-        crate::engine::Engine::initialize_with_main_branch_id(
+        Engine::initialize_with_main_branch_id(
             storage.clone(),
             Some(default_branch_id),
         )
@@ -6713,82 +6760,53 @@ mod tests {
             demand.succeed_for_test();
         });
 
-        let router = handler(LixServerProtocol::new(replica));
-        let (session_id, _) = new_session(&router).await;
-        let headers = [(IDEMPOTENCY_KEY_HEADER, "sparse-history-batch")];
-        let body = json!({
-            "statements": [
-                {
-                    "sql": format!(
-                        "SELECT COUNT(*) AS versions FROM lix_history('lix_file', '{head}')"
-                    ),
-                    "params": []
-                },
-                {
-                    "sql": "INSERT INTO lix_key_value (key, value) VALUES ('history-hydrated', 'once') RETURNING value",
-                    "params": []
-                }
-            ]
-        });
-        let first = request_with_headers(
-            &router,
-            "POST",
-            "/lix/v1/execute-batch",
-            Some(&session_id),
-            &headers,
-            Some(body.clone()),
-        )
-        .await;
-        assert_eq!(first.status(), StatusCode::OK);
-        let first = response_json(first).await;
+        let statements = [
+            ExecuteBatchStatement {
+                sql: format!(
+                    "SELECT COUNT(*) AS versions FROM lix_history('lix_file', '{head}')"
+                ),
+                params: Vec::new(),
+                label: None,
+            },
+            ExecuteBatchStatement {
+                sql: "INSERT INTO lix_key_value (key, value) VALUES ('history-hydrated', 'once') RETURNING value".to_string(),
+                params: Vec::new(),
+                label: None,
+            },
+        ];
+        let first = replica
+            .execute_batch(&statements)
+            .await
+            .expect("sparse history batch should hydrate and commit");
         assert!(
-            first[0]["rows"][0][0]["value"].as_i64().unwrap_or(0) >= 2,
-            "sparse history response: {first}"
+            first[0].rows()[0].get::<i64>("versions").unwrap_or(0) >= 2,
+            "sparse history response: {:?}",
+            first[0]
         );
         hydration.await.expect("history hydration task");
 
-        let replay = request_with_headers(
-            &router,
-            "POST",
-            "/lix/v1/execute-batch",
-            Some(&session_id),
-            &headers,
-            Some(body),
-        )
-        .await;
-        let replay_status = replay.status();
-        let replay = response_json(replay).await;
-        assert_eq!(replay_status, StatusCode::OK, "replay response: {replay}");
-        assert_eq!(replay, first);
-
-        let count = request(
-            &router,
-            "POST",
-            "/lix/v1/execute",
-            Some(&session_id),
-            Some(json!({
-                "sql": "SELECT COUNT(*) FROM lix_key_value WHERE key = 'history-hydrated'"
-            })),
-        )
-        .await;
-        assert_eq!(count.status(), StatusCode::OK);
+        let count = replica
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_key_value WHERE key = 'history-hydrated'",
+                &[],
+            )
+            .await
+            .expect("read hydrated batch write");
         assert_eq!(
-            response_json(count).await["rows"][0][0],
-            json!({ "kind": "int", "value": 1 })
+            count.rows()[0].get::<i64>("count"),
+            Ok(1),
+            "the write runs once after hydration"
         );
     }
 
     #[tokio::test]
     async fn keyed_write_without_durable_receipt_proof_is_not_acknowledged() {
         let storage = PostCommitUnknownStorage::new();
-        let lix = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let server = LixServerProtocol::new(lix);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve Lix");
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
         let headers = [(IDEMPOTENCY_KEY_HEADER, "memory-has-no-durable-proof")];
@@ -6836,20 +6854,13 @@ mod tests {
     }
 
     async fn app_with_tracing_telemetry() -> TestApp {
-        let lix = Arc::new(
-            open_lix()
-                .with_telemetry(Arc::new(OpenTelemetryTracingSink::new()))
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::new(lix.clone());
+        let server = open_lix()
+            .with_telemetry(Arc::new(OpenTelemetryTracingSink::new()))
+            .serve()
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
-        TestApp {
-            lix,
-            server,
-            router,
-        }
+        TestApp { server, router }
     }
 
     async fn request(
@@ -7279,32 +7290,54 @@ mod tests {
         spans: Arc<Mutex<Vec<CompletedTelemetrySpan>>>,
     ) -> TestApp {
         let captured = Arc::clone(&spans);
-        let lix = Arc::new(
-            open_lix()
-                .with_telemetry(Arc::new(CallbackTelemetrySink::new(move |span| {
-                    captured.lock().expect("spans").push(span);
-                })))
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::new(lix.clone());
+        let server = open_lix()
+            .with_telemetry(Arc::new(CallbackTelemetrySink::new(move |span| {
+                captured.lock().expect("spans").push(span);
+            })))
+            .serve()
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
-        TestApp {
-            lix,
-            server,
-            router,
-        }
+        TestApp { server, router }
     }
 
     #[tokio::test]
     async fn handshake_that_creates_a_session_emits_one_opened_span() {
         let spans = Arc::new(Mutex::new(Vec::new()));
         let app = app_with_callback_telemetry(Arc::clone(&spans)).await;
-        assert_eq!(opened_spans(&spans.lock().expect("spans")).len(), 0);
+        {
+            let spans = spans.lock().expect("spans");
+            assert_eq!(opened_spans(&spans).len(), 0);
+            assert!(
+                spans
+                    .iter()
+                    .filter(|span| span.start.name == "lix.engine.open")
+                    .count()
+                    >= 1
+            );
+            assert_eq!(
+                spans
+                    .iter()
+                    .filter(|span| span.start.name == "lix.session.open")
+                    .count(),
+                0,
+                "serving opens an engine, not a hidden application session"
+            );
+        }
 
         let (session_id, first) = new_session(&app.router).await;
-        assert_eq!(opened_spans(&spans.lock().expect("spans")).len(), 1);
+        {
+            let spans = spans.lock().expect("spans");
+            assert_eq!(opened_spans(&spans).len(), 1);
+            assert_eq!(
+                spans
+                    .iter()
+                    .filter(|span| span.start.name == "lix.session.open")
+                    .count(),
+                1,
+                "one handshake opens one application session"
+            );
+        }
 
         let resumed = request(&app.router, "GET", "/lix/v1/", Some(&session_id), None).await;
         assert_eq!(resumed.status(), StatusCode::OK);
@@ -7338,7 +7371,7 @@ mod tests {
     async fn handshake_without_a_sink_emits_no_opened_span() {
         let app = app().await;
         let (_session_id, _) = new_session(&app.router).await;
-        assert!(app.server.inner.root.telemetry().is_none());
+        assert!(app.server.inner.engine.telemetry().is_none());
     }
 
     #[tokio::test]
@@ -7498,6 +7531,10 @@ mod tests {
     async fn sync_router_roundtrips_inline_files_without_blob_routes() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;
+        let client = {
+            let registry = app.server.inner.registry.lock().await;
+            Arc::clone(&registry.get(&session_id).expect("registered client").lix)
+        };
         let snapshot = request(
             &app.router,
             "GET",
@@ -7510,7 +7547,7 @@ mod tests {
         let snapshot = response_json(snapshot).await;
         let cursor = snapshot["cursor"].as_u64().expect("snapshot cursor");
 
-        app.lix
+        client
             .execute(
                 "INSERT INTO lix_file (path, content) VALUES ($1, CAST('' AS BYTEA))",
                 &[Value::Text("/empty-inline.md".to_owned())],
@@ -7536,7 +7573,7 @@ mod tests {
         );
         let empty_cursor = empty_pull["cursor"].as_u64().expect("empty file cursor");
 
-        app.lix
+        client
             .execute(
                 "INSERT INTO lix_file (path, content) VALUES ($1, CAST('inline' AS BYTEA))",
                 &[Value::Text("/nonempty-inline.md".to_owned())],
@@ -7581,8 +7618,12 @@ mod tests {
     #[tokio::test]
     async fn sync_history_and_push_roundtrip_commit_scoped_merge_provenance() {
         let app = app().await;
-        let source_branch = app
-            .lix
+        let (session_id, _) = new_session(&app.router).await;
+        let client = {
+            let registry = app.server.inner.registry.lock().await;
+            Arc::clone(&registry.get(&session_id).expect("registered client").lix)
+        };
+        let source_branch = client
             .create_branch(CreateBranchOptions {
                 id: Some("01920000-0000-7000-8000-000000001501".to_owned()),
                 name: "sync selected source".to_owned(),
@@ -7590,8 +7631,7 @@ mod tests {
             })
             .await
             .expect("source branch should be created");
-        let source = app
-            .lix
+        let source = client
             .open_another_session()
             .await
             .expect("source session should open");
@@ -7615,15 +7655,14 @@ mod tests {
             )
             .await
             .expect("source branch should span more than one commit");
-        app.lix
+        client
             .execute(
                 "INSERT INTO lix_key_value (key, value) VALUES ('sync-target', 'authored')",
                 &[],
             )
             .await
             .expect("target branch should diverge");
-        let merge = app
-            .lix
+        let merge = client
             .merge_branch(lix::MergeBranchOptions {
                 source_branch_id: source_branch.id,
             })
@@ -7633,7 +7672,6 @@ mod tests {
             .created_merge_commit_id
             .expect("diverged branches should create a merge commit");
 
-        let (session_id, _) = new_session(&app.router).await;
         let history_path = format!("/lix/v1/sync/history?head={merge_commit_id}&limit=1");
         let history = request(&app.router, "GET", &history_path, Some(&session_id), None).await;
         assert_eq!(history.status(), StatusCode::OK);
@@ -7666,8 +7704,7 @@ mod tests {
             if imported.contains_key(&commit_id) {
                 continue;
             }
-            let response = app
-                .lix
+            let response = client
                 .sync_history(&commit_id, 1)
                 .await
                 .expect("source history closure should load");
@@ -7697,6 +7734,16 @@ mod tests {
             .expect("merge has a selected member");
         forged_selected["snapshot"] = json!({"key": "forged", "value": "forged"});
         let forged_target = self::app().await;
+        let (forged_session_id, _) = new_session(&forged_target.router).await;
+        let forged_client = {
+            let registry = forged_target.server.inner.registry.lock().await;
+            Arc::clone(
+                &registry
+                    .get(&forged_session_id)
+                    .expect("forged target session")
+                    .lix,
+            )
+        };
         let forged_request: SyncPushRequest = serde_json::from_value(json!({
             "commits": forged_commits,
             "inlineBlobs": [],
@@ -7709,14 +7756,23 @@ mod tests {
             }]
         }))
         .expect("forged request should decode");
-        let forged = forged_target
-            .lix
+        let forged = forged_client
             .push_sync_repository(&forged_request)
             .await
             .expect_err("forged selected payload must fail authority validation");
         assert_eq!(forged.code, LixError::CODE_INVALID_PARAM);
 
         let target = self::app().await;
+        let (target_session_id, _) = new_session(&target.router).await;
+        let target_client = {
+            let registry = target.server.inner.registry.lock().await;
+            Arc::clone(
+                &registry
+                    .get(&target_session_id)
+                    .expect("roundtrip target session")
+                    .lix,
+            )
+        };
         let replay_request: SyncPushRequest = serde_json::from_value(json!({
             "commits": imported.into_values().collect::<Vec<_>>(),
             "inlineBlobs": [],
@@ -7729,12 +7785,10 @@ mod tests {
             }]
         }))
         .expect("roundtrip request should decode");
-        target
-            .lix
+        target_client
             .push_sync_repository(&replay_request)
             .await
             .expect("valid full graph should import");
-        let (target_session_id, _) = new_session(&target.router).await;
 
         let roundtrip = request(
             &target.router,
@@ -11085,7 +11139,7 @@ mod tests {
         );
         assert!(
             spans.iter().all(|span| span.name != "lix.engine.open"),
-            "warm handshake must not reopen the protocol-root engine"
+            "warm handshake must not reopen the protocol engine"
         );
         assert_no_bound_parameter_or_bytea_fields(&spans);
     }
@@ -11239,7 +11293,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn close_waits_for_pending_session_opens_before_closing_the_root() {
+    async fn close_waits_for_pending_session_opens_before_closing_the_server() {
         let app = app().await;
         let pending = app
             .server
@@ -11271,6 +11325,131 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn close_waits_for_authenticated_account_bootstrap() {
+        let storage = BlockingFencedWriteStorage::new();
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .with_options(ServerProtocolOptions {
+                max_sessions: 1,
+                ..ServerProtocolOptions::default()
+            })
+            .await
+            .expect("serve lix");
+        storage.block_next_write();
+
+        let opening_server = server.clone();
+        let opening = tokio::spawn(async move {
+            let account_id = "01920000-0000-7000-8000-0000000006a1";
+            opening_server
+                .create_session(
+                    None,
+                    Some(account_id.to_owned()),
+                    Some(ServerProtocolPrincipal::Authenticated {
+                        account_id: account_id.to_owned(),
+                        idempotency_scope: "test".to_owned(),
+                    }),
+                    None,
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), storage.wait_for_blocked_write())
+            .await
+            .expect("account bootstrap should reach storage");
+        assert_eq!(server.inner.session_open_gate.pending(), 1);
+
+        let closing_server = server.clone();
+        let mut closing = tokio::spawn(async move { closing_server.close().await });
+        while !server.inner.session_open_gate.is_closing() {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut closing)
+                .await
+                .is_err(),
+            "close completed while authenticated account creation was still writing"
+        );
+
+        storage.release_blocked_write();
+        assert!(
+            opening
+                .await
+                .expect("join authenticated session open")
+                .is_err(),
+            "the fenced account write must fail the session open"
+        );
+        closing
+            .await
+            .expect("join server close")
+            .expect("close server");
+    }
+
+    #[tokio::test]
+    async fn cancelled_authenticated_handshake_remains_tracked_until_storage_finishes() {
+        let storage = BlockingFencedWriteStorage::new();
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .with_options(ServerProtocolOptions {
+                max_sessions: 1,
+                ..ServerProtocolOptions::default()
+            })
+            .await
+            .expect("serve lix");
+        storage.block_next_write();
+
+        let opening_server = server.clone();
+        let opening = tokio::spawn(async move {
+            let account_id = "01920000-0000-7000-8000-0000000006a2";
+            opening_server
+                .create_session(
+                    None,
+                    Some(account_id.to_owned()),
+                    Some(ServerProtocolPrincipal::Authenticated {
+                        account_id: account_id.to_owned(),
+                        idempotency_scope: "cancelled-test".to_owned(),
+                    }),
+                    None,
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), storage.wait_for_blocked_write())
+            .await
+            .expect("account bootstrap should reach storage");
+        assert_eq!(server.inner.session_open_gate.pending(), 1);
+
+        opening.abort();
+        let Err(cancelled) = opening.await else {
+            panic!("request-owned session open should be cancelled");
+        };
+        assert!(cancelled.is_cancelled());
+        assert_eq!(
+            server.inner.session_open_gate.pending(),
+            1,
+            "server-owned session creation must outlive request cancellation"
+        );
+
+        let closing_server = server.clone();
+        let mut closing = tokio::spawn(async move { closing_server.close().await });
+        while !server.inner.session_open_gate.is_closing() {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut closing)
+                .await
+                .is_err(),
+            "close completed before cancelled account storage reached a terminal result"
+        );
+
+        storage.release_blocked_write();
+        closing
+            .await
+            .expect("join server close")
+            .expect("close server");
+        assert_eq!(server.inner.session_open_gate.pending(), 0);
+    }
+
+    #[tokio::test]
     async fn close_waits_for_eviction_cleanup_in_a_pending_session_open() {
         let app = app_with_options(ServerProtocolOptions {
             max_sessions: 1,
@@ -11290,10 +11469,8 @@ mod tests {
         // Shutdown must continue to track the whole create operation, not only
         // the child open and registry mutation.
         let first_transactions = first_record.transactions.lock().await;
-        let branch_id = app
-            .server
-            .inner
-            .root
+        let branch_id = first_record
+            .lix
             .active_branch_id()
             .await
             .expect("active branch");
@@ -11381,22 +11558,21 @@ mod tests {
     async fn concurrent_session_opens_do_not_hold_the_registry_lock_during_storage_reads() {
         const SESSION_COUNT: usize = 8;
         let storage = GatedReadStorage::new(SESSION_COUNT);
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open Lix"),
-        );
-        let branch_id = root.active_branch_id().await.expect("active branch");
-        let server = LixServerProtocol::with_options(
-            root,
-            ServerProtocolOptions {
+        let lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("open Lix");
+        let branch_id = lix.active_branch_id().await.expect("active branch");
+        lix.close().await.expect("close setup session");
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .with_options(ServerProtocolOptions {
                 max_sessions: SESSION_COUNT,
                 ..ServerProtocolOptions::default()
-            },
-        )
-        .expect("protocol server");
+            })
+            .await
+            .expect("serve Lix");
         storage.gate_next_reads(SESSION_COUNT);
 
         let mut tasks = tokio::task::JoinSet::new();
@@ -11611,16 +11787,18 @@ mod tests {
         )
         .await;
         assert_eq!(staged.status(), StatusCode::OK);
-        let visible = app
-            .server
-            .inner
-            .root
+        let (observer_id, _) = new_session(&app.router).await;
+        let observer = {
+            let registry = app.server.inner.registry.lock().await;
+            Arc::clone(&registry.get(&observer_id).expect("observer session").lix)
+        };
+        let visible = observer
             .execute(
                 "SELECT COUNT(*) AS count FROM lix_key_value WHERE key = 'abandoned'",
                 &[],
             )
             .await
-            .expect("root should read committed state");
+            .expect("observer should read committed state");
         assert_eq!(visible.rows()[0].get::<i64>("count").unwrap(), 0);
 
         app.server.close().await.expect("server should close");
@@ -11630,22 +11808,16 @@ mod tests {
     #[tokio::test]
     async fn cancelled_cancellable_read_releases_session_for_close_and_replacement() {
         let storage = BlockingReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::with_options(
-            root,
-            ServerProtocolOptions {
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .with_options(ServerProtocolOptions {
                 max_sessions: 1,
                 session_idle_timeout: Duration::from_mins(1),
                 ..ServerProtocolOptions::default()
-            },
-        )
-        .expect("protocol server");
+            })
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
         let lease = server
             .create_session(None, None, None, None)
@@ -11701,14 +11873,11 @@ mod tests {
     #[tokio::test]
     async fn resumed_handshake_uses_cached_session_identity_and_closes() {
         let storage = BlockingReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
         let lease = server
             .create_session(None, None, None, None)
@@ -11736,14 +11905,11 @@ mod tests {
     #[tokio::test]
     async fn cancelled_raw_file_read_releases_session_for_close() {
         let storage = BlockingReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
         let lease = server
             .create_session(None, None, None, None)
@@ -11788,22 +11954,16 @@ mod tests {
     #[tokio::test]
     async fn cancelled_durable_operation_reports_terminal_storage_after_caller_cancellation() {
         let storage = BlockingFencedWriteStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::with_options(
-            root,
-            ServerProtocolOptions {
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .with_options(ServerProtocolOptions {
                 max_sessions: 1,
                 session_idle_timeout: Duration::from_mins(1),
                 ..ServerProtocolOptions::default()
-            },
-        )
-        .expect("protocol server");
+            })
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
         let lease = server
             .create_session(None, None, None, None)
@@ -11868,22 +12028,16 @@ mod tests {
     #[tokio::test]
     async fn cancelled_remote_commit_releases_transaction_pin_after_detached_work() {
         let storage = BlockingFencedWriteStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::with_options(
-            root,
-            ServerProtocolOptions {
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .with_options(ServerProtocolOptions {
                 max_sessions: 1,
                 session_idle_timeout: Duration::from_mins(1),
                 ..ServerProtocolOptions::default()
-            },
-        )
-        .expect("protocol server");
+            })
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
         let (session_id, _) = new_session(&router).await;
         let transaction_id = begin_remote_transaction(&router, &session_id).await;
@@ -12052,14 +12206,11 @@ mod tests {
     #[tokio::test]
     async fn cancelled_branch_switch_reports_terminal_storage_after_caller_cancellation() {
         let storage = BlockingFencedBranchControlReadStorage::new();
-        let root = Arc::new(
-            open_lix()
-                .with_storage(storage.clone())
-                .as_protocol_root()
-                .await
-                .expect("open lix"),
-        );
-        let server = LixServerProtocol::new(root);
+        let server = open_lix()
+            .with_storage(storage.clone())
+            .serve()
+            .await
+            .expect("serve lix");
         let router = handler(server.clone());
         let (session_id, _) = new_session(&router).await;
         let created = request(
@@ -12117,15 +12268,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn close_drains_children_and_root_and_is_idempotent() {
+    async fn close_drains_sessions_and_is_idempotent() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;
         let child = {
             let registry = app.server.inner.registry.lock().await;
             Arc::clone(&registry.get(&session_id).expect("registered child").lix)
         };
-        let root = Arc::clone(&app.server.inner.root);
-
         app.server.close().await.expect("close server");
         app.server.close().await.expect("close server again");
         assert_eq!(
@@ -12133,13 +12282,6 @@ mod tests {
                 .execute("SELECT 1", &[])
                 .await
                 .expect_err("child closed")
-                .code,
-            LixError::CODE_CLOSED
-        );
-        assert_eq!(
-            root.execute("SELECT 1", &[])
-                .await
-                .expect_err("root closed")
                 .code,
             LixError::CODE_CLOSED
         );
@@ -12153,34 +12295,69 @@ mod tests {
 
     #[tokio::test]
     async fn zero_capacity_is_rejected() {
-        let lix = open_lix().as_protocol_root().await.expect("open lix");
-        let result = LixServerProtocol::with_options(
-            Arc::new(lix),
-            ServerProtocolOptions {
+        let result = open_lix()
+            .serve()
+            .with_options(ServerProtocolOptions {
                 max_sessions: 0,
                 session_idle_timeout: Duration::from_secs(1),
                 ..ServerProtocolOptions::default()
-            },
-        );
+            })
+            .await;
         let Err(error) = result else {
             panic!("zero capacity must be rejected");
         };
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
 
-        let result = LixServerProtocol::with_options(
-            Arc::new(
-                open_lix()
-                    .as_protocol_root()
-                    .await
-                    .expect("open second lix"),
-            ),
-            ServerProtocolOptions {
+        let result = open_lix()
+            .serve()
+            .with_options(ServerProtocolOptions {
                 max_request_blob_cache_bytes: 0,
                 ..ServerProtocolOptions::default()
-            },
-        );
+            })
+            .await;
         let Err(error) = result else {
             panic!("zero request blob cache capacity must be rejected");
+        };
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+    }
+
+    #[tokio::test]
+    async fn sync_replica_configuration_cannot_be_served_as_an_authority() {
+        let result = open_lix()
+            .with_server(lix::ServerOptions::sync("https://example.invalid/repository"))
+            .serve()
+            .await;
+        let Err(error) = result else {
+            panic!("sync replica configuration must not open as an authority");
+        };
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+    }
+
+    #[tokio::test]
+    async fn persisted_sync_replica_cannot_be_served_as_an_authority() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize replica storage");
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+        let mut writes = adapter.new_write_set();
+        writes.put(
+            crate::sync::SYNC_REPLICA_STATE_SPACE,
+            crate::storage_adapter::StorageKey(Bytes::from_static(b"remote")),
+            br#"{"activeAccountId":"anonymous","cursor":0,"authoritativeBranches":{},"authorityKnownCommitIds":[]}"#
+                .to_vec(),
+        );
+        adapter
+            .commit_write_set(
+                writes,
+                crate::storage_adapter::StorageWriteOptions::default(),
+            )
+            .await
+            .expect("persist replica identity");
+
+        let result = open_lix().with_storage(storage).serve().await;
+        let Err(error) = result else {
+            panic!("persisted sync replica must not be promoted to authority");
         };
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
     }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1726,16 +1726,6 @@ where
         Ok(IdempotencyReceiptResolution::Replay(durable))
     }
 
-    pub(crate) async fn replay_execute_idempotency_result(
-        &self,
-        idempotency: &ExecuteIdempotency,
-    ) -> Result<Option<ExecuteResult>, LixError> {
-        match self.resolve_idempotency_receipt(idempotency).await? {
-            IdempotencyReceiptResolution::Absent => Ok(None),
-            IdempotencyReceiptResolution::Replay(receipt) => receipt.into_single_result().map(Some),
-        }
-    }
-
     async fn load_idempotency_receipt(
         &self,
         idempotency: &ExecuteIdempotency,

--- a/packages/lix/src/telemetry/mod.rs
+++ b/packages/lix/src/telemetry/mod.rs
@@ -805,8 +805,6 @@ pub(crate) fn unix_time_ms() -> u64 {
 ///
 /// This is the only place that emits `lix.repository.opened`.
 /// Handshake session creation and in-process [`crate::open_lix`] call it.
-/// Protocol roots opened with [`crate::OpenLixBuilder::as_protocol_root`]
-/// skip it so a cached runtime can inherit a sink without emitting.
 /// Hosts that mint a session against an already-open runtime (MCP signed
 /// context, cache hit) should call the same helper instead of opening another
 /// engine.

--- a/packages/lix/tests/migration_v68.rs
+++ b/packages/lix/tests/migration_v68.rs
@@ -17,6 +17,10 @@
 use lix::Memory;
 use lix::migration::{MigrationOptions, MigrationStatus, inspect_lix, migrate_lix};
 use lix::open_lix;
+#[cfg(feature = "server-protocol")]
+use lix::server_protocol::{ServerProtocolBody, ServerProtocolContext};
+#[cfg(feature = "server-protocol")]
+use lix::telemetry::{CallbackTelemetrySink, CompletedTelemetrySpan};
 
 const V68_SNAPSHOT: &[u8] = include_bytes!("fixtures/v68_bundled_csv_history.snapshot");
 // Generated with the protocol-v68 engine in `lix-engine-typed-main-current`:
@@ -226,4 +230,124 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
             "fixture should contain live {schema_key} history"
         );
     }
+}
+
+#[cfg(feature = "server-protocol")]
+#[tokio::test]
+async fn migrated_v68_fixture_serves_two_independent_protocol_sessions() {
+    use http::StatusCode;
+    use http_body_util::BodyExt as _;
+    use std::sync::{Arc, Mutex};
+
+    let storage = Memory::from_snapshot(V68_SNAPSHOT).expect("v68 golden snapshot should decode");
+    let Err(open_error) = open_lix().with_storage(storage.clone()).serve().await else {
+        panic!("protocol serving must require an explicit migration");
+    };
+    assert_eq!(open_error.code, "LIX_ERROR_REPOSITORY_MIGRATION_REQUIRED");
+    migrate_lix(storage.clone(), MigrationOptions::default())
+        .await
+        .expect("v68 fixture should migrate");
+
+    let spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
+    let captured_spans = Arc::clone(&spans);
+    let protocol = open_lix()
+        .with_storage(storage)
+        .with_telemetry(Arc::new(CallbackTelemetrySink::new(move |span| {
+            captured_spans.lock().expect("telemetry spans").push(span);
+        })))
+        .serve()
+        .await
+        .expect("migrated repository should serve without a root session");
+    assert_eq!(
+        spans
+            .lock()
+            .expect("telemetry spans")
+            .iter()
+            .filter(|span| span.start.name == "lix.repository.opened")
+            .count(),
+        0,
+        "serving a migrated repository must not create a hidden root session"
+    );
+
+    let mut session_ids = Vec::new();
+    for index in 0..2 {
+        let response = protocol
+            .handle(
+                http::Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1")
+                    .body(ServerProtocolBody::empty())
+                    .expect("build handshake"),
+                ServerProtocolContext::anonymous(),
+            )
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect handshake")
+            .to_bytes();
+        let body: serde_json::Value =
+            serde_json::from_slice(&body).expect("decode handshake response");
+        let session_id = body["sessionId"]
+            .as_str()
+            .expect("handshake session id")
+            .to_owned();
+        session_ids.push(session_id.clone());
+
+        for (query_index, (sql, expected_rows)) in [
+            ("SELECT id, cells, order_key FROM csv_row", 1),
+            ("SELECT id FROM lix_history('csv_row')", 1),
+            ("SELECT schema_key FROM lix_registered_schema", 1),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let response = protocol
+                .handle(
+                    http::Request::builder()
+                        .method("POST")
+                        .uri("/lix/v1/execute")
+                        .header("lix-session-id", &session_id)
+                        .header(
+                            "idempotency-key",
+                            format!("migrated-v68-{index}-{query_index}"),
+                        )
+                        .header("content-type", "application/json")
+                        .body(ServerProtocolBody::from(
+                            serde_json::json!({ "sql": sql, "params": [] }).to_string(),
+                        ))
+                        .expect("build migrated query"),
+                    ServerProtocolContext::anonymous(),
+                )
+                .await;
+            assert_eq!(response.status(), StatusCode::OK, "query failed: {sql}");
+            let body = response
+                .into_body()
+                .collect()
+                .await
+                .expect("collect migrated query")
+                .to_bytes();
+            let body: serde_json::Value =
+                serde_json::from_slice(&body).expect("decode migrated query");
+            assert!(
+                body["rows"]
+                    .as_array()
+                    .is_some_and(|rows| rows.len() >= expected_rows),
+                "migrated query returned too few rows: {sql}: {body}"
+            );
+        }
+    }
+    assert_ne!(session_ids[0], session_ids[1]);
+    assert_eq!(
+        spans
+            .lock()
+            .expect("telemetry spans")
+            .iter()
+            .filter(|span| span.start.name == "lix.repository.opened")
+            .count(),
+        2,
+        "each successful handshake must bind exactly one application session"
+    );
 }


### PR DESCRIPTION
## Summary

- hard-cut protocol authority construction to open_lix().with_storage(storage).serve().await and remove the fake root-session APIs
- make the protocol own Engine directly; every handshake creates one retained client session through a bounded server-owned lifecycle
- fail closed when persisted sync-replica storage is opened as an authority
- centralize authenticated account bootstrap on Engine and keep durable bootstrap/session opening tracked across request cancellation and shutdown
- migrate protocol, sync, SlateDB, plugin, crash-consistency, telemetry, docs, and v68 migration coverage to the new ownership model

## Breaking API cut

Removed without compatibility shims:

- OpenLixBuilder::as_protocol_root()
- LixServerProtocol::new(...)
- LixServerProtocol::with_options(root, options)

Protocol options now use open_lix().serve().with_options(options).await.

## Production boundary

The old server booted a hidden application/root session and then opened protocol child sessions over it. That duplicated ownership and coupled repository migration/opening to root-session branch/account/telemetry behavior. The protocol now opens only Engine at serve time. Raw v68 storage fails closed until explicitly migrated; the migrated v68 fixture then serves with zero hidden sessions, supports two independent handshakes, and executes current, history, and registered-schema queries through both.

Session creation is server-owned detached work from synchronous capacity reservation through authenticated account bootstrap, client registration, and cleanup. HTTP cancellation cannot let close() return while a durable adapter write is still in flight.

## Validation

- cargo test -p lix --all-features server_protocol: 126 passed, 3 ignored
- cargo test --manifest-path packages/e2e/Cargo.toml --test sync_mode --features sdk-tests,server-protocol: 17 passed
- migrated v68 protocol acceptance passed
- authenticated bootstrap cancellation-versus-close regression passed
- root and tooling workspace Clippy with -D warnings passed
- cargo check -p lix --tests passed
- formatting, diff, change fragment, release script, and server-protocol docs validation passed

Reviewed independently for lifecycle/cancellation correctness, migration/test adequacy, and simplification/API residue; all reviewer blockers were addressed.