### PR TITLE
Release v0.14.0

### DIFF
--- a/.changenotes/README.md
+++ b/.changenotes/README.md
@@ -1,6 +1,6 @@
 # Changenotes
 
-Changenotes are release-note fragments for user-facing changes in core Lix packages.
+Changenotes are release-note fragments for significant user-facing changes in core Lix packages.
 
 Add one Markdown file per change to this folder. Use a short descriptive filename, for example:
 
@@ -28,11 +28,16 @@ SQLite now avoids loading values for key-only point reads and uses native storag
 
 ## When To Add One
 
-Add a changenote for user-facing changes in the core packages above.
+Add a changenote only when users would reasonably need to know about the change
+when deciding whether to upgrade or when adapting their application. Consolidate
+related capabilities and fixes into one release-level theme.
 
 - Use `minor` for backward-compatible user-facing capability additions.
 - Use `patch` for user-facing fixes, compatibility fixes, and performance improvements.
 
 Lix does not publish major releases from changenotes. Coordinate breaking changes so they can ship in a minor release before adding a changenote.
 
-Do not add a changenote for repo-only, documentation-only, CI-only, test-only, or chore-only changes.
+Do not add a changenote for repo-only, documentation-only, CI-only, test-only,
+chore-only, implementation-detail, or narrowly scoped optimization changes.
+Avoid separate notes for internal hard cuts, storage mechanics, retry paths, or
+telemetry subspans unless they materially change the public contract.

--- a/.changenotes/add-account-profile-uri.md
+++ b/.changenotes/add-account-profile-uri.md
@@ -1,9 +1,0 @@
----
-type: minor
----
-
-Added optional public profile URIs to repository accounts.
-
-Applications can now associate an account with a machine-readable public profile while keeping authentication and authorization separate from presentation metadata.
-
-Existing repositories durably add the nullable account column through the v72 to v73 repository migration.

--- a/.changenotes/add-commit-ancestry-sql.md
+++ b/.changenotes/add-commit-ancestry-sql.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Added `lix_commit_ancestry()` for querying commits reachable from the active branch through SQL.
-
-The table function defaults to the active branch head, accepts an explicit commit anchor, and reports each reachable commit with its shortest ancestry depth.

--- a/.changenotes/batch-opfs-point-reads.md
+++ b/.changenotes/batch-opfs-point-reads.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-OPFS-backed Lix repositories now batch point reads through SQLite and suppress delayed retry replays after an owner request completes. This keeps checkpointing and other bounded foreground operations responsive while multiple browser clients bootstrap the same repository.

--- a/.changenotes/browser-wasm-multi-tab.md
+++ b/.changenotes/browser-wasm-multi-tab.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Fixed concurrent cold starts of Lix in multiple browser tabs.
-
-Browser workers now coordinate the initial load of the fingerprinted Lix WebAssembly asset so every tab opens reliably while retaining immutable asset caching.

--- a/.changenotes/checkpoint-local-selected-payloads.md
+++ b/.changenotes/checkpoint-local-selected-payloads.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Partial checkpoints now reuse selected payloads already present in a synced repository snapshot instead of hydrating each cold source commit.

--- a/.changenotes/classify-sql-surfaces.md
+++ b/.changenotes/classify-sql-surfaces.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Added `information_schema.lix_surfaces` for discovering whether each public SQL surface is a relation, table function, command sink, or scalar function, including whether a relation is a base or view.
-
-The catalog also reports read and write capabilities, includes `lix_diff` and `lix_restore`, and classifies composed file, directory, branch, and change relations as views.

--- a/.changenotes/explicit-opentelemetry-dispatch.md
+++ b/.changenotes/explicit-opentelemetry-dispatch.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Configure `OpenTelemetryTracingSink` with an explicit `tracing::Dispatch`.
-
-The zero-argument constructor was removed. The captured dispatch must contain a `tracing-opentelemetry` layer and now governs both span enablement and creation, independent of ambient task or thread subscribers.

