### PR TITLE
feat: add active-branch latest checkpoint commit accessor

### DIFF
--- a/.changenotes/latest-checkpoint-commit-accessor.md
+++ b/.changenotes/latest-checkpoint-commit-accessor.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added `lix_latest_checkpoint_commit_id()` for reading the active branch's latest checkpoint directly in SQL.
+
+The accessor falls back to the repository root when the branch has no checkpoint, allowing reactive working changes to be queried with `lix_diff('lix_file', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id())`.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -27,7 +27,7 @@ INSERT INTO lix_create_checkpoint DEFAULT VALUES RETURNING commit_id;
 import { openLix } from "@lix-js/sdk";
 
 const lix = await openLix();
-const initial = await lix.createCheckpoint();
+await lix.createCheckpoint();
 
 await lix.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
   "checkpoint-demo",
@@ -36,19 +36,25 @@ await lix.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
 
 const working = await lix.execute(
   `SELECT row_pk, diff_type, from_value, to_value
-   FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())`,
-  [initial.commitId],
+   FROM lix_diff(
+     'lix_key_value',
+     lix_latest_checkpoint_commit_id(),
+     lix_active_branch_commit_id()
+   )`,
 );
 
 for (const row of working.rows) {
   console.log(row.get("diff_type"), row.get("row_pk"));
 }
 
-const checkpoint = await lix.createCheckpoint();
+await lix.createCheckpoint();
 const remaining = await lix.execute(
   `SELECT count(*) AS count
-   FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())`,
-  [checkpoint.commitId],
+   FROM lix_diff(
+     'lix_key_value',
+     lix_latest_checkpoint_commit_id(),
+     lix_active_branch_commit_id()
+   )`,
 );
 console.assert(remaining.rows[0].get("count") === 0);
 
@@ -67,6 +73,7 @@ A runnable Rust version lives at
 | `lix_commit` | Repository-global commit graph | `id`, `parent_commit_ids`, and standard `lixcol_*` columns |
 | `lix_history('lix_checkpoint'[, commit_id])` | Global checkpoint-row authorship history | Checkpoint columns and standard history `lixcol_*` columns |
 | `lix_commit_ancestry([commit_id])` | Active head or an explicit anchor | `commit_id`, `depth` |
+| `lix_latest_checkpoint_commit_id()` | Active branch | Latest checkpoint commit ID, or the repository root if the branch has no checkpoint |
 | `lix_root_commit_id()` | Repository root | Scalar ID of the repository bootstrap root |
 
 `parent_commit_ids` is an ordered JSONB array: element zero is the mainline
@@ -78,7 +85,22 @@ FROM lix_commit
 WHERE id = $checkpoint_commit_id;
 ```
 
-The newest checkpoint remains a normal query:
+Use `lix_latest_checkpoint_commit_id()` to resolve the active branch's working
+baseline. It returns the branch's latest checkpoint, or `lix_root_commit_id()`
+when the branch has no checkpoint. Pair it with the active head to inspect
+working changes in one query, including before the first checkpoint:
+
+```sql
+SELECT row_pk, diff_type
+FROM lix_diff(
+  'lix_file',
+  lix_latest_checkpoint_commit_id(),
+  lix_active_branch_commit_id()
+);
+```
+
+Checkpoint markers in `lix_checkpoint` are repository-global. Querying the
+newest marker can therefore return a checkpoint from a different branch:
 
 ```sql
 SELECT commit_id

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -16,18 +16,14 @@ tracked content.
 import { openLix } from "@lix-js/sdk";
 
 const lix = await openLix();
