### PR TITLE
ci: parallelize Rust test scopes and avoid duplicate builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,11 +224,12 @@ jobs:
 
       # Cargo's default test target selection also compiles every example even
       # though nextest cannot execute their main functions. The e2e package has
-      # 30 examples; explicitly selecting libraries and tests avoids rebuilding
-      # all 30 while Clippy above still checks their compilation.
+      # 30 examples; explicitly selecting tests avoids rebuilding all 30 while
+      # Clippy above still checks their compilation. This package has no library
+      # target, so passing --lib would fail before any tests could run.
       - name: Run Rust E2E tests with nextest
         if: matrix.task == 'e2e'
-        run: cargo nextest run --config-file .config/nextest.toml --profile ci-e2e --locked --manifest-path tooling/Cargo.toml --cargo-profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --lib --tests --timings
+        run: cargo nextest run --config-file .config/nextest.toml --profile ci-e2e --locked --manifest-path tooling/Cargo.toml --cargo-profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --tests --timings
 
       - name: Upload Rust test timing reports
         if: matrix.task != 'clippy' && !cancelled()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - main
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -33,6 +37,9 @@ jobs:
 
       - name: Validate server protocol docs
         run: node scripts/validate-server-protocol-docs.mjs
+
+      - name: Validate CI workflow invariants
+        run: node --test scripts/ci-workflow.test.mjs
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})
@@ -68,8 +75,19 @@ jobs:
         include:
           - name: Clippy
             task: clippy
+            workspace: .
           - name: Test
             task: test
+            workspace: .
+            junit: target/nextest/ci/junit.xml
+          - name: Tooling Test
+            task: tooling
+            workspace: tooling
+            junit: tooling/target/nextest/ci/junit.xml
+          - name: E2E Test
+            task: e2e
+            workspace: tooling
+            junit: tooling/target/nextest/ci-e2e/junit.xml
 
     steps:
       - name: Checkout repository
@@ -101,7 +119,7 @@ jobs:
           sudo apt-get install -y llvm-dev libclang-dev clang mold
 
       - name: Install cargo-nextest
-        if: matrix.task == 'test'
+        if: matrix.task != 'clippy'
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
@@ -113,8 +131,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: cargo-${{ matrix.task }}
-          workspaces: |
-            . -> target
+          workspaces: ${{ matrix.workspace }}
           cache-targets: true
           cache-workspace-crates: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -133,7 +150,8 @@ jobs:
         if: matrix.task == 'clippy'
         run: |
           cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
-          cargo clippy --locked --manifest-path tooling/Cargo.toml --profile test --workspace --all-targets --all-features -- -D warnings
+          cargo clippy --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-targets --all-features -- -D warnings
+          cargo clippy --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --all-targets --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace,system-allocation-profiler -- -D warnings
 
       # The one supported configuration nothing else here builds: `cfg(test)`
       # with `storage-benches` OFF, which is exactly what a plain
@@ -198,37 +216,45 @@ jobs:
         # the second sat invisible behind the first for hours because CI could
         # only ever report one.
         if: matrix.task == 'test'
-        run: |
-          cargo nextest run --config-file .config/nextest.toml --profile ci --cargo-profile test --workspace --all-features --timings
-          cargo nextest run --config-file .config/nextest.toml --profile ci --locked --manifest-path tooling/Cargo.toml --cargo-profile test --workspace --exclude lix_e2e --all-features --timings
-          cargo nextest run --config-file .config/nextest.toml --profile ci-e2e --locked --manifest-path tooling/Cargo.toml --cargo-profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --timings
+        run: cargo nextest run --config-file .config/nextest.toml --profile ci --cargo-profile test --workspace --all-features --lib --tests --timings
+
+      - name: Run Rust tooling tests with nextest
+        if: matrix.task == 'tooling'
+        run: cargo nextest run --config-file .config/nextest.toml --profile ci --locked --manifest-path tooling/Cargo.toml --cargo-profile test --workspace --exclude lix_e2e --all-features --lib --tests --timings
+
+      # Cargo's default test target selection also compiles every example even
+      # though nextest cannot execute their main functions. The e2e package has
+      # 30 examples; explicitly selecting libraries and tests avoids rebuilding
+      # all 30 while Clippy above still checks their compilation.
+      - name: Run Rust E2E tests with nextest
+        if: matrix.task == 'e2e'
+        run: cargo nextest run --config-file .config/nextest.toml --profile ci-e2e --locked --manifest-path tooling/Cargo.toml --cargo-profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --lib --tests --timings
 
       - name: Upload Rust test timing reports
-        if: matrix.task == 'test' && !cancelled()
+        if: matrix.task != 'clippy' && !cancelled()
         uses: actions/upload-artifact@v4
         with:
-          name: rust-nextest-junit
-          path: |
-            target/nextest/ci/junit.xml
-            tooling/target/nextest/ci/junit.xml
-            tooling/target/nextest/ci-e2e/junit.xml
+          name: rust-nextest-junit-${{ matrix.task }}
+          path: ${{ matrix.junit }}
           if-no-files-found: error
 
       - name: Upload Cargo build timings