--- a/.changenotes/export-commit-storage-open-spans.md
+++ b/.changenotes/export-commit-storage-open-spans.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Production telemetry now uses one stable eleven-name contract across native tracing and JavaScript callbacks.
-
-SQL is hard-cut to `lix.sql.query`, `lix.sql.batch`, and `lix.sql.coherent_read_batch`; repository binding is `lix.repository.opened`; cold open is `lix.engine.open` plus `lix.session.open`. Writes expose additive `lix.transaction.materialize`, `lix.transaction.storage`, and `lix.transaction.notify` phases with a shared `lix.commit_cohort_id`. Callback spans use schema v2 and carry trace, span, and parent IDs. Fine-grained `lix_perf` diagnostics remain DEBUG-only.

--- a/.changenotes/fix-untracked-indexed-joins.md
+++ b/.changenotes/fix-untracked-indexed-joins.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Indexed equality reads now include rows written with `lixcol_untracked = true`, fixing point-filtered joins that could previously return null-extended children even though an unfiltered join found them.

--- a/.changenotes/hot-working-diff-primary-fallback.md
+++ b/.changenotes/hot-working-diff-primary-fallback.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Kept browser working-diff reads local when the sparse index cannot certify its coverage.
-
-Lix now falls back to authoritative HOT rows and resolves snapshot-local payloads before hydrating canonical commit history.

--- a/.changenotes/keep-partial-checkpoints-hot.md
+++ b/.changenotes/keep-partial-checkpoints-hot.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Kept partial checkpoints on the history-free working-diff path.
-
-Lix now carries unselected changes into the new checkpoint epoch atomically, avoiding cold history reconstruction and sync hydration on the next write or partial checkpoint.

--- a/.changenotes/lix-opened-session-bind.md
+++ b/.changenotes/lix-opened-session-bind.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Added a vendor-neutral `lix.repository.opened` engine span when a client session binds to a Lix.
-
-In-process `open_lix()` and protocol handshake session creation each emit one span. Protocol servers opened with `open_lix().serve()` attach their telemetry sink while creating no application session and emitting no opened span. Hosts that mint a session against an already-open runtime call `Lix::bind_session()` or `lix::bind_session`.

--- a/.changenotes/local-first-repository-sync.md
+++ b/.changenotes/local-first-repository-sync.md
@@ -1,9 +1,0 @@
----
-type: minor
----
-
-Added durable local-first repository sync for `openLix({ storage, server: { mode: "sync" } })`.
-
-Reads and writes stay local while Lix synchronizes commits with the server in
-the background. Browser apps can use OPFS for durable offline work. Older
-history and binary content download only when needed.

--- a/.changenotes/migrate-working-diff-before-session-open.md
+++ b/.changenotes/migrate-working-diff-before-session-open.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-Moved legacy working-diff repair out of application and protocol session opening and into the explicit offline repository migration. Repository format v72 guarantees current working-diff epochs before the engine opens, so successful handshakes allocate session state without repairing repository storage.

--- a/.changenotes/opfs-multi-client-owner.md
+++ b/.changenotes/opfs-multi-client-owner.md
@@ -1,9 +1,0 @@
----
-type: minor
----
-
-Added `@lix-js/storage-opfs`, a durable SQLite Wasm + OPFS storage provider for browser Lix repositories. It supports multiple Lix workers and tabs attaching to the same repository through one package-owned SQLite connection.
-
-Storage change watches wake `lix.observe()` after commits from another worker or tab, recover missed broadcasts through heartbeat state, and survive owner-tab failover. Lix transparently restarts full read queries when a concurrent commit expires their snapshot.
-
-Auto-commit mutations and mutation batches also restart as a whole when their planning snapshot expires or optimistic commit validation loses a race. The provider is covered for offline reads and writes, reload and abrupt-tab recovery, branch and repository isolation, divergent local engines, and cross-tab convergence.

--- a/.changenotes/packed-working-diff-local.md
+++ b/.changenotes/packed-working-diff-local.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Kept packed browser working diffs local by classifying checkpoint additions from their compact current-state authority instead of hydrating historical payload owners.

--- a/.changenotes/packed-working-diff-recreate.md
+++ b/.changenotes/packed-working-diff-recreate.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Kept restarted partial checkpoints over packed replacements on the local working-diff path instead of replaying repository history.

