### PR TITLE
refactor(migration): remove session-open repository repair

### DIFF
--- a/.changenotes/migrate-working-diff-before-session-open.md
+++ b/.changenotes/migrate-working-diff-before-session-open.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Moved legacy working-diff repair out of application and protocol session opening and into the explicit offline repository migration. Repository format v72 guarantees current working-diff epochs before the engine opens, so successful handshakes allocate session state without repairing repository storage.

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1,19 +1,12 @@
-use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::BinaryCasContext;
-use crate::branch::{
-    BranchContext, BranchHeadControlContext, BranchRefReader, branch_head_control_precondition,
-    stage_branch_head_control,
-};
+use crate::branch::{BranchContext, BranchRefReader};
 use crate::catalog::{CatalogContext, CatalogFingerprint};
 use crate::changelog::COMMIT_SPACE;
 use crate::commit_graph::CommitGraphContext;
-use crate::hot_state::{
-    CompleteWorkingDiffMode, HotStateContext, HotTrackedSnapshot, TrackedHeadContext,
-    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
-};
+use crate::hot_state::HotStateContext;
 use crate::hot_state::HotStateRowRequest;
 use crate::init::InitReceipt;
 use crate::observe_coordinator::ObserveCoordinator;
@@ -28,16 +21,14 @@ use crate::sql2::SqlPlanningCache;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageBeginScanOptions, StorageCoreProjection, StoragePrefix,
-    StorageError, StorageReadOptions, StorageWriteOptions, StorageWriteSetError,
+    StorageReadOptions, StorageWriteOptions,
 };
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
 use crate::sync::SyncModeState;
 use crate::telemetry::{
     ActiveTelemetrySpan, ENGINE_OPEN, SESSION_OPEN, TelemetrySink, instrument_lix_result,
 };
-use crate::tracked_state::{
-    TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns, TrackedStateScanRequest,
-};
+use crate::tracked_state::TrackedStateContext;
 use crate::transaction::CommitCoordinator;
 use crate::{LixError, NullableKeyFilter};
 
@@ -303,8 +294,6 @@ where
             let active_branch_id = active_branch_id.into();
             let active_account_id = active_account_id.into();
             self.validate_active_account(&active_account_id).await?;
-            self.repair_stale_working_diff_epoch(&active_branch_id)
-                .await?;
             Ok(SessionContext::new(
                 SessionBranch::new(active_branch_id),
                 active_account_id,
@@ -355,8 +344,6 @@ where
             )
             .await?;
             drop(read);
-            self.repair_stale_working_diff_epoch(&active_branch_id)
-                .await?;
             Ok(SessionContext::new(
                 SessionBranch::new(active_branch_id),
                 active_account_id,
@@ -411,159 +398,6 @@ where
         let close_result = system.close().await;
         execute_result?;
         close_result
-    }
-
-    /// Repairs the private working-diff projection produced by the former
-    /// partial-checkpoint publication path. The branch control is the durable
-    /// authority for `(head, checkpoint)`; HOT rows and their sparse epoch are
-    /// derived serving state, so rebuilding them does not alter repository
-    /// history or any public API surface.
-    async fn repair_stale_working_diff_epoch(&self, branch_id: &str) -> Result<(), LixError> {
-        // Healthy session opens must not serialize behind writes or sync
-        // imports. Read the two private coordinates optimistically and take
-        // the write gate only when repair may actually be necessary.
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let control = BranchHeadControlContext::new()
-            .reader(read.clone())
-            .load(branch_id)
-            .await?;
-        let Some(control) = control else {
-            return Ok(());
-        };
-        let Some(checkpoint_commit_id) = control.working_diff_checkpoint_commit_id else {
-            return Ok(());
-        };
-        let epoch = TrackedHeadContext::new()
-            .reader(read)
-            .working_diff_epoch(branch_id)
-            .await?;
-        if epoch.as_ref().is_some_and(|epoch| {
-            epoch.checkpoint_commit_id == checkpoint_commit_id
-                && epoch.generation == control.tracked_generation
-        }) {
-            return Ok(());
-        }
-
-        let _write_guard = self.collaboration_write_gate.lock().await;
-        for _attempt in 0..3 {
-            let read = SharedStorageAdapterRead::new(
-                self.storage
-                    .begin_read(StorageReadOptions::default())
-                    .await?,
-            );
-            let mut observations = BranchHeadControlContext::new()
-                .reader(read.clone())
-                .load_observed(&[branch_id.to_owned()])
-                .await?;
-            let observation = observations
-                .pop()
-                .expect("one requested branch produces one observation");
-            let Some(mut control) = observation.control else {
-                return Ok(());
-            };
-            let Some(checkpoint_commit_id) = control.working_diff_checkpoint_commit_id else {
-                return Ok(());
-            };
-            let epoch = TrackedHeadContext::new()
-                .reader(read.clone())
-                .working_diff_epoch(branch_id)
-                .await?;
-            if epoch.as_ref().is_some_and(|epoch| {
-                epoch.checkpoint_commit_id == checkpoint_commit_id
-                    && epoch.generation == control.tracked_generation
-            }) {
-                return Ok(());
-            }
-
-            let current = load_repair_hot_snapshot(
-                &read,
-                branch_id,
-                control.head_commit_id,
-            )
-            .await?;
-            let checkpoint = load_repair_hot_snapshot(
-                &read,
-                branch_id,
-                checkpoint_commit_id,
-            )
-            .await?;
-            let generation = crate::changelog::CommitId::with_change_address_space(
-                uuid::Uuid::now_v7(),
-            );
-            let mut coverage = WorkingDiffIndexCoverage::default();
-            let mut writes = self.storage.new_write_set();
-            let (_, schema_keys) = TrackedHeadContext::new()
-                .writer(&read, &mut writes)
-                .stage_complete_current_state_with_working_diff(
-                    branch_id,
-                    generation,
-                    current,
-                    Some(control.tracked_generation),
-                    &[],
-                    &[],
-                    &BTreeSet::new(),
-                    if control.head_commit_id == checkpoint_commit_id {
-                        CompleteWorkingDiffMode::ResetClean
-                    } else {
-                        CompleteWorkingDiffMode::Rebase {
-                            checkpoint_commit_id,
-                            checkpoint,
-                        }
-                    },
-                    &mut coverage,
-                )
-                .await?;
-            stage_tracked_working_diff_epoch(
-                &mut writes,
-                branch_id,
-                TrackedWorkingDiffEpoch {
-                    checkpoint_commit_id,
-                    generation,
-                    coverage,
-                },
-            )?;
-            control.tracked_generation = generation;
-            control.current_state_revision = control
-                .current_state_revision
-                .checked_add(1)
-                .ok_or_else(|| LixError::unknown("branch current-state revision overflowed"))?;
-            control.reset_schema_presence();
-            control.note_schemas(schema_keys.iter().map(String::as_str));
-            stage_branch_head_control(&mut writes, branch_id, control)?;
-            let preconditions = vec![branch_head_control_precondition(
-                branch_id,
-                observation.raw_token,
-            )?];
-            drop(read);
-            match self
-                .storage
-                .commit_write_set(
-                    writes,
-                    StorageWriteOptions {
-                        preconditions,
-                        ..StorageWriteOptions::default()
-                    },
-                )
-                .await
-            {
-                Ok(_) => {
-                    self.observe_invalidation.bump();
-                    return Ok(());
-                }
-                Err(StorageWriteSetError::Storage(
-                    StorageError::WriteConflict | StorageError::PreconditionFailed(_),
-                )) => continue,
-                Err(error) => return Err(error.into()),
-            }
-        }
-        Err(LixError::new(
-            LixError::CODE_TRANSACTION_CONFLICT,
-            format!("branch '{branch_id}' changed while repairing its working-diff epoch"),
-        ))
     }
 
     /// Rebuilds the tracked serving commit root for one branch from changelog.
@@ -681,35 +515,6 @@ where
         }
         Ok(())
     }
-}
-
-async fn load_repair_hot_snapshot(
-    read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-    branch_id: &str,
-    commit_id: crate::changelog::CommitId,
-) -> Result<HotTrackedSnapshot, LixError> {
-    let rows = TrackedStateContext::new()
-        .reader(read)
-        .scan_batch_at_commit(
-            &commit_id.to_string(),
-            &TrackedStateScanRequest {
-                filter: TrackedStateFilter {
-                    include_tombstones: true,
-                    ..TrackedStateFilter::default()
-                },
-                read_columns: TrackedStateReadColumns::default(),
-                limit: None,
-            },
-        )
-        .await?
-        .into_rows()
-        .into_iter()
-        .filter(|row| {
-            branch_id == GLOBAL_BRANCH_ID
-                || row.schema_key != crate::checkpoint::CHECKPOINT_SCHEMA_KEY
-        })
-        .collect();
-    HotTrackedSnapshot::from_materialized_rows(rows)
 }
 
 async fn assert_initialized<StorageImpl>(

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5315,6 +5315,10 @@ enum WorkingDiffBaselineAction {
 }
 
 impl HotTrackedSnapshot {
+    pub(crate) fn len(&self) -> usize {
+        self.rows.len()
+    }
+
     pub(crate) fn from_materialized_rows(
         tracked_rows: Vec<MaterializedTrackedStateRow>,
     ) -> Result<Self, LixError> {

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -83,9 +83,14 @@ pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 /// working-diff checkpoint cursor retained by the branch control. Checkpoint
 /// aliases and chronology GC both rely on the complete root set, so v70
 /// repositories are repaired by the explicit offline migration before open.
-pub(crate) const CURRENT_FORMAT_VERSION: u32 = 71;
+///
+/// `v72` requires every live branch's private working-diff epoch to agree with
+/// its branch control. The explicit offline migration rebuilds stale derived
+/// projections once; application and protocol session opening contains no
+/// legacy repair path.
+pub(crate) const CURRENT_FORMAT_VERSION: u32 = 72;
 const REPOSITORY_PROTOCOL_PREFIX: &[u8] = b"tracked-default-branch.v";
-pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v71";
+pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v72";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -1214,20 +1219,20 @@ mod tests {
     #[test]
     fn repository_protocol_parser_distinguishes_versions() {
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v71"),
+            parse_repository_protocol(b"tracked-default-branch.v72"),
             RepositoryProtocolStatus::Current
         );
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v70"),
-            RepositoryProtocolStatus::MigrationRequired { found_version: 70 }
+            parse_repository_protocol(b"tracked-default-branch.v71"),
+            RepositoryProtocolStatus::MigrationRequired { found_version: 71 }
         );
         assert_eq!(
             parse_repository_protocol(b"tracked-default-branch.v69"),
             RepositoryProtocolStatus::MigrationRequired { found_version: 69 }
         );
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v72"),
-            RepositoryProtocolStatus::TooNew { found_version: 72 }
+            parse_repository_protocol(b"tracked-default-branch.v73"),
+            RepositoryProtocolStatus::TooNew { found_version: 73 }
         );
         assert_eq!(
             parse_repository_protocol(b"not-a-lix-format"),

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -3,7 +3,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use bytes::Bytes;
 
 use crate::LixError;
-use crate::branch::BranchHeadControlContext;
+use crate::branch::{
+    BranchHeadControlContext, branch_head_control_precondition, stage_branch_head_control,
+};
+use crate::hot_state::{
+    CompleteWorkingDiffMode, HotTrackedSnapshot, TrackedHeadContext, TrackedWorkingDiffEpoch,
+    WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
+};
 use crate::init::{
     CURRENT_FORMAT_VERSION, REPOSITORY_PROTOCOL_KEY, REPOSITORY_PROTOCOL_SPACE,
     RepositoryProtocolStatus, parse_repository_protocol,
@@ -14,8 +20,10 @@ use crate::storage_adapter::{
     StoragePrecondition as Precondition, StorageProjectedValue as ProjectedValue, StorageRead,
     StorageReadOptions as ReadOptions, StorageWrite, StorageWriteOptions as WriteOptions,
 };
+use crate::storage_adapter::StorageWriteOptions as AdapterWriteOptions;
 use crate::tracked_state::{
-    CommitStateReplayDebt, TrackedStateContext,
+    CommitStateReplayDebt, TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns,
+    TrackedStateScanRequest,
     encode_commit_state_manifest_replacement_for_migration,
     load_rebuild_plans_to_nearest_available_root_bounded, stage_rebuild_plan_with_writer,
 };
@@ -23,6 +31,7 @@ use crate::tracked_state::{
 const REPOSITORY_PROTOCOL_V68: &[u8] = b"tracked-default-branch.v68";
 const REPOSITORY_PROTOCOL_V69: &[u8] = b"tracked-default-branch.v69";
 const REPOSITORY_PROTOCOL_V70: &[u8] = b"tracked-default-branch.v70";
+const REPOSITORY_PROTOCOL_V71: &[u8] = b"tracked-default-branch.v71";
 
 /// Bounds for explicit offline repository migrations.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -139,7 +148,7 @@ where
         .map_err(storage_error)?;
     let from_version = match crate::init::repository_protocol_status(&read).await? {
         RepositoryProtocolStatus::MigrationRequired {
-            found_version: found_version @ (68 | 69 | 70),
+            found_version: found_version @ (68 | 69 | 70 | 71),
         } => found_version,
         RepositoryProtocolStatus::Current => {
             return Ok(MigrationReport {
@@ -179,21 +188,25 @@ where
             )
             .await?;
         }
-        promote_chronology_roots(
-            &adapter,
-            &storage,
-            options,
-            70,
-            REPOSITORY_PROTOCOL_V70,
-            crate::init::REPOSITORY_PROTOCOL_VALUE,
-        )
-        .await?;
+        if from_version <= 70 {
+            promote_chronology_roots(
+                &adapter,
+                &storage,
+                options,
+                70,
+                REPOSITORY_PROTOCOL_V70,
+                REPOSITORY_PROTOCOL_V71,
+            )
+            .await?;
+        }
+        let hot_rows_rewritten =
+            migrate_v71_working_diff_epochs(&adapter, &storage, options).await?;
         return Ok(MigrationReport {
             from_version,
             to_version: CURRENT_FORMAT_VERSION,
             changes_rewritten: 0,
             commit_members_rewritten: 0,
-            hot_rows_rewritten: 0,
+            hot_rows_rewritten,
         });
     }
     let expected_revision =
@@ -279,16 +292,216 @@ where
         options,
         70,
         REPOSITORY_PROTOCOL_V70,
-        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        REPOSITORY_PROTOCOL_V71,
     )
     .await?;
+    let migrated_hot_rows = migrate_v71_working_diff_epochs(&adapter, &storage, options).await?;
     Ok(MigrationReport {
         from_version: 68,
         to_version: CURRENT_FORMAT_VERSION,
         changes_rewritten,
         commit_members_rewritten: commit_plan.member_count,
-        hot_rows_rewritten,
+        hot_rows_rewritten: hot_rows_rewritten.saturating_add(migrated_hot_rows),
     })
+}
+
+/// Moves the former session-open compatibility repair into the explicit
+/// offline repository migration. Once the v72 marker is published, opening a
+/// client session only allocates session state and never repairs storage.
+async fn migrate_v71_working_diff_epochs<S>(
+    adapter: &crate::storage_adapter::StorageAdapter<S>,
+    storage: &S,
+    options: MigrationOptions,
+) -> Result<u64, LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let read = SharedStorageAdapterRead::new(
+        adapter
+            .begin_read(ReadOptions::default())
+            .await
+            .map_err(storage_error)?,
+    );
+    match crate::init::repository_protocol_status(&read).await? {
+        RepositoryProtocolStatus::MigrationRequired { found_version: 71 } => {}
+        status => {
+            return Err(migration_error(format!(
+                "v71 working-diff migration observed unexpected repository status {status:?}"
+            )));
+        }
+    }
+    let branch_ids = BranchHeadControlContext::new()
+        .reader(read.clone())
+        .scan()
+        .await?
+        .into_iter()
+        .map(|(branch_id, _)| branch_id)
+        .collect::<Vec<_>>();
+    if branch_ids.len() > options.max_changes {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "v71 working-diff migration exceeds configured branch bound: {} branches",
+                branch_ids.len()
+            ),
+        ));
+    }
+    read.finish().map_err(storage_error)?;
+
+    let mut hot_rows_rewritten = 0_u64;
+    for branch_id in branch_ids {
+        hot_rows_rewritten = hot_rows_rewritten
+            .saturating_add(migrate_working_diff_epoch(adapter, &branch_id).await?);
+    }
+
+    let read = SharedStorageAdapterRead::new(
+        adapter
+            .begin_read(ReadOptions::default())
+            .await
+            .map_err(storage_error)?,
+    );
+    let expected_revision = crate::storage_adapter::load_repository_mutation_revision(&read)
+        .await
+        .map_err(storage_error)?;
+    read.finish().map_err(storage_error)?;
+    crate::migration::publish::publish(
+        storage,
+        expected_revision,
+        REPOSITORY_PROTOCOL_V71,
+        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        crate::migration::publish::PublicationPlan::bounded(0, 0),
+    )
+    .await?;
+    Ok(hot_rows_rewritten)
+}
+
+async fn migrate_working_diff_epoch<S>(
+    storage: &crate::storage_adapter::StorageAdapter<S>,
+    branch_id: &str,
+) -> Result<u64, LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let read = SharedStorageAdapterRead::new(
+        storage
+            .begin_read(ReadOptions::default())
+            .await
+            .map_err(storage_error)?,
+    );
+    let mut observations = BranchHeadControlContext::new()
+        .reader(read.clone())
+        .load_observed(&[branch_id.to_owned()])
+        .await?;
+    let observation = observations
+        .pop()
+        .expect("one requested branch produces one observation");
+    let Some(mut control) = observation.control else {
+        return Ok(0);
+    };
+    let Some(checkpoint_commit_id) = control.working_diff_checkpoint_commit_id else {
+        return Ok(0);
+    };
+    let epoch = TrackedHeadContext::new()
+        .reader(read.clone())
+        .working_diff_epoch(branch_id)
+        .await?;
+    if epoch.as_ref().is_some_and(|epoch| {
+        epoch.checkpoint_commit_id == checkpoint_commit_id
+            && epoch.generation == control.tracked_generation
+    }) {
+        return Ok(0);
+    }
+
+    let current = load_migration_hot_snapshot(&read, branch_id, control.head_commit_id).await?;
+    let hot_rows_rewritten = current.len() as u64;
+    let checkpoint =
+        load_migration_hot_snapshot(&read, branch_id, checkpoint_commit_id).await?;
+    let generation = crate::changelog::CommitId::with_change_address_space(uuid::Uuid::now_v7());
+    let mut coverage = WorkingDiffIndexCoverage::default();
+    let mut writes = storage.new_write_set();
+    let (_, schema_keys) = TrackedHeadContext::new()
+        .writer(&read, &mut writes)
+        .stage_complete_current_state_with_working_diff(
+            branch_id,
+            generation,
+            current,
+            Some(control.tracked_generation),
+            &[],
+            &[],
+            &BTreeSet::new(),
+            if control.head_commit_id == checkpoint_commit_id {
+                CompleteWorkingDiffMode::ResetClean
+            } else {
+                CompleteWorkingDiffMode::Rebase {
+                    checkpoint_commit_id,
+                    checkpoint,
+                }
+            },
+            &mut coverage,
+        )
+        .await?;
+    stage_tracked_working_diff_epoch(
+        &mut writes,
+        branch_id,
+        TrackedWorkingDiffEpoch {
+            checkpoint_commit_id,
+            generation,
+            coverage,
+        },
+    )?;
+    control.tracked_generation = generation;
+    control.current_state_revision = control
+        .current_state_revision
+        .checked_add(1)
+        .ok_or_else(|| migration_error("branch current-state revision overflowed"))?;
+    control.reset_schema_presence();
+    control.note_schemas(schema_keys.iter().map(String::as_str));
+    stage_branch_head_control(&mut writes, branch_id, control)?;
+    let preconditions = vec![branch_head_control_precondition(
+        branch_id,
+        observation.raw_token,
+    )?];
+    read.finish().map_err(storage_error)?;
+    storage
+        .commit_write_set(
+            writes,
+            AdapterWriteOptions {
+                preconditions,
+                ..AdapterWriteOptions::default()
+            },
+        )
+        .await
+        .map(|_| hot_rows_rewritten)
+        .map_err(LixError::from)
+}
+
+async fn load_migration_hot_snapshot(
+    read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    commit_id: crate::changelog::CommitId,
+) -> Result<HotTrackedSnapshot, LixError> {
+    let rows = TrackedStateContext::new()
+        .reader(read)
+        .scan_batch_at_commit(
+            &commit_id.to_string(),
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns::default(),
+                limit: None,
+            },
+        )
+        .await?
+        .into_rows()
+        .into_iter()
+        .filter(|row| {
+            branch_id == crate::GLOBAL_BRANCH_ID
+                || row.schema_key != crate::checkpoint::CHECKPOINT_SCHEMA_KEY
+        })
+        .collect();
+    HotTrackedSnapshot::from_materialized_rows(rows)
 }
 
 /// Promotes every distinct live branch chronology root to a durable root.
@@ -512,6 +725,9 @@ fn migration_error(message: impl Into<String>) -> LixError {
 mod tests {
     use super::*;
     use crate::changelog::CommitId;
+    use crate::hot_state::{
+        TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
+    };
     use crate::storage::{Memory, StorageWrite, WriteOptions};
     use crate::storage_adapter::{PutBatch, PutEntry, StorageValue};
     use crate::tracked_state::TrackedStateRootId;
@@ -555,7 +771,7 @@ mod tests {
     async fn seed_rooted_head_with_rootless_checkpoint_cursor(
         storage: &Memory,
         protocol: &'static [u8],
-    ) -> (CommitId, CommitId, TrackedStateRootId) {
+    ) -> (String, CommitId, CommitId, TrackedStateRootId) {
         let lix = crate::open_lix()
             .with_storage(storage.clone())
             .await
@@ -577,13 +793,13 @@ mod tests {
             .scan()
             .await
             .unwrap();
-        let mut candidates = controls.into_iter().filter_map(|(_, control)| {
+        let mut candidates = controls.into_iter().filter_map(|(branch_id, control)| {
             control
                 .working_diff_checkpoint_commit_id
                 .filter(|checkpoint_commit_id| *checkpoint_commit_id != control.head_commit_id)
-                .map(|_| control)
+                .map(|_| (branch_id, control))
         });
-        let control = candidates
+        let (branch_id, control) = candidates
             .next()
             .expect("fixture should have one branch with a distinct checkpoint cursor");
         assert!(
@@ -658,7 +874,12 @@ mod tests {
             .unwrap();
         fixture.commit().await.unwrap();
 
-        (head_commit_id, checkpoint_commit_id, head_root_id)
+        (
+            branch_id,
+            head_commit_id,
+            checkpoint_commit_id,
+            head_root_id,
+        )
     }
 
     async fn assert_chronology_roots_promoted(
@@ -699,7 +920,7 @@ mod tests {
     #[tokio::test]
     async fn v69_promotion_roots_head_and_distinct_checkpoint_cursor_before_v70() {
         let storage = Memory::new();
-        let (head_commit_id, checkpoint_commit_id, head_root_id) =
+        let (_branch_id, head_commit_id, checkpoint_commit_id, head_root_id) =
             seed_rooted_head_with_rootless_checkpoint_cursor(
                 &storage,
                 REPOSITORY_PROTOCOL_V69,
@@ -720,7 +941,7 @@ mod tests {
             inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Required {
                 from_version: 70,
-                to_version: 71,
+                to_version: 72,
             }
         );
         assert_chronology_roots_promoted(
@@ -745,25 +966,56 @@ mod tests {
     #[tokio::test]
     async fn v70_repair_promotes_distinct_rootless_checkpoint_cursor() {
         let storage = Memory::new();
-        let (head_commit_id, checkpoint_commit_id, head_root_id) =
+        let (branch_id, head_commit_id, checkpoint_commit_id, head_root_id) =
             seed_rooted_head_with_rootless_checkpoint_cursor(
                 &storage,
                 REPOSITORY_PROTOCOL_V70,
             )
             .await;
 
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+        promote_chronology_roots(
+            &adapter,
+            &storage,
+            MigrationOptions::default(),
+            70,
+            REPOSITORY_PROTOCOL_V70,
+            REPOSITORY_PROTOCOL_V71,
+        )
+        .await
+        .unwrap();
+        let mut stale_epoch = adapter.new_write_set();
+        stage_tracked_working_diff_epoch(
+            &mut stale_epoch,
+            &branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id,
+                generation: CommitId::with_change_address_space(uuid::Uuid::now_v7()),
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .unwrap();
+        adapter
+            .commit_write_set(stale_epoch, Default::default())
+            .await
+            .unwrap();
+
         assert_eq!(
             inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Required {
-                from_version: 70,
-                to_version: 71,
+                from_version: 71,
+                to_version: 72,
             }
         );
         let report = migrate_lix(storage.clone(), MigrationOptions::default())
             .await
             .unwrap();
-        assert_eq!(report.from_version, 70);
-        assert_eq!(report.to_version, 71);
+        assert_eq!(report.from_version, 71);
+        assert_eq!(report.to_version, 72);
+        assert!(
+            report.hot_rows_rewritten > 0,
+            "the v71 edge must repair the stale working-diff epoch before publishing v72"
+        );
         assert_chronology_roots_promoted(
             &storage,
             head_commit_id,

--- a/packages/lix/src/migration/registry.rs
+++ b/packages/lix/src/migration/registry.rs
@@ -21,6 +21,10 @@ const MIGRATIONS: &[Migration] = &[
         from_version: 70,
         to_version: 71,
     },
+    Migration {
+        from_version: 71,
+        to_version: 72,
+    },
 ];
 
 pub(crate) fn registered_migrations() -> &'static [Migration] {
@@ -60,7 +64,14 @@ mod tests {
                 to_version: 71,
             })
         );
-        assert_eq!(registered_migrations().len(), 3);
+        assert_eq!(
+            migration_from(71),
+            Some(&Migration {
+                from_version: 71,
+                to_version: 72,
+            })
+        );
+        assert_eq!(registered_migrations().len(), 4);
         assert_eq!(migration_from(crate::init::CURRENT_FORMAT_VERSION), None);
     }
 }

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -1556,7 +1556,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
     );
 }
 
-async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
+async fn stale_partial_checkpoint_epoch_repairs_in_migration(_sim: Simulation) {
 	let authority = fresh_authority().await;
 	write_key_value(&authority, "selected", "baseline").await;
 	write_key_value(&authority, "remaining", "baseline").await;
@@ -1624,6 +1624,15 @@ async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
 		old_epoch,
 	)
 	.unwrap();
+	writes.put(
+		crate::init::REPOSITORY_PROTOCOL_SPACE,
+		crate::storage_adapter::StorageKey(bytes::Bytes::from_static(
+			crate::init::REPOSITORY_PROTOCOL_KEY,
+		)),
+		crate::storage_adapter::StorageValue {
+			bytes: bytes::Bytes::from_static(b"tracked-default-branch.v71"),
+		},
+	);
 	adapter
 		.commit_write_set(
 			writes,
@@ -1633,6 +1642,13 @@ async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
 		.unwrap();
 	crate::tracked_state::arm_diff_commits_test_probe(&checkpoint_commit_id, &head_commit_id);
 
+	replica.lix.close().await.unwrap();
+	crate::migration::migrate_lix(
+		replica.storage.clone(),
+		crate::migration::MigrationOptions::default(),
+	)
+	.await
+	.expect("offline migration should repair the stale derived epoch");
 	replica.restart().await;
 	assert_eq!(
 		crate::tracked_state::take_diff_commits_test_probe(
@@ -1640,7 +1656,7 @@ async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
 			&head_commit_id,
 		),
 		0,
-		"reopening must repair the stale derived epoch directly from rooted snapshots",
+		"migration must repair the stale derived epoch directly from rooted snapshots",
 	);
 	assert_eq!(
 		replica
@@ -1652,7 +1668,7 @@ async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
 			.get::<i64>("count")
 			.unwrap(),
 		1,
-		"reopen repair must retain the unselected change",
+		"migration repair must retain the unselected change",
 	);
 	replica.write("selected", "after-reopen").await;
 }
@@ -1746,8 +1762,8 @@ sync_simulation_test!(
     partial_checkpoint_rebases_unselected_tombstone
 );
 sync_simulation_test!(
-	stale_partial_checkpoint_epoch_repairs_on_reopen,
-	stale_partial_checkpoint_epoch_repairs_on_reopen
+	stale_partial_checkpoint_epoch_repairs_in_migration,
+	stale_partial_checkpoint_epoch_repairs_in_migration
 );
 
 struct XorShift64(u64);

--- a/packages/lix/tests/migration_v68.rs
+++ b/packages/lix/tests/migration_v68.rs
@@ -40,7 +40,7 @@ async fn current_format_inspection_recognizes_v68_golden_snapshot() {
             .expect("v68 format inspection should succeed"),
         MigrationStatus::Required {
             from_version: 68,
-            to_version: 71,
+            to_version: 72,
         }
     );
 }
@@ -53,7 +53,7 @@ async fn migrates_external_v68_authority_and_plugin_and_engine_tombstones() {
         inspect_lix(&storage).await.unwrap(),
         MigrationStatus::Required {
             from_version: 68,
-            to_version: 71,
+            to_version: 72,
         }
     );
     let report = migrate_lix(storage.clone(), MigrationOptions::default())
@@ -152,19 +152,19 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
         .await
         .expect("v68 fixture should migrate");
     assert_eq!(report.from_version, 68);
-    assert_eq!(report.to_version, 71);
+    assert_eq!(report.to_version, 72);
     assert!(report.changes_rewritten >= 2);
     assert!(report.commit_members_rewritten >= 2);
     assert!(report.hot_rows_rewritten >= 1);
     assert_eq!(
         inspect_lix(&storage).await.unwrap(),
-        MigrationStatus::Current { version: 71 }
+        MigrationStatus::Current { version: 72 }
     );
     let retry = migrate_lix(storage.clone(), MigrationOptions::default())
         .await
         .expect("migration retry should be idempotent");
-    assert_eq!(retry.from_version, 71);
-    assert_eq!(retry.to_version, 71);
+    assert_eq!(retry.from_version, 72);
+    assert_eq!(retry.to_version, 72);
     assert_eq!(retry.changes_rewritten, 0);
 
     let migrated_snapshot = storage
@@ -251,7 +251,7 @@ async fn migrated_v68_fixture_serves_two_independent_protocol_sessions() {
     let spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
     let captured_spans = Arc::clone(&spans);
     let protocol = open_lix()
-        .with_storage(storage)
+        .with_storage(storage.clone())
         .with_telemetry(Arc::new(CallbackTelemetrySink::new(move |span| {
             captured_spans.lock().expect("telemetry spans").push(span);
         })))
@@ -268,6 +268,9 @@ async fn migrated_v68_fixture_serves_two_independent_protocol_sessions() {
         0,
         "serving a migrated repository must not create a hidden root session"
     );
+    let before_handshake = storage
+        .export_snapshot()
+        .expect("capture migrated repository before handshake");
 
     let mut session_ids = Vec::new();
     for index in 0..2 {
@@ -295,6 +298,15 @@ async fn migrated_v68_fixture_serves_two_independent_protocol_sessions() {
             .expect("handshake session id")
             .to_owned();
         session_ids.push(session_id.clone());
+        if index == 0 {
+            assert_eq!(
+                storage
+                    .export_snapshot()
+                    .expect("capture repository after handshake"),
+                before_handshake,
+                "a v72 handshake must not repair or mutate repository storage"
+            );
+        }
 
         for (query_index, (sql, expected_rows)) in [
             ("SELECT id, cells, order_key FROM csv_row", 1),


### PR DESCRIPTION
## Summary

- hard-cut session opening so it never repairs or mutates repository storage
- move the former stale working-diff epoch repair into an explicit offline v71 -> v72 migration
- keep v68-v71 repositories supported only through `inspect_lix` / `migrate_lix`
- prove migrated protocol handshakes do not mutate storage

## Architecture

A repository is either v72 and safe to open, or older and rejected until its owner runs the migration. There is no runtime compatibility branch and no hidden repair during application or protocol session creation.

LixRay's migration manager already owns maintenance mode, A/B backup, progress, retry, and rollback. This migration remains backend-agnostic inside Lix.

## Validation

- `RUSTFLAGS='-D warnings' cargo check -p lix --all-features --tests`
- `cargo clippy -p lix --all-features --tests -- -D warnings`
- `cargo test -p lix --all-features --lib --quiet` (3433 passed)
- `cargo test -p lix --all-features --test migration_v68 -- --nocapture` (4 passed)
- `cargo test -p lix --all-features stale_partial_checkpoint_epoch_repairs_in_migration_base -- --nocapture`
- `cargo test -p lix --doc`
- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