-        if: matrix.task == 'test' && !cancelled()
+        if: matrix.task != 'clippy' && !cancelled()
         uses: actions/upload-artifact@v4
         with:
-          name: rust-cargo-timings
-          path: target/cargo-timings/*.html
+          name: rust-cargo-timings-${{ matrix.task }}
+          path: ${{ matrix.workspace }}/target/cargo-timings/*.html
           if-no-files-found: warn
 
       # Nextest deliberately does not execute rustdoc tests. Keep their Cargo
       # feature/package scopes aligned with the nextest runs above.
       - name: Run Rust doctests
         if: matrix.task == 'test'
-        run: |
-          cargo test --doc --profile test --workspace --all-features --no-fail-fast
-          cargo test --doc --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
+        run: cargo test --doc --profile test --workspace --all-features --no-fail-fast
+
+      - name: Run Rust tooling doctests
+        if: matrix.task == 'tooling'
+        run: cargo test --doc --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
 
       # The e2e test compilation above already builds the real workspace plugin
       # artifacts. This one external fixture covers the distinct risk: whether

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -40,7 +40,12 @@ test("nextest compiles test targets without building unused examples", () => {
 	const commands = workflow.match(/^\s*run: cargo nextest run .+$/gm) ?? [];
 	assert.equal(commands.length, 3);
 	for (const command of commands) {
-		assert.match(command, /--lib --tests/);
+		assert.match(command, /--tests/);
+		if (command.includes("-p lix_e2e")) {
+			assert.doesNotMatch(command, /--lib\b/);
+		} else {
+			assert.match(command, /--lib --tests/);
+		}
 		assert.doesNotMatch(command, /--examples|--all-targets/);
 	}
 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const workflow = readFileSync(
+	resolve(repositoryRoot, ".github/workflows/ci.yml"),
+	"utf8",
+);
+
+test("superseded CI runs are cancelled per pull request or branch", () => {
+	assert.match(
+		workflow,
+		/group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
+	);
+	assert.match(workflow, /cancel-in-progress: true/);
+});
+
+test("Rust test scopes run independently with workspace-specific caches", () => {
+	for (const [name, task, workspace] of [
+		["Test", "test", "."],
+		["Tooling Test", "tooling", "tooling"],
+		["E2E Test", "e2e", "tooling"],
+	]) {
+		assert.match(
+			workflow,
+			new RegExp(
+				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}`,
+			),
+		);
+	}
+	assert.match(workflow, /workspaces: \$\{\{ matrix\.workspace \}\}/);
+	assert.match(workflow, /name: rust-nextest-junit-\$\{\{ matrix\.task \}\}/);
+	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
+});
+
+test("nextest compiles test targets without building unused examples", () => {
+	const commands = workflow.match(/^\s*run: cargo nextest run .+$/gm) ?? [];
+	assert.equal(commands.length, 3);
+	for (const command of commands) {
+		assert.match(command, /--lib --tests/);
+		assert.doesNotMatch(command, /--examples|--all-targets/);
+	}
+});
+
+test("tooling Clippy excludes the benchmark-only DuckDB feature", () => {
+	assert.match(
+		workflow,
+		/cargo clippy .*--manifest-path tooling\/Cargo\.toml .*--workspace --exclude lix_e2e --all-targets --all-features/,
+	);
+	const e2eClippy = workflow
+		.split("\n")
+		.find((line) => line.includes("cargo clippy") && line.includes("-p lix_e2e"));
+	assert.ok(e2eClippy);
+	assert.match(e2eClippy, /--all-targets --features /);
+	assert.doesNotMatch(e2eClippy, /\btpch\b|--all-features/);
+});


### PR DESCRIPTION
## Summary

- Run the main Rust workspace, tooling workspace, and E2E package in separate parallel matrix lanes with their own dependency caches and timing artifacts.
- Tell nextest to build only library and test targets, avoiding the 30 E2E examples previously compiled without being executed.
- Keep Clippy coverage for examples and supported E2E features while excluding benchmark-only DuckDB, and cancel superseded CI runs.
- Add regression tests for workflow target selection, cache scoping, artifact names, and benchmark feature exclusions.

## Why

Recent CI timing artifacts show 4,107 Rust tests executing in about 69 seconds, while the current sequential Rust job spends roughly 588 seconds compiling three workspaces/configurations. The E2E invocation alone spends about 1,337 CPU-seconds compiling examples that never run.

## Verification

- `node --test scripts/ci-workflow.test.mjs scripts/release.test.mjs`
- `/tmp/lix-ci-audit-20260825/actionlint/actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml`
- `cargo metadata --no-deps --format-version 1`
- `cargo metadata --no-deps --format-version 1 --manifest-path tooling/Cargo.toml --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace,system-allocation-profiler`
- `node scripts/validate-changes.mjs`
- `node scripts/validate-server-protocol-docs.mjs`
- `node scripts/validate-publish-surface.mjs`
- Confirmed with a temporary nextest fixture that `--lib --tests` executes unit and integration tests without compiling an intentionally broken example.