-const checkpoint = await lix.execute(
-  "SELECT commit_id FROM lix_checkpoint ORDER BY lixcol_created_at DESC LIMIT 1",
-);
-const checkpointCommitId = checkpoint.rows[0].get("commit_id");
-const head = await lix.execute("SELECT lix_active_branch_commit_id() AS id");
-const headCommitId = head.rows[0].get("id");
-
 const changedFiles = await lix.execute(
   `SELECT row_pk, diff_type, from_path, to_path, row_count
-   FROM lix_diff('lix_file', $1, $2)
+   FROM lix_diff(
+     'lix_file',
+     lix_latest_checkpoint_commit_id(),
+     lix_active_branch_commit_id()
+   )
    ORDER BY coalesce(to_path, from_path)`,
-  [checkpointCommitId, headCommitId],
 );
 
 for (const row of changedFiles.rows) {
@@ -37,10 +33,14 @@ for (const row of changedFiles.rows) {
 const reverted = await lix.execute(
   `INSERT INTO lix_revert (relation, row_pk)
    SELECT 'lix_file', row_pk
-   FROM lix_diff('lix_file', $1, $2)
-   WHERE row_pk = $3
+   FROM lix_diff(
+     'lix_file',
+     lix_latest_checkpoint_commit_id(),
+     lix_active_branch_commit_id()
+   )
+   WHERE row_pk = $1
    RETURNING commit_id`,
-  [checkpointCommitId, headCommitId, changedFiles.rows[0].get("row_pk")],
+  [changedFiles.rows[0].get("row_pk")],
 );
 
 if (reverted.rows.length > 0) {
@@ -49,6 +49,11 @@ if (reverted.rows.length > 0) {
 
 await lix.close();
 ```
+
+`lix_latest_checkpoint_commit_id()` uses the active branch's checkpoint, not
+the newest repository-global checkpoint marker. Before the branch has a
+checkpoint, it returns `lix_root_commit_id()`, so the same query also works
+for a new branch.
 
 ## Diff rows
 
@@ -69,7 +74,11 @@ descriptor and content rows contributing to the aggregate:
 
 ```sql
 SELECT count(*) AS changed_files, sum(row_count) AS changed_rows
-FROM lix_diff('lix_file', $checkpoint_commit_id, $head_commit_id);
+FROM lix_diff(
+  'lix_file',
+  lix_latest_checkpoint_commit_id(),
+  lix_active_branch_commit_id()
+);
 ```
 
 `lix_diff('lix_directory', ...)` supports changes to directory descriptors,
@@ -100,7 +109,11 @@ The insert-only command sinks consume queries selecting `(relation, row_pk)`:
 ```sql
 INSERT INTO lix_revert (relation, row_pk)
 SELECT 'lix_file', row_pk
-FROM lix_diff('lix_file', $checkpoint_commit_id, $head_commit_id)
+FROM lix_diff(
+  'lix_file',
+  lix_latest_checkpoint_commit_id(),
+  lix_active_branch_commit_id()
+)
 WHERE coalesce(to_path, from_path) LIKE '/docs/%';
 
 INSERT INTO lix_apply (relation, row_pk)
@@ -110,7 +123,11 @@ WHERE to_done = true;
 
 INSERT INTO lix_create_checkpoint (relation, row_pk)
 SELECT 'lix_file', row_pk
-FROM lix_diff('lix_file', $checkpoint_commit_id, $head_commit_id)
+FROM lix_diff(
+  'lix_file',
+  lix_latest_checkpoint_commit_id(),
+  lix_active_branch_commit_id()
+)
 WHERE to_path LIKE '/docs/%'
 RETURNING commit_id;
 

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -12,6 +12,8 @@ operators; there are no public `lix_json_*` functions.
 | `lix_active_account_id()` | text | Active SQL-session account. |
 | `lix_active_branch_id()` | text | Active branch. |
 | `lix_active_branch_commit_id()` | text | Active branch head pinned for the statement. |
+| `lix_latest_checkpoint_commit_id()` | text | Active branch's latest checkpoint, or the repository root if it has none. |
+| `lix_root_commit_id()` | text | Repository bootstrap root. |
 | `uuidv7()` | uuid | Generate a UUIDv7 value. |
 | `CURRENT_TIMESTAMP` | timestamptz | Transaction-start instant at microsecond precision. |
 
@@ -53,6 +55,20 @@ SELECT lixcol_depth, title
 FROM lix_history('acme_task')
 WHERE id = 't1'
 ORDER BY lixcol_depth;
+```
+
+`lix_latest_checkpoint_commit_id()` returns the latest checkpoint for the
+active branch, not the newest repository-global checkpoint. If the branch has
+no checkpoint, it returns `lix_root_commit_id()`. Use both branch-scoped
+accessors to read working changes in one query:
+
+```sql
+SELECT row_pk, diff_type
+FROM lix_diff(
+  'lix_file',
+  lix_latest_checkpoint_commit_id(),
+  lix_active_branch_commit_id()
+);
 ```
 
 `lix_commit_ancestry()` returns the active head at depth `0` and every

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -47,6 +47,11 @@ columns. Pass `(relation, row_pk)` to the `lix_revert`, `lix_apply`, and
 `lix_create_checkpoint` command sinks. See [Checkpoints](./checkpoints.md) and
 [Diff commands](./diff-commands.md).
 
+For branch-scoped working changes, use `lix_latest_checkpoint_commit_id()` and
+`lix_active_branch_commit_id()` as the commit arguments to `lix_diff()`. The
+latest-checkpoint accessor returns the repository root when the active branch
+has no checkpoint.
+
 ## The executable column contract
 
 The SQL engine is backed by DataFusion. Query `information_schema.columns` for
@@ -95,7 +100,7 @@ schema contributes another `RELATION` / `BASE` surface.
 | Relation / view | `lix_branch`, `lix_change`, `lix_directory`, `lix_file` |
 | Table function | `lix_commit_ancestry`, `lix_diff`, `lix_history` |
 | Command sink | `lix_apply`, `lix_create_checkpoint`, `lix_restore`, `lix_revert` |
-| Scalar function | `lix_active_account_id`, `lix_active_branch_commit_id`, `lix_active_branch_id`, `lix_root_commit_id`, `uuidv7` |
+| Scalar function | `lix_active_account_id`, `lix_active_branch_commit_id`, `lix_active_branch_id`, `lix_latest_checkpoint_commit_id`, `lix_root_commit_id`, `uuidv7` |
 
 Standard SQL value expressions such as `CURRENT_TIMESTAMP` are supported SQL
 syntax, not Lix-owned scalar-function surfaces, and are therefore omitted from

--- a/packages/lix/src/checkpoint.rs
+++ b/packages/lix/src/checkpoint.rs
@@ -7,8 +7,10 @@ use crate::branch::BranchHeadControlContext;
 use crate::changelog::CommitId;
 #[cfg(feature = "storage-benches")]
 use crate::changelog::{ChangelogContext, ChangelogReader, CommitScanRequest};
+use crate::commit_graph::CommitGraphContext;
 #[cfg(feature = "storage-benches")]
 use crate::commit_graph::CommitGraphNode;
+use crate::hot_state::{HotStateExactBatchRequest, HotStateExactRowRequest, HotStateReader};
 use crate::row_pk::RowPk;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::transaction_types::{TransactionJson, TransactionWriteRow};
@@ -85,6 +87,76 @@ where
             format!("branch '{branch_id}' has no checkpoint cursor"),
         )
     })
+}
+
+/// Resolves the latest real checkpoint on the active branch's mainline.
+///
+/// The private working-diff cursor normally names a checkpoint, but branch
+/// creation and restore can initialize it to an arbitrary source commit. A
+/// cursor is therefore only a search anchor until its global checkpoint row
+/// has been verified. Following first parents keeps merged checkpoints from
+/// other branches out of this branch-scoped accessor.
+pub(crate) async fn latest_checkpoint_commit_id_at_head<S>(
+    store: S,
+    hot_state: &dyn HotStateReader,
+    branch_id: &str,
+    head_commit_id: CommitId,
+) -> Result<Option<CommitId>, LixError>
+where
+    S: StorageAdapterRead + Clone,
+{
+    let control = BranchHeadControlContext::new()
+        .reader(store.clone())
+        .load(branch_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::branch_not_found(branch_id, "resolve latest checkpoint", "branch")
+        })?;
+    if control.head_commit_id != head_commit_id {
+        return Err(LixError::new(
+            LixError::CODE_TRANSACTION_CONFLICT,
+            format!("branch '{branch_id}' head changed while resolving its latest checkpoint"),
+        ));
+    }
+    let Some(mut candidate) = control.working_diff_checkpoint_commit_id else {
+        return Ok(None);
+    };
+    let mut commit_graph = CommitGraphContext::new().reader(store);
+
+    loop {
+        let row_pk = RowPk::uuid_from_canonical(&candidate.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("checkpoint candidate '{candidate}' has an invalid row identity: {error}"),
+            )
+        })?;
+        let markers = hot_state
+            .load_exact_batch(&HotStateExactBatchRequest {
+                rows: vec![HotStateExactRowRequest {
+                    schema_key: CHECKPOINT_SCHEMA_KEY.to_string(),
+                    branch_id: GLOBAL_BRANCH_ID.to_string(),
+                    row_pk,
+                    file_id: None,
+                }],
+                untracked: Some(false),
+                ..Default::default()
+            })
+            .await?;
+        if markers.row(0).is_some() {
+            return Ok(Some(candidate));
+        }
+
+        let node = commit_graph.load_node(&candidate).await?.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("cannot resolve latest checkpoint: commit '{candidate}' is missing"),
+            )
+        })?;
+        let Some(first_parent) = node.parent_commit_ids.first().copied() else {
+            return Ok(None);
+        };
+        candidate = first_parent;
+    }
 }
 
 #[cfg(feature = "storage-benches")]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -5431,6 +5431,15 @@ mod tests {
             .await
             .expect("legacy cursor corruption should commit");
 
+        let fallback = session
+            .execute("SELECT lix_latest_checkpoint_commit_id() AS commit_id", &[])
+            .await
+            .expect("a missing checkpoint cursor should fall back to the repository root");
+        assert_eq!(
+            fallback.rows()[0].get::<String>("commit_id").unwrap(),
+            restore_target
+        );
+
         let restored = session
             .execute(
                 "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -40,10 +40,11 @@ pub(crate) struct PublicScalarFunctionContract {
     pub(crate) class: PublicSurfaceClass,
 }
 
-pub(crate) const PUBLIC_SCALAR_FUNCTION_NAMES: [&str; 5] = [
+pub(crate) const PUBLIC_SCALAR_FUNCTION_NAMES: [&str; 6] = [
     "lix_active_account_id",
     "lix_active_branch_commit_id",
     "lix_active_branch_id",
+    "lix_latest_checkpoint_commit_id",
     "lix_root_commit_id",
     "uuidv7",
 ];

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -109,6 +109,7 @@ fn text_argument(
         let value = match function.func.name() {
             "lix_root_commit_id" => slots.root_commit_id(),
             "lix_active_branch_commit_id" => slots.active_branch_commit_id(),
+            "lix_latest_checkpoint_commit_id" => slots.latest_checkpoint_commit_id(),
             _ => None,
         };
         if let Some(value) = value {

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::LixError;
 use crate::branch::{BranchHead, BranchRefReader};
+use crate::checkpoint::latest_checkpoint_commit_id_at_head;
 
 use super::branch_ref::CachingBranchRefReader;
 use super::planning_cache::PooledReadSession;
@@ -71,8 +72,23 @@ where
             .await?
             .map(|head| head.commit_id.to_string()),
     };
-    let root_commit_id = if statements.iter().any(statement_uses_root_commit_id) {
+    let root_commit_id = if statements
+        .iter()
+        .any(|statement| statement_uses_execution_function(statement, "lix_root_commit_id"))
+    {
         resolve_root_commit_id(ctx, active_branch_commit_id.as_deref()).await?
+    } else {
+        None
+    };
+    let latest_checkpoint_commit_id = if statements.iter().any(|statement| {
+        statement_uses_execution_function(statement, "lix_latest_checkpoint_commit_id")
+    }) {
+        resolve_latest_checkpoint_commit_id(
+            ctx,
+            active_branch_commit_id.as_deref(),
+            root_commit_id.as_deref(),
+        )
+        .await?
     } else {
         None
     };
@@ -82,6 +98,7 @@ where
         ctx.active_account_id(),
         Some(ctx.active_branch_id()),
         active_branch_commit_id.as_deref(),
+        latest_checkpoint_commit_id.as_deref(),
         root_commit_id.as_deref(),
     );
     let provider_selection = providers::read_provider_selection(pooled.state(), statements);
@@ -113,17 +130,29 @@ where
         .load_head(read_ctx.active_branch_id())
         .await?
         .map(|head| head.commit_id.to_string());
-    let root_commit_id = if statement_uses_root_commit_id(statement) {
+    let root_commit_id = if statement_uses_execution_function(statement, "lix_root_commit_id") {
         resolve_root_commit_id(read_ctx, active_branch_commit_id.as_deref()).await?
     } else {
         None
     };
+    let latest_checkpoint_commit_id =
+        if statement_uses_execution_function(statement, "lix_latest_checkpoint_commit_id") {
+            resolve_latest_checkpoint_commit_id(
+                read_ctx,
+                active_branch_commit_id.as_deref(),
+                root_commit_id.as_deref(),
+            )
+            .await?
+        } else {
+            None
+        };
     bind_execution_sql2_functions(
         session,
         read_ctx.functions(),
         read_ctx.active_account_id(),
         Some(read_ctx.active_branch_id()),
         active_branch_commit_id.as_deref(),
+        latest_checkpoint_commit_id.as_deref(),
         root_commit_id.as_deref(),
     );
     let write_ctx = SqlWriteContext::new(write_ctx);
@@ -205,6 +234,7 @@ pub(crate) async fn build_write_session_with_options(
         Some(&active_branch_id),
         Some(&active_branch_commit_id.commit_id.to_string()),
         None,
+        None,
     );
     providers::register_write(&session, write_ctx, branch_ref, options, provider_selection).await?;
 
@@ -214,20 +244,22 @@ pub(crate) async fn build_write_session_with_options(
     })
 }
 
-fn statement_uses_root_commit_id(statement: &DataFusionStatement) -> bool {
+fn statement_uses_execution_function(statement: &DataFusionStatement, function_name: &str) -> bool {
     use datafusion::sql::sqlparser::ast::{Expr, Visit, Visitor};
     use std::ops::ControlFlow;
 
-    struct RootCommitVisitor;
+    struct ExecutionFunctionVisitor<'a> {
+        function_name: &'a str,
+    }
 
-    impl Visitor for RootCommitVisitor {
+    impl Visitor for ExecutionFunctionVisitor<'_> {
         type Break = ();
 
         fn pre_visit_expr(&mut self, expression: &Expr) -> ControlFlow<Self::Break> {
             if let Expr::Function(function) = expression
                 && crate::sql2::parse::object_name_is_public_function(
                     &function.name,
-                    "lix_root_commit_id",
+                    self.function_name,
                 )
             {
                 return ControlFlow::Break(());
@@ -237,14 +269,53 @@ fn statement_uses_root_commit_id(statement: &DataFusionStatement) -> bool {
     }
 
     match statement {
-        DataFusionStatement::Statement(statement) => {
-            statement.visit(&mut RootCommitVisitor).is_break()
-        }
+        DataFusionStatement::Statement(statement) => statement
+            .visit(&mut ExecutionFunctionVisitor { function_name })
+            .is_break(),
         DataFusionStatement::Explain(explain) => {
-            statement_uses_root_commit_id(explain.statement.as_ref())
+            statement_uses_execution_function(explain.statement.as_ref(), function_name)
         }
         _ => false,
     }
+}
+
+async fn resolve_latest_checkpoint_commit_id<C>(
+    context: &C,
+    active_branch_commit_id: Option<&str>,
+    root_commit_id: Option<&str>,
+) -> Result<Option<String>, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let Some(active_branch_commit_id) = active_branch_commit_id else {
+        return Ok(None);
+    };
+    let head_commit_id = active_branch_commit_id
+        .parse::<crate::changelog::CommitId>()
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "active branch commit ID is invalid while resolving the latest checkpoint: {error}"
+                ),
+            )
+        })?;
+    let hot_state = context.hot_state();
+    if let Some(checkpoint_commit_id) = latest_checkpoint_commit_id_at_head(
+        context.changelog_query_source().store,
+        hot_state.as_ref(),
+        context.active_branch_id(),
+        head_commit_id,
+    )
+    .await?
+    {
+        return Ok(Some(checkpoint_commit_id.to_string()));
+    }
+
+    if let Some(root_commit_id) = root_commit_id {
+        return Ok(Some(root_commit_id.to_string()));
+    }
+    resolve_root_commit_id(context, Some(active_branch_commit_id)).await
 }
 
 async fn resolve_root_commit_id<C>(

--- a/packages/lix/src/sql2/udfs/execution_slots.rs
+++ b/packages/lix/src/sql2/udfs/execution_slots.rs
@@ -8,12 +8,9 @@ use crate::functions::FunctionProviderHandle;
 
 /// Per-session storage for the per-statement facts the execution UDFs report.
 ///
-/// The five execution functions (`lix_active_account_id`,
-/// `lix_active_branch_id`, `lix_active_branch_commit_id`, `uuidv7`,
-/// `CURRENT_TIMESTAMP`) used to be registered and deregistered on every statement so
-/// each one could capture that statement's values in its own fields. They are
-/// now registered once, when the session is created, and read this slot at
-/// invocation time instead.
+/// Execution functions such as `lix_active_branch_commit_id`,
+/// `lix_latest_checkpoint_commit_id`, and `CURRENT_TIMESTAMP` are registered
+/// once, when the session is created, and read this slot at invocation time.
 ///
 /// The slot is what makes that safe: a pooled session never carries a value from
 /// an earlier statement, because [`Self::bind`] overwrites every field before
@@ -28,6 +25,7 @@ struct ExecutionSlotValues {
     active_account_id: Option<String>,
     active_branch_id: Option<String>,
     active_branch_commit_id: Option<String>,
+    latest_checkpoint_commit_id: Option<String>,
     root_commit_id: Option<String>,
     functions: Option<FunctionProviderHandle>,
     current_timestamp: Option<LixTimestamp>,
@@ -54,12 +52,17 @@ impl ExecutionSlots {
         active_account_id: &str,
         active_branch_id: Option<&str>,
         active_branch_commit_id: Option<&str>,
+        latest_checkpoint_commit_id: Option<&str>,
         root_commit_id: Option<&str>,
     ) {
         let mut values = self.lock();
         assign(&mut values.active_account_id, Some(active_account_id));
         assign(&mut values.active_branch_id, active_branch_id);
         assign(&mut values.active_branch_commit_id, active_branch_commit_id);
+        assign(
+            &mut values.latest_checkpoint_commit_id,
+            latest_checkpoint_commit_id,
+        );
         assign(&mut values.root_commit_id, root_commit_id);
         values.functions = Some(functions);
         values.current_timestamp = None;
@@ -75,6 +78,10 @@ impl ExecutionSlots {
 
     pub(crate) fn active_branch_commit_id(&self) -> Option<String> {
         self.lock().active_branch_commit_id.clone()
+    }
+
+    pub(crate) fn latest_checkpoint_commit_id(&self) -> Option<String> {
+        self.lock().latest_checkpoint_commit_id.clone()
     }
 
     pub(crate) fn root_commit_id(&self) -> Option<String> {

--- a/packages/lix/src/sql2/udfs/lix_latest_checkpoint_commit_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_latest_checkpoint_commit_id.rs
@@ -1,0 +1,72 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{Result, ScalarValue, plan_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
+pub(super) struct LixLatestCheckpointCommitId {
+    slots: Arc<ExecutionSlots>,
+}
+
+impl LixLatestCheckpointCommitId {
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+impl PartialEq for LixLatestCheckpointCommitId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixLatestCheckpointCommitId {}
+
+impl std::hash::Hash for LixLatestCheckpointCommitId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+    }
+}
+
+impl std::fmt::Debug for LixLatestCheckpointCommitId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LixLatestCheckpointCommitId")
+            .finish()
+    }
+}
+
+impl ScalarUDFImpl for LixLatestCheckpointCommitId {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "lix_latest_checkpoint_commit_id"
+    }
+
+    fn signature(&self) -> &Signature {
+        static SIGNATURE: std::sync::LazyLock<Signature> =
+            std::sync::LazyLock::new(|| Signature::nullary(Volatility::Stable));
+        &SIGNATURE
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if !args.args.is_empty() {
+            return plan_err!("lix_latest_checkpoint_commit_id requires no arguments");
+        }
+        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
+            self.slots.latest_checkpoint_commit_id(),
+        )))
+    }
+}

--- a/packages/lix/src/sql2/udfs/mod.rs
+++ b/packages/lix/src/sql2/udfs/mod.rs
@@ -8,6 +8,7 @@ mod lix_json_get;
 mod lix_json_get_text;
 mod lix_json_predicate;
 mod lix_jsonb;
+mod lix_latest_checkpoint_commit_id;
 mod lix_octet_length;
 mod lix_root_commit_id;
 mod uuidv7;
@@ -49,8 +50,8 @@ pub(crate) fn register_static_sql2_functions(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(lix_octet_length::LixOctetLength::new()));
 }
 
-/// Installs the five per-statement execution functions once, for the lifetime
-/// of the session.
+/// Installs the per-statement execution functions once, for the lifetime of
+/// the session.
 ///
 /// Each one holds only the session's [`ExecutionSlots`] and reads the current
 /// statement's value at invocation time, so a session can be pooled and reused
@@ -68,6 +69,9 @@ pub(crate) fn register_execution_sql2_functions(ctx: &SessionContext, slots: Arc
         lix_active_branch_commit_id::LixActiveBranchCommitId::new(Arc::clone(&slots)),
     ));
     ctx.register_udf(ScalarUDF::from(
+        lix_latest_checkpoint_commit_id::LixLatestCheckpointCommitId::new(Arc::clone(&slots)),
+    ));
+    ctx.register_udf(ScalarUDF::from(
         lix_root_commit_id::LixRootCommitId::new(Arc::clone(&slots)),
     ));
     ctx.register_udf(ScalarUDF::from(uuidv7::UuidV7 {
@@ -83,6 +87,7 @@ pub(crate) fn bind_execution_sql2_functions(
     active_account_id: &str,
     active_branch_id: Option<&str>,
     active_branch_commit_id: Option<&str>,
+    latest_checkpoint_commit_id: Option<&str>,
     root_commit_id: Option<&str>,
 ) {
     execution_slots(ctx).bind(
@@ -90,6 +95,7 @@ pub(crate) fn bind_execution_sql2_functions(
         active_account_id,
         active_branch_id,
         active_branch_commit_id,
+        latest_checkpoint_commit_id,
         root_commit_id,
     );
 }
@@ -106,6 +112,7 @@ pub(super) mod test_support {
             &ctx,
             system_sql2_function_provider(),
             crate::ANONYMOUS_ACCOUNT_ID,
+            None,
             None,
             None,
             None,

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -9194,7 +9194,29 @@ where
         let head = self.load_branch_head(&branch_id).await?.ok_or_else(|| {
             LixError::branch_not_found(&branch_id, "resolve diff source", "branch")
         })?;
-        let root = if from == DiffCommandSourceCommit::Root || to == DiffCommandSourceCommit::Root {
+        let uses_latest_checkpoint = from == DiffCommandSourceCommit::LatestCheckpoint
+            || to == DiffCommandSourceCommit::LatestCheckpoint;
+        let latest_checkpoint = if uses_latest_checkpoint {
+            let opening_read = self.opening_read();
+            let hot_state = self.hot_state.transaction_reader(
+                opening_read.clone(),
+                Arc::clone(&self.branch_head_control_cache),
+            );
+            crate::checkpoint::latest_checkpoint_commit_id_at_head(
+                opening_read,
+                &hot_state,
+                &branch_id,
+                head,
+            )
+            .await?
+            .map(|commit_id| commit_id.to_string())
+        } else {
+            None
+        };
+        let needs_root = from == DiffCommandSourceCommit::Root
+            || to == DiffCommandSourceCommit::Root
+            || (uses_latest_checkpoint && latest_checkpoint.is_none());
+        let root = if needs_root {
             let mut graph = CommitGraphContext::new().reader(self.opening_read());
             let mut current = head;
             loop {
@@ -9222,6 +9244,10 @@ where
             DiffCommandSourceCommit::Root => root
                 .clone()
                 .expect("a repository root was resolved when either source requested it"),
+            DiffCommandSourceCommit::LatestCheckpoint => latest_checkpoint
+                .clone()
+                .or_else(|| root.clone())
+                .expect("a latest checkpoint or repository root was resolved when requested"),
         };
         Ok((resolve(from), resolve(to)))
     }
@@ -9232,6 +9258,7 @@ enum DiffCommandSourceCommit {
     Literal(String),
     Root,
     ActiveHead,
+    LatestCheckpoint,
 }
 
 fn diff_command_source_commits(
@@ -9273,7 +9300,7 @@ fn diff_command_source_commits(
                 let FunctionArg::Unnamed(FunctionArgExpr::Expr(expression)) = argument else {
                     return Err(LixError::new(
                         LixError::CODE_UNSUPPORTED_SQL,
-                        "diff command source commits must be text literals, parameters, or root/head functions",
+                        "diff command source commits must be text literals, parameters, or root/checkpoint/head functions",
                     ));
                 };
                 match expression {
@@ -9314,16 +9341,22 @@ fn diff_command_source_commits(
                             .eq_ignore_ascii_case("lix_active_branch_commit_id")
                         {
                             Ok(DiffCommandSourceCommit::ActiveHead)
+                        } else if function
+                            .name
+                            .to_string()
+                            .eq_ignore_ascii_case("lix_latest_checkpoint_commit_id")
+                        {
+                            Ok(DiffCommandSourceCommit::LatestCheckpoint)
                         } else {
                             Err(LixError::new(
                                 LixError::CODE_UNSUPPORTED_SQL,
-                                "diff command source commits only support lix_root_commit_id() and lix_active_branch_commit_id() functions",
+                                "diff command source commits only support lix_root_commit_id(), lix_latest_checkpoint_commit_id(), and lix_active_branch_commit_id() functions",
                             ))
                         }
                     }
                     _ => Err(LixError::new(
                         LixError::CODE_UNSUPPORTED_SQL,
-                        "diff command source commits must be text literals, parameters, or root/head functions",
+                        "diff command source commits must be text literals, parameters, or root/checkpoint/head functions",
                     )),
                 }
             };

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -88,6 +88,73 @@ simulation_test!(observe_next_returns_initial_snapshot, |sim| async move {
     assert_key_value_row(&initial, "observe-initial", "v0");
 });
 
+simulation_test!(
+    observe_latest_checkpoint_diff_updates_without_changing_query_parameters,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
+        let mut events = raw_session
+            .observe(
+                "SELECT row_pk, diff_type \
+                 FROM lix_diff(\
+                   'lix_key_value', \
+                   lix_latest_checkpoint_commit_id(), \
+                   lix_active_branch_commit_id()\
+                 ) \
+                 ORDER BY row_pk",
+                &[],
+            )
+            .expect("checkpoint-to-head diff should open as one observed query");
+
+        let initial = next_event(&mut events, "initial clean checkpoint diff").await;
+        assert!(initial.rows.is_empty());
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-checkpoint', 'draft')",
+                &[],
+            )
+            .await
+            .expect("working change should commit");
+        let changed = next_event(&mut events, "working change after checkpoint").await;
+        assert_eq!(changed.rows.len(), 1);
+        assert_eq!(
+            changed.rows.rows()[0].values(),
+            &[
+                Value::Jsonb(json!(["observe-checkpoint"]).into()),
+                Value::Text("added".to_string()),
+            ]
+        );
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should advance the observed branch baseline");
+        let checkpointed = next_event(&mut events, "clean diff after checkpoint").await;
+        assert!(
+            checkpointed.rows.is_empty(),
+            "the same observation should update when its checkpoint accessor changes"
+        );
+
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'next' WHERE key = 'observe-checkpoint'",
+                &[],
+            )
+            .await
+            .expect("later working change should commit");
+        let changed_again = next_event(&mut events, "working change after re-baseline").await;
+        assert_eq!(changed_again.rows.len(), 1);
+        assert_eq!(
+            changed_again.rows.rows()[0].values(),
+            &[
+                Value::Jsonb(json!(["observe-checkpoint"]).into()),
+                Value::Text("modified".to_string()),
+            ]
+        );
+    }
+);
+
 simulation_test!(observe_follows_in_place_branch_switch, |sim| async move {
     let engine = sim.boot_engine().await;
     let (raw_session, session) = open_default_session(&sim, &engine).await;

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -85,20 +85,16 @@ simulation_test!(
         assert_eq!(applied.columns(), &["commit_id"]);
         assert_eq!(applied.rows().len(), 1);
 
-        let head_before_checkpoint = engine
-            .load_branch_head_commit_id(sim.main_branch_id())
-            .await
-            .expect("head before checkpoint should load")
-            .expect("head before checkpoint should exist")
-            .to_string();
         let checkpointed = session
             .execute(
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
                  SELECT 'lix_key_value', row_pk \
-                 FROM lix_diff('lix_key_value', $1, $2) \
+                 FROM lix_diff(\
+                   'lix_key_value', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()\
+                 ) \
                  WHERE row_pk = CAST('[\"a\"]' AS JSONB) \
                  RETURNING commit_id",
-                &[Value::Text(baseline), Value::Text(head_before_checkpoint)],
+                &[],
             )
             .await
             .expect("partial relation-row checkpoint should succeed");
@@ -161,6 +157,96 @@ simulation_test!(
             .await
             .expect_err("duplicate public relation-row selections must fail atomically");
         assert_eq!(duplicate.code, LixError::CODE_CONSTRAINT_VIOLATION);
+    }
+);
+
+simulation_test!(
+    diff_commands_resolve_the_active_branch_latest_checkpoint,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-baseline', 'saved')",
+                &[],
+            )
+            .await
+            .expect("baseline value should commit");
+        session
+            .create_checkpoint()
+            .await
+            .expect("baseline checkpoint should commit");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-working', 'draft')",
+                &[],
+            )
+            .await
+            .expect("working value should commit");
+        let working_head = session
+            .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+            .await
+            .expect("working head should read")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("working head should be text");
+
+        let reverted = session
+            .execute(
+                "INSERT INTO lix_revert (relation, row_pk) \
+                 SELECT 'lix_key_value', row_pk \
+                 FROM lix_diff(\
+                   'lix_key_value', \
+                   lix_latest_checkpoint_commit_id(), \
+                   lix_active_branch_commit_id()\
+                 ) \
+                 RETURNING commit_id",
+                &[],
+            )
+            .await
+            .expect("revert should resolve the branch's checkpoint/head source commits");
+        assert_eq!(reverted.rows_affected(), 1);
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT key FROM lix_key_value WHERE key LIKE 'checkpoint-%' ORDER BY key",
+            )
+            .await,
+            vec![vec![Value::Text("checkpoint-baseline".to_string())]],
+            "revert must preserve checkpointed values while removing working changes"
+        );
+
+        let applied = session
+            .execute(
+                "INSERT INTO lix_apply (relation, row_pk) \
+                 SELECT 'lix_key_value', row_pk \
+                 FROM lix_diff(\
+                   'lix_key_value', \
+                   lix_latest_checkpoint_commit_id(), \
+                   $1\
+                 ) \
+                 RETURNING commit_id",
+                &[Value::Text(working_head)],
+            )
+            .await
+            .expect("apply should resolve the active branch checkpoint source");
+        assert_eq!(applied.rows_affected(), 1);
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT key FROM lix_key_value WHERE key LIKE 'checkpoint-%' ORDER BY key",
+            )
+            .await,
+            vec![
+                vec![Value::Text("checkpoint-baseline".to_string())],
+                vec![Value::Text("checkpoint-working".to_string())],
+            ],
+            "apply must resolve the actual checkpoint baseline and restore the historical row"
+        );
     }
 );
 

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -20,7 +20,8 @@ simulation_test!(
              FROM information_schema.lix_surfaces \
              WHERE surface_name IN (\
                'lix_active_branch_id', 'lix_create_checkpoint', 'lix_diff',\
-               'lix_file', 'lix_restore', 'lix_root_commit_id'\
+               'lix_file', 'lix_latest_checkpoint_commit_id', \
+               'lix_restore', 'lix_root_commit_id'\
              ) \
              ORDER BY surface_name",
             &[],
@@ -61,6 +62,14 @@ simulation_test!(
                     Value::Text("VIEW".to_string()),
                     Value::Boolean(true),
                     Value::Boolean(true),
+                    Value::Boolean(false),
+                ],
+                vec![
+                    Value::Text("lix_latest_checkpoint_commit_id".to_string()),
+                    Value::Text("SCALAR_FUNCTION".to_string()),
+                    Value::Null,
+                    Value::Boolean(true),
+                    Value::Boolean(false),
                     Value::Boolean(false),
                 ],
                 vec![

--- a/packages/lix/tests/integration/sql/udfs.rs
+++ b/packages/lix/tests/integration/sql/udfs.rs
@@ -1,4 +1,4 @@
-use lix::{CreateBranchOptions, Value};
+use lix::{CreateBranchOptions, LixError, Value};
 use serde_json::json;
 
 simulation_test!(
@@ -6,7 +6,10 @@ simulation_test!(
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
-            engine.open_session().await.expect("main session should open"),
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
             &engine,
         );
         let expected_root = sim.initial_commit_id().to_string();
@@ -15,7 +18,10 @@ simulation_test!(
             session
                 .execute(
                     "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
-                    &[Value::Text(format!("root-{value}")), Value::Text(value.to_owned())],
+                    &[
+                        Value::Text(format!("root-{value}")),
+                        Value::Text(value.to_owned()),
+                    ],
                 )
                 .await
                 .expect("tracked write should advance the active head");
@@ -37,7 +43,10 @@ simulation_test!(
             )
             .await
             .expect("the root commit should have no parents");
-        assert_eq!(parents.rows()[0].values(), &[Value::Jsonb(json!([]).into())]);
+        assert_eq!(
+            parents.rows()[0].values(),
+            &[Value::Jsonb(json!([]).into())]
+        );
     }
 );
 
@@ -79,6 +88,260 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    lix_latest_checkpoint_commit_id_is_scoped_to_the_active_branch,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let root = sim.initial_commit_id().to_string();
+        assert_eq!(latest_checkpoint_commit_id(&main).await, root);
+
+        let invalid = main
+            .execute("SELECT lix_latest_checkpoint_commit_id('extra')", &[])
+            .await
+            .expect_err("the checkpoint accessor must reject arguments");
+        assert_eq!(invalid.code, LixError::CODE_INVALID_PARAM);
+
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-scope', 'main')",
+            &[],
+        )
+        .await
+        .expect("main change should commit");
+        let inherited = main
+            .create_checkpoint()
+            .await
+            .expect("main checkpoint should commit");
+        assert_eq!(
+            latest_checkpoint_commit_id(&main).await,
+            inherited.commit_id
+        );
+
+        let branch_id = "01930000-0000-7000-8000-0000000000c1";
+        main.create_branch(CreateBranchOptions {
+            id: Some(branch_id.to_string()),
+            name: "Checkpoint UDF draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft branch should be created");
+        let draft = sim.wrap_session(
+            engine
+                .open_session_at(branch_id)
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+        assert_eq!(
+            latest_checkpoint_commit_id(&draft).await,
+            inherited.commit_id
+        );
+
+        main.execute(
+            "UPDATE lix_key_value SET value = 'main-next' WHERE key = 'checkpoint-scope'",
+            &[],
+        )
+        .await
+        .expect("main should diverge");
+        let main_checkpoint = main
+            .create_checkpoint()
+            .await
+            .expect("newer main checkpoint should commit");
+        assert_eq!(
+            latest_checkpoint_commit_id(&draft).await,
+            inherited.commit_id,
+            "a newer global checkpoint on another branch must not leak into the draft"
+        );
+
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'draft' WHERE key = 'checkpoint-scope'",
+                &[],
+            )
+            .await
+            .expect("draft should diverge");
+        let diff = draft
+            .execute(
+                "SELECT row_pk FROM lix_diff(\
+                 'lix_key_value', lix_latest_checkpoint_commit_id(), \
+                 lix_active_branch_commit_id())",
+                &[],
+            )
+            .await
+            .expect("the checkpoint accessor should work directly as a diff argument");
+        assert_eq!(diff.len(), 1);
+        let draft_checkpoint = draft
+            .create_checkpoint()
+            .await
+            .expect("draft checkpoint should commit");
+        assert_eq!(
+            latest_checkpoint_commit_id(&draft).await,
+            draft_checkpoint.commit_id
+        );
+        assert_eq!(
+            latest_checkpoint_commit_id(&main).await,
+            main_checkpoint.commit_id,
+            "a newer global draft checkpoint must not replace the main baseline"
+        );
+
+        let mut transaction = draft
+            .begin_transaction()
+            .await
+            .expect("draft transaction should begin");
+        let result = transaction
+            .execute("SELECT lix_latest_checkpoint_commit_id() AS commit_id", &[])
+            .await
+            .expect("the branch checkpoint should resolve inside read transactions");
+        assert_eq!(
+            result.rows()[0].get::<String>("commit_id").unwrap(),
+            draft_checkpoint.commit_id
+        );
+        transaction
+            .rollback()
+            .await
+            .expect("read transaction should roll back");
+    }
+);
+
+simulation_test!(
+    lix_latest_checkpoint_commit_id_ignores_non_checkpoint_fork_and_restore_cursors,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let root = sim.initial_commit_id().to_string();
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-fork', 'dirty-root')",
+            &[],
+        )
+        .await
+        .expect("an uncheckpointed main change should commit");
+
+        let root_fork_id = "01930000-0000-7000-8000-0000000000c2";
+        main.create_branch(CreateBranchOptions {
+            id: Some(root_fork_id.to_string()),
+            name: "Uncheckpointed fork".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("fork from an uncheckpointed commit should succeed");
+        let root_fork = sim.wrap_session(
+            engine
+                .open_session_at(root_fork_id)
+                .await
+                .expect("uncheckpointed fork session should open"),
+            &engine,
+        );
+        assert_eq!(
+            latest_checkpoint_commit_id(&root_fork).await,
+            root,
+            "a fork's private baseline is not itself a checkpoint marker"
+        );
+
+        let checkpoint = main
+            .create_checkpoint()
+            .await
+            .expect("main checkpoint should commit");
+        main.execute(
+            "UPDATE lix_key_value SET value = 'dirty-checkpoint' WHERE key = 'checkpoint-fork'",
+            &[],
+        )
+        .await
+        .expect("main should advance beyond its real checkpoint");
+        let checkpoint_fork_id = "01930000-0000-7000-8000-0000000000c3";
+        main.create_branch(CreateBranchOptions {
+            id: Some(checkpoint_fork_id.to_string()),
+            name: "Post-checkpoint dirty fork".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("fork from a post-checkpoint commit should succeed");
+        let checkpoint_fork = sim.wrap_session(
+            engine
+                .open_session_at(checkpoint_fork_id)
+                .await
+                .expect("post-checkpoint fork session should open"),
+            &engine,
+        );
+        assert_eq!(
+            latest_checkpoint_commit_id(&checkpoint_fork).await,
+            checkpoint.commit_id,
+            "a dirty fork should inherit its nearest real mainline checkpoint"
+        );
+
+        let abandoned = main
+            .create_checkpoint()
+            .await
+            .expect("later checkpoint should commit");
+        main.execute(
+            "INSERT INTO lix_restore (commit_id) VALUES ($1)",
+            &[Value::Text(checkpoint.commit_id.clone())],
+        )
+        .await
+        .expect("restoring the older checkpoint should succeed");
+        assert_eq!(
+            latest_checkpoint_commit_id(&main).await,
+            checkpoint.commit_id,
+            "an abandoned later global checkpoint must not remain active"
+        );
+        assert_ne!(abandoned.commit_id, checkpoint.commit_id);
+
+        main.execute(
+            "UPDATE lix_key_value SET value = 'restore-target' WHERE key = 'checkpoint-fork'",
+            &[],
+        )
+        .await
+        .expect("ordinary restore target should commit");
+        let restore_target = main
+            .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+            .await
+            .expect("restore target head should read")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .unwrap();
+        main.execute(
+            "UPDATE lix_key_value SET value = 'after-target' WHERE key = 'checkpoint-fork'",
+            &[],
+        )
+        .await
+        .expect("later ordinary change should commit");
+        main.execute(
+            "INSERT INTO lix_restore (commit_id) VALUES ($1)",
+            &[Value::Text(restore_target)],
+        )
+        .await
+        .expect("restoring an ordinary commit should succeed");
+        assert_eq!(
+            latest_checkpoint_commit_id(&main).await,
+            checkpoint.commit_id,
+            "a non-checkpoint restore target must not masquerade as a checkpoint"
+        );
+    }
+);
+
+async fn latest_checkpoint_commit_id(
+    session: &crate::support::simulation_test::engine::SimSession,
+) -> String {
+    session
+        .execute("SELECT lix_latest_checkpoint_commit_id() AS commit_id", &[])
+        .await
+        .expect("latest checkpoint accessor should execute")
+        .rows()[0]
+        .get::<String>("commit_id")
+        .expect("latest checkpoint accessor should return text")
+}
 
 simulation_test!(
     lix_active_branch_id_is_session_scoped_in_reads_transactions_and_writes,


### PR DESCRIPTION
## Summary

- Add `lix_latest_checkpoint_commit_id()` as a stable, active-branch-scoped SQL accessor with repository-root fallback.
- Verify actual checkpoint markers and follow first-parent history when branch creation or restore leaves an ordinary commit in the working-diff cursor.
- Support the accessor in `lix_diff` and revert/apply/checkpoint command sources, expose it through `information_schema.lix_surfaces`, and document single-query reactive working diffs.
- Add coverage for divergent branches, dirty forks, restores, missing cursors, transaction reads, command sinks, catalog discovery, and observed-query updates.

## Verification

- `CARGO_TARGET_DIR=/root/repos/lix-ci-iteration-speed/target cargo test -p lix --lib --features all-simulations -- --quiet` — 3,317 passed, 26 ignored on the rebased PR head.
- `CARGO_TARGET_DIR=/root/repos/lix-ci-iteration-speed/target cargo test -p lix --doc` — 10 passed.
- `CARGO_TARGET_DIR=/root/repos/lix-ci-iteration-speed/target cargo test -p lix --lib --features all-simulations latest_checkpoint` — 8 passed.
- `node scripts/validate-changes.mjs`
- `node scripts/validate-server-protocol-docs.mjs`
- `node --test scripts/ci-workflow.test.mjs`
- Independently reviewed by two sub-agents.