--- a/.changenotes/preserve-sync-error-details.md
+++ b/.changenotes/preserve-sync-error-details.md
@@ -1,6 +1,0 @@
----
-type: patch
----
-
-Repository sync now preserves structured server error details while adding the
-HTTP status, allowing hosts to react to states such as an in-progress migration.

--- a/.changenotes/push-down-working-diff-projection.md
+++ b/.changenotes/push-down-working-diff-projection.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Relation-specific `lix_diff()` queries honor SQL projection when constructing result rows, avoiding row identities, changed payloads, and file descriptors that an aggregate or narrow query did not request. Empty projections such as `COUNT(*)` also avoid allocating one placeholder row per change.

--- a/.changenotes/reconcile-concurrent-sync-bootstrap.md
+++ b/.changenotes/reconcile-concurrent-sync-bootstrap.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Centralized first-time sync admission around one durable replica binding and one atomic snapshot installer. Simultaneous opens now restart through the existing whole-open retry path until one publication is durable; aliases cannot claim the same local replica.
-
-Hard cut: JavaScript sync calls must now pass `storage` (`openLix({ storage, server: { mode: "sync", ... } })`). The implicit volatile Memory fallback no longer type-checks and is rejected at runtime because Memory cannot prove durable bootstrap publication.

--- a/.changenotes/relation-diff-api-v2.md
+++ b/.changenotes/relation-diff-api-v2.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Replace heterogeneous working diffs with relation-specific commit comparisons and row-based diff commands.
-
-`lix_diff(relation, from_commit_id, to_commit_id)` now exposes paired before/after relation columns, aggregated file changes, and underlying changed-row counts. Revert, apply, and partial checkpoints select `(relation, row_pk)`; commit parents and the repository root are available through `lix_commit.parent_commit_ids` and `lix_root_commit_id()`.

--- a/.changenotes/remote-observe-stream-sharding.md
+++ b/.changenotes/remote-observe-stream-sharding.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Fixed remote observations failing when an application opens more than 32 live queries.
-
-The remote client now keeps each multiplex stream within the server's safety limit while transparently distributing additional observations across coordinated streams.

--- a/.changenotes/remove-workerd-entrypoint.md
+++ b/.changenotes/remove-workerd-entrypoint.md
@@ -1,6 +1,0 @@
----
-type: minor
----
-
-Removed the `@lix-js/sdk/workerd` entry point, its direct in-isolate WASM
-snapshot bindings, and the now-unused synchronous WASM initializer.

--- a/.changenotes/restore-sql.md
+++ b/.changenotes/restore-sql.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Added the `lix_restore` command sink to move the active branch head to an ancestor commit without creating a new commit.
-
-Call it with `INSERT INTO lix_restore (commit_id) VALUES (...)`. Restore is available through the existing `execute()` API on local and remote sessions. Orphaned commits remain eligible for ordinary garbage collection, while checkpoint rows are retained.

--- a/.changenotes/retry-complete-repository-open.md
+++ b/.changenotes/retry-complete-repository-open.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Fixed simultaneous repository opens against shared browser storage.
-
-Lix now restarts the complete open lifecycle when a concurrent commit invalidates its coherent read, so another tab finishing sync bootstrap cannot leave the repository half-open.

--- a/.changenotes/retry-cross-context-opfs-reads.md
+++ b/.changenotes/retry-cross-context-opfs-reads.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Prevented transient cross-tab writes from interrupting coherent SQL reads in browser repositories.
-
-Lix now gives competing OPFS commits time to settle before retrying the complete query, while preserving bounded failure under continuous invalidation.

--- a/.changenotes/retry-filesystem-provider-expiry.md
+++ b/.changenotes/retry-filesystem-provider-expiry.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-Preserved typed storage-expiry errors through `lix_file` and `lix_directory` scans and restarted repository opening coherently after concurrent browser commits.

--- a/.changenotes/rust-protocol-client.md
+++ b/.changenotes/rust-protocol-client.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Remote `openLix({ server })` now uses one Rust Lix Server Protocol client.
-
-JavaScript only supplies `fetch` and authentication headers. Session expiry (`LIX_ERROR_PROTOCOL_SESSION_GONE` and `LIX_ERROR_PROTOCOL_SERVER_CLOSED`) recovers once by opening a new session that pins the last known branch, then retries the original request.

--- a/.changenotes/serve-protocol-engine.md
+++ b/.changenotes/serve-protocol-engine.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Open a Lix Server Protocol authority with `open_lix().with_storage(storage).serve().await`.
-
-Serving now owns the repository engine directly and retains one application session per successful handshake. The former `OpenLixBuilder::as_protocol_root()`, `LixServerProtocol::new()`, and `LixServerProtocol::with_options()` APIs were removed. Configure limits with `open_lix().serve().with_options(options).await`.

--- a/.changenotes/telemetry-hard-cut-one-pipeline.md
+++ b/.changenotes/telemetry-hard-cut-one-pipeline.md
@@ -1,7 +1,0 @@
----
-type: patch
----
-
-Lix is now the only producer of engine performance records: every stable production span goes through the per-engine TelemetrySink.
-
-Hosts attach one sink. JavaScript `onSpan` and native tracing export the same eleven names and ids. Coordinated commits carry `lix.commit_cohort_id` and links to every logical transaction. Dropped operations finish as `cancelled`. Legacy INFO names (`SELECT`, `SQL batch`, `lix.opened`) are gone; the SQL verb lives on `db.operation.name`.

--- a/.changenotes/unexport-sql-script-parse.md
+++ b/.changenotes/unexport-sql-script-parse.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Removed the public SQL script-parsing API from the Rust and JavaScript SDKs.
-
-Hosts no longer call `parse_sql_script` / `parseSqlScript`. `execute()` runs one statement. To run several statements atomically, pass an array of `{ sql, params? }` objects to `executeBatch()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,29 @@
 # Changelog
 
-## Unreleased
+## 0.14.0 - 2026-08-25
 
-### Breaking
+### Minor
 
-- Renamed the Rust repository migration functions from `inspect_repository` and
-  `migrate_repository` to `inspect_lix` and `migrate_lix`. Migration remains an
-  explicit offline operation before `open_lix()`.
-- Removed the `@lix-js/sdk/workerd` entry point, its direct in-isolate WASM
-  snapshot bindings, and the now-unused synchronous WASM initializer.
-- Removed the public SQL script-parsing API (`parse_sql_script` /
-  `parseSqlScript`, `SqlScriptPlan`, `SqlScriptStatement`) from the Rust and
-  JavaScript SDKs. Hosts pass an array of statements to `executeBatch`;
-  `execute` remains one statement. Do not parse a script string into statements
-  on the host.
-- Removed the public `lix_branch_descriptor`, `lix_branch_ref`, and matching
-  history SQL relations. Use the writable `lix_branch` relation for branch
-  creation, metadata, and current head access.
-- Removed every public `*_by_branch` SQL relation and the public
-  `lixcol_branch_id` row-routing column. SQL relations now always use the
-  current session's active branch. Open another session to work with another
-  branch. Compare tracked relations with
-  `lix_diff(relation, from_commit_id, to_commit_id)`; compare the current
-  checkpoint with the active head to inspect uncheckpointed work.
-  `lixcol_global` and the global branch remain supported.
-- Replaced heterogeneous working diffs, `diff_id` command selections, and the
-  public `lix_commit_edge` relation with relation-specific commit diffs,
-  `(relation, row_pk)` command selections, and ordered
-  `lix_commit.parent_commit_ids`. Use `lix_root_commit_id()` to obtain the
-  repository's existing initial commit.
+- Added optional public profile URIs to repository accounts.
+
+  Applications can now associate an account with a machine-readable public profile while keeping authentication and authorization separate from presentation metadata.
+
+  v0.14 uses repository format v73. Existing repositories must run the explicit offline migration before opening; historical accounts receive `NULL` for the new field and profile updates remain durable.
+- Added durable local-first repository sync for offline-capable applications.
+
+  `openLix({ storage, server: { mode: "sync" } })` keeps reads and writes local while synchronizing with the server in the background. Browser applications can use OPFS for durable offline work, safely share a repository across tabs and workers, and recover when the owning tab closes.
+- Redesigned version control around session-scoped SQL relations and commit-to-commit diffs.
+
+  Use `lix_diff(relation, from_commit_id, to_commit_id)` to compare tracked relations, `lix_restore` to move a branch to an ancestor, and `lix_commit_ancestry()` plus commit parent IDs to inspect history. This replaces the former `*_by_branch`, branch descriptor/ref, heterogeneous working-diff, `diff_id`, and commit-edge surfaces; open a separate session for each branch.
+- Simplified the public SDK surface for serving, batching, migrations, and telemetry.
+
+  Serve a repository with `open_lix().with_storage(storage).serve().await`, submit atomic statement arrays through `executeBatch`, and run explicit offline migrations through `inspect_lix` and `migrate_lix`. Rust and JavaScript now share one stable telemetry contract. The former protocol constructors, Workerd entry point, SQL script parser, migration names, and legacy telemetry surface have been removed.
+
+### Patch
+
+- Improved browser, remote, and large-repository reliability and performance.
+
+  Concurrent tabs now open, synchronize, and query coherently; remote clients recover sessions and support larger sets of live observations; and diff, checkpoint, and sync operations avoid loading unused rows, payloads, and history.
 
 ## 0.12.3 - 2026-08-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lix"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "async-executor",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "lix-schema"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "lix-storage-filesystem"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "futures-lite",
  "lix",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "lix-storage-rocksdb"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "lix-storage-slatedb"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "lix_collaboration_test_support"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "lix_js_sdk"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "async-stream",
  "blake3",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_csv"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64",
  "lix",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_excalidraw"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "lix",
  "serde_json",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_json"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64",
  "blake3",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_markdown"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64",
  "chardetng",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_text"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64",
  "lix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.12.3"
+version = "0.14.0"
 authors = ["Opral"]
 edition = "2024"
 description = "Embeddable version control for apps and AI agents."
@@ -34,13 +34,13 @@ categories = ["development-tools", "artificial-intelligence", "filesystem"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-lix_cli = { path = "packages/cli", version = "=0.12.3" }
-lix = { path = "packages/lix", version = "=0.12.3", default-features = false }
-lix_schema = { package = "lix-schema", path = "packages/lix-schema", version = "=0.12.3" }
-lix_storage_filesystem = { package = "lix-storage-filesystem", path = "packages/storage-filesystem", version = "=0.12.3", default-features = false }
-lix_storage_rocksdb = { package = "lix-storage-rocksdb", path = "packages/storage-rocksdb", version = "=0.12.3" }
-lix_storage_slatedb = { package = "lix-storage-slatedb", path = "packages/storage-slatedb", version = "=0.12.3" }
-lix_js_sdk = { path = "packages/js-sdk", version = "=0.12.3" }
+lix_cli = { path = "packages/cli", version = "=0.14.0" }
+lix = { path = "packages/lix", version = "=0.14.0", default-features = false }
+lix_schema = { package = "lix-schema", path = "packages/lix-schema", version = "=0.14.0" }
+lix_storage_filesystem = { package = "lix-storage-filesystem", path = "packages/storage-filesystem", version = "=0.14.0", default-features = false }
+lix_storage_rocksdb = { package = "lix-storage-rocksdb", path = "packages/storage-rocksdb", version = "=0.14.0" }
+lix_storage_slatedb = { package = "lix-storage-slatedb", path = "packages/storage-slatedb", version = "=0.14.0" }
+lix_js_sdk = { path = "packages/js-sdk", version = "=0.14.0" }
 mimalloc = { version = "0.1.52", features = ["local_dynamic_tls"] }
 
 [workspace.lints.rust]

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lix-js/sdk",
-	"version": "0.12.3",
+	"version": "0.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lix-js/sdk",
-			"version": "0.12.3",
+			"version": "0.14.0",
 			"license": "MIT",
 			"dependencies": {
 				"fflate": "^0.8.3"
@@ -20,10 +20,10 @@
 				"vitest": "4.1.10"
 			},
 			"optionalDependencies": {
-				"@lix-js/sdk-darwin-arm64": "0.12.3",
-				"@lix-js/sdk-linux-arm64": "0.12.3",
-				"@lix-js/sdk-linux-x64": "0.12.3",
-				"@lix-js/sdk-win32-x64": "0.12.3"
+				"@lix-js/sdk-darwin-arm64": "0.14.0",
+				"@lix-js/sdk-linux-arm64": "0.14.0",
+				"@lix-js/sdk-linux-x64": "0.14.0",
+				"@lix-js/sdk-win32-x64": "0.14.0"
 			}
 		},
 		"node_modules/@blazediff/core": {
@@ -78,8 +78,8 @@
 			"license": "MIT"
 		},
 		"node_modules/@lix-js/sdk-darwin-arm64": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/@lix-js/sdk-darwin-arm64/-/sdk-darwin-arm64-0.12.3.tgz",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-darwin-arm64/-/sdk-darwin-arm64-0.14.0.tgz",
 			"cpu": [
 				"arm64"
 			],
@@ -89,8 +89,8 @@
 			]
 		},
 		"node_modules/@lix-js/sdk-linux-arm64": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-arm64/-/sdk-linux-arm64-0.12.3.tgz",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-arm64/-/sdk-linux-arm64-0.14.0.tgz",
 			"cpu": [
 				"arm64"
 			],
@@ -100,8 +100,8 @@
 			]
 		},
 		"node_modules/@lix-js/sdk-linux-x64": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-x64/-/sdk-linux-x64-0.12.3.tgz",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-x64/-/sdk-linux-x64-0.14.0.tgz",
 			"cpu": [
 				"x64"
 			],
@@ -111,8 +111,8 @@
 			]
 		},
 		"node_modules/@lix-js/sdk-win32-x64": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/@lix-js/sdk-win32-x64/-/sdk-win32-x64-0.12.3.tgz",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-win32-x64/-/sdk-win32-x64-0.14.0.tgz",
 			"cpu": [
 				"x64"
 			],

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@lix-js/sdk",
 	"type": "module",
-	"version": "0.12.3",
+	"version": "0.14.0",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -49,10 +49,10 @@
 		"typecheck": "tsc -p tsconfig.test.json --noEmit"
 	},
 	"optionalDependencies": {
-		"@lix-js/sdk-darwin-arm64": "0.12.3",
-		"@lix-js/sdk-linux-arm64": "0.12.3",
-		"@lix-js/sdk-linux-x64": "0.12.3",
-		"@lix-js/sdk-win32-x64": "0.12.3"
+		"@lix-js/sdk-darwin-arm64": "0.14.0",
+		"@lix-js/sdk-linux-arm64": "0.14.0",
+		"@lix-js/sdk-linux-x64": "0.14.0",
+		"@lix-js/sdk-win32-x64": "0.14.0"
 	},
 	"devDependencies": {
 		"@vitest/browser-playwright": "4.1.10",

--- a/packages/storage-filesystem/package-lock.json
+++ b/packages/storage-filesystem/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lix-js/storage-filesystem",
-	"version": "0.12.3",
+	"version": "0.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lix-js/storage-filesystem",
-			"version": "0.12.3",
+			"version": "0.14.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^24.10.2",
@@ -14,7 +14,7 @@
 				"vitest": "4.1.10"
 			},
 			"peerDependencies": {
-				"@lix-js/sdk": "0.12.3"
+				"@lix-js/sdk": "0.14.0"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@lix-js/storage-filesystem",
 	"type": "module",
-	"version": "0.12.3",
+	"version": "0.14.0",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -25,7 +25,7 @@
 		"typecheck": "tsc -p tsconfig.test.json --noEmit"
 	},
 	"peerDependencies": {
-		"@lix-js/sdk": "0.12.3"
+		"@lix-js/sdk": "0.14.0"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.2",

--- a/packages/storage-opfs/package-lock.json
+++ b/packages/storage-opfs/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lix-js/storage-opfs",
-	"version": "0.12.3",
+	"version": "0.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lix-js/storage-opfs",
-			"version": "0.12.3",
+			"version": "0.14.0",
 			"license": "MIT",
 			"dependencies": {
 				"@sqlite.org/sqlite-wasm": "3.53.0-build1"
@@ -21,12 +21,12 @@
 				"vitest": "4.1.10"
 			},
 			"peerDependencies": {
-				"@lix-js/sdk": "0.12.3"
+				"@lix-js/sdk": "0.14.0"
 			}
 		},
 		"../js-sdk": {
 			"name": "@lix-js/sdk",
-			"version": "0.12.3",
+			"version": "0.14.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -41,10 +41,10 @@
 				"vitest": "4.1.10"
 			},
 			"optionalDependencies": {
-				"@lix-js/sdk-darwin-arm64": "0.12.3",
-				"@lix-js/sdk-linux-arm64": "0.12.3",
-				"@lix-js/sdk-linux-x64": "0.12.3",
-				"@lix-js/sdk-win32-x64": "0.12.3"
+				"@lix-js/sdk-darwin-arm64": "0.14.0",
+				"@lix-js/sdk-linux-arm64": "0.14.0",
+				"@lix-js/sdk-linux-x64": "0.14.0",
+				"@lix-js/sdk-win32-x64": "0.14.0"
 			}
 		},
 		"node_modules/@blazediff/core": {

--- a/packages/storage-opfs/package.json
+++ b/packages/storage-opfs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@lix-js/storage-opfs",
 	"type": "module",
-	"version": "0.12.3",
+	"version": "0.14.0",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -32,7 +32,7 @@
 		"@sqlite.org/sqlite-wasm": "3.53.0-build1"
 	},
 	"peerDependencies": {
-		"@lix-js/sdk": "0.12.3"
+		"@lix-js/sdk": "0.14.0"
 	},
 	"devDependencies": {
 		"@lix-js/sdk": "file:../js-sdk",

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -3128,7 +3128,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lix"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "async-stream",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "lix-schema"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lix-storage-filesystem"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "lix",
  "lix-storage-rocksdb",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "lix-storage-rocksdb"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "lix-storage-slatedb"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "lix_collaboration_test_support"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_csv"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "lix",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_excalidraw"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "lix",
  "serde_json",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_json"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_markdown"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "chardetng",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_text"
-version = "0.12.3"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "lix",

--- a/tooling/Cargo.toml
+++ b/tooling/Cargo.toml
@@ -21,10 +21,10 @@ categories = ["development-tools", "artificial-intelligence", "filesystem"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-lix = { path = "../packages/lix", version = "=0.12.3", default-features = false }
-lix_storage_filesystem = { package = "lix-storage-filesystem", path = "../packages/storage-filesystem", version = "=0.12.3", default-features = false }
-lix_storage_rocksdb = { package = "lix-storage-rocksdb", path = "../packages/storage-rocksdb", version = "=0.12.3" }
-lix_storage_slatedb = { package = "lix-storage-slatedb", path = "../packages/storage-slatedb", version = "=0.12.3" }
+lix = { path = "../packages/lix", version = "=0.14.0", default-features = false }
+lix_storage_filesystem = { package = "lix-storage-filesystem", path = "../packages/storage-filesystem", version = "=0.14.0", default-features = false }
+lix_storage_rocksdb = { package = "lix-storage-rocksdb", path = "../packages/storage-rocksdb", version = "=0.14.0" }
+lix_storage_slatedb = { package = "lix-storage-slatedb", path = "../packages/storage-slatedb", version = "=0.14.0" }
 mimalloc = { version = "0.1.52", features = ["local_dynamic_tls"] }
 
 [workspace.lints.rust]


### PR DESCRIPTION
Skips v0.13.0 and prepares the lockstep v0.14.0 release.\n\n- consolidates 31 pending fragments into five major user-facing themes\n- tightens changenote policy to exclude implementation-level notes\n- bumps all published Rust and npm packages to 0.14.0\n- refreshes root, tooling, and npm lockfiles\n\nValidated with the release-script tests, publish-surface validation, cargo-nextest all-simulations (3,321 passed), and Rust doc tests (10 passed).