### PR TITLE
refactor(telemetry): require explicit OpenTelemetry dispatch

### DIFF
--- a/.changenotes/explicit-opentelemetry-dispatch.md
+++ b/.changenotes/explicit-opentelemetry-dispatch.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Configure `OpenTelemetryTracingSink` with an explicit `tracing::Dispatch`.
+
+The zero-argument constructor was removed. The captured dispatch must contain a `tracing-opentelemetry` layer and now governs both span enablement and creation, independent of ambient task or thread subscribers.

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -6854,8 +6854,9 @@ mod tests {
     }
 
     async fn app_with_tracing_telemetry() -> TestApp {
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
         let server = open_lix()
-            .with_telemetry(Arc::new(OpenTelemetryTracingSink::new()))
+            .with_telemetry(Arc::new(OpenTelemetryTracingSink::new(dispatch)))
             .serve()
             .await
             .expect("serve lix");
@@ -11145,6 +11146,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_telemetry_dispatch_survives_an_unrelated_ambient_subscriber() {
+        let capture = CaptureLayer::default();
+        let spans = Arc::clone(&capture.spans);
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("lix-test");
+        let dispatch = tracing::Dispatch::new(
+            tracing_subscriber::registry()
+                .with(capture)
+                .with(tracing_opentelemetry::layer().with_tracer(tracer)),
+        );
+        let server = open_lix()
+            .with_telemetry(Arc::new(OpenTelemetryTracingSink::new(dispatch)))
+            .serve()
+            .await
+            .expect("serve lix");
+        let app = TestApp {
+            router: handler(server.clone()),
+            server,
+        };
+
+        let _ambient = tracing::subscriber::set_default(tracing_subscriber::registry());
+        let (session_id, _) = new_session(&app.router).await;
+        assert!(!session_id.is_empty());
+
+        let spans = spans.lock().expect("capture spans");
+        require_span(&spans, "lix.session.open");
+        require_span(&spans, "lix.repository.opened");
+    }
+
+    #[tokio::test]
     async fn explicit_transaction_exports_one_transaction_notify_span() {
         let capture = CaptureLayer::default();
         let spans = Arc::clone(&capture.spans);
@@ -11195,8 +11226,9 @@ mod tests {
         let capture = CaptureLayer::default();
         let spans = Arc::clone(&capture.spans);
         let (_provider, _subscriber) = set_otel_capture_default(capture);
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
         let _lix = open_lix()
-            .with_telemetry(Arc::new(OpenTelemetryTracingSink::new()))
+            .with_telemetry(Arc::new(OpenTelemetryTracingSink::new(dispatch)))
             .await
             .expect("open lix");
 

--- a/packages/lix/src/telemetry/mod.rs
+++ b/packages/lix/src/telemetry/mod.rs
@@ -286,50 +286,62 @@ pub(crate) fn new_span_context(parent: Option<&SpanContext>) -> SpanContext {
 
 /// OpenTelemetry-compliant adapter from engine telemetry into `tracing`.
 ///
-/// The active subscriber must include `tracing-opentelemetry`. This adapter
-/// sets real OpenTelemetry parents, links, attributes, and status, and returns
-/// the context assigned by that layer. It never creates shadow identifiers.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct OpenTelemetryTracingSink;
+/// `dispatch` must contain a `tracing-opentelemetry` layer. Capturing it at
+/// construction keeps span creation independent from whichever subscriber is
+/// ambient on the thread or task that later runs a Lix operation.
+#[derive(Clone)]
+pub struct OpenTelemetryTracingSink {
+    dispatch: tracing::Dispatch,
+}
+
+impl std::fmt::Debug for OpenTelemetryTracingSink {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OpenTelemetryTracingSink")
+            .finish_non_exhaustive()
+    }
+}
 
 impl OpenTelemetryTracingSink {
-    pub fn new() -> Self {
-        Self
+    pub fn new(dispatch: tracing::Dispatch) -> Self {
+        Self { dispatch }
     }
 }
 
 impl TelemetrySink for OpenTelemetryTracingSink {
     fn enabled(&self, descriptor: &TelemetrySpanDescriptor) -> bool {
-        match descriptor.class {
+        tracing::dispatcher::with_default(&self.dispatch, || match descriptor.class {
             TelemetrySpanClass::Sql | TelemetrySpanClass::Performance => {
                 tracing::enabled!(target: "lix_sql", tracing::Level::INFO)
             }
             TelemetrySpanClass::Lifecycle => {
                 tracing::enabled!(target: "lix", tracing::Level::INFO)
             }
-        }
+        })
     }
 
     fn start_span(&self, start: TelemetrySpanStart) -> Box<dyn TelemetrySpanHandle> {
-        let span = (start.descriptor.create_tracing_span)();
-        if let Some(parent) = start.parent_span_context.as_ref() {
-            span.set_parent(
-                OpenTelemetryContext::new().with_remote_span_context(parent.clone()),
-            )
-            .expect("tracing-opentelemetry rejected the Lix span parent");
-        }
-        for link in &start.links {
-            span.add_link(link.clone());
-        }
-        for attribute in &start.attributes {
-            record_attribute(&span, attribute);
-        }
-        let span_context = span.context().span().span_context().clone();
-        assert!(
-            span_context.is_valid(),
-            "OpenTelemetryTracingSink requires an active tracing-opentelemetry layer"
-        );
-        Box::new(OpenTelemetryTracingSpan { span, span_context })
+        tracing::dispatcher::with_default(&self.dispatch, || {
+            let span = (start.descriptor.create_tracing_span)();
+            if let Some(parent) = start.parent_span_context.as_ref() {
+                span.set_parent(
+                    OpenTelemetryContext::new().with_remote_span_context(parent.clone()),
+                )
+                .expect("tracing-opentelemetry rejected the Lix span parent");
+            }
+            for link in &start.links {
+                span.add_link(link.clone());
+            }
+            for attribute in &start.attributes {
+                record_attribute(&span, attribute);
+            }
+            let span_context = span.context().span().span_context().clone();
+            assert!(
+                span_context.is_valid(),
+                "OpenTelemetryTracingSink dispatch must contain an active tracing-opentelemetry layer"
+            );
+            Box::new(OpenTelemetryTracingSpan { span, span_context })
+        })
     }
 }
 
@@ -1196,11 +1208,12 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
         let tracer = provider.tracer("lix");
-        let _subscriber = tracing::subscriber::set_default(
+        let dispatch = tracing::Dispatch::new(
             tracing_subscriber::registry()
                 .with(tracing_opentelemetry::layer().with_tracer(tracer)),
         );
-        let sink: Arc<dyn TelemetrySink> = Arc::new(OpenTelemetryTracingSink::new());
+        let sink: Arc<dyn TelemetrySink> =
+            Arc::new(OpenTelemetryTracingSink::new(dispatch));
         let parent = ActiveTelemetrySpan::start(
             &sink,
             TelemetrySpanStart::new(&SQL_BATCH, Vec::new()),


### PR DESCRIPTION
## Summary

- make `OpenTelemetryTracingSink` capture a host-provided `tracing::Dispatch`
- use that dispatch for both span enablement and span creation
- remove the zero-argument constructor with no compatibility shim
- add a protocol regression for an unrelated ambient subscriber

## Why

Lix is vendor-neutral and must not depend on process-global telemetry state. A host can configure OpenTelemetry correctly while a request executes under a different ambient subscriber; the old API then admitted a span and created it without an OpenTelemetry context. Explicit ownership removes that invalid state.

## Verification

- `cargo fmt --all --check`
- `cargo check -p lix --lib`
- `cargo test -p lix tracing_sink_exports_real_parent_context_links_and_status`
- `cargo test -p lix --features server-protocol explicit_telemetry_dispatch_survives_an_unrelated_ambient_subscriber`
- `cargo test -p lix --features server-protocol handshake_exports_session_open_separate_from_opened_bind`