### PR TITLE
feat(sql): add point-in-time state reads

### DIFF
--- a/.changenotes/lix-state-at.md
+++ b/.changenotes/lix-state-at.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added immutable, branch-scoped point-in-time reads with `lix_state_at(relation, commit_id)`.
+
+Diff machinery columns now use the reserved `lixcol_` namespace, and repository format v74 adds the authenticated row-primary-key index used for bounded historical reads. Existing repositories require the explicit offline migration before opening.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -35,7 +35,7 @@ await lix.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
 ]);
 
 const working = await lix.execute(
-  `SELECT row_pk, diff_type, from_value, to_value
+  `SELECT lixcol_row_pk, lixcol_diff_type, from_value, to_value
    FROM lix_diff(
      'lix_key_value',
      lix_latest_checkpoint_commit_id(),
@@ -44,7 +44,7 @@ const working = await lix.execute(
 );
 
 for (const row of working.rows) {
-  console.log(row.get("diff_type"), row.get("row_pk"));
+  console.log(row.get("lixcol_diff_type"), row.get("lixcol_row_pk"));
 }
 
 await lix.createCheckpoint();
@@ -68,7 +68,7 @@ A runnable Rust version lives at
 
 | Surface | Scope | Columns |
 | :-- | :-- | :-- |
-| `lix_diff(relation, from_commit_id, to_commit_id)` | One relation across two explicit commits | `row_pk`, `diff_type`, `row_count`, and paired `from_<column>` / `to_<column>` relation columns |
+| `lix_diff(relation, from_commit_id, to_commit_id)` | One relation across two explicit commits | `lixcol_row_pk`, `lixcol_diff_type`, `lixcol_row_count`, and paired `from_<column>` / `to_<column>` relation columns |
 | `lix_checkpoint` | Repository-global checkpoint markers | `id`, `commit_id`, and standard `lixcol_*` columns |
 | `lix_commit` | Repository-global commit graph | `id`, `parent_commit_ids`, and standard `lixcol_*` columns |
 | `lix_history('lix_checkpoint'[, commit_id])` | Global checkpoint-row authorship history | Checkpoint columns and standard history `lixcol_*` columns |
@@ -91,7 +91,7 @@ when the branch has no checkpoint. Pair it with the active head to inspect
 working changes in one query, including before the first checkpoint:
 
 ```sql
-SELECT row_pk, diff_type
+SELECT lixcol_row_pk, lixcol_diff_type
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -17,7 +17,7 @@ import { openLix } from "@lix-js/sdk";
 
 const lix = await openLix();
 const changedFiles = await lix.execute(
-  `SELECT row_pk, diff_type, from_path, to_path, row_count
+  `SELECT lixcol_row_pk, lixcol_diff_type, from_path, to_path, lixcol_row_count
    FROM lix_diff(
      'lix_file',
      lix_latest_checkpoint_commit_id(),
@@ -27,20 +27,20 @@ const changedFiles = await lix.execute(
 );
 
 for (const row of changedFiles.rows) {
-  console.log(row.get("diff_type"), row.get("to_path") ?? row.get("from_path"));
+  console.log(row.get("lixcol_diff_type"), row.get("to_path") ?? row.get("from_path"));
 }
 
 const reverted = await lix.execute(
   `INSERT INTO lix_revert (relation, row_pk)
-   SELECT 'lix_file', row_pk
+   SELECT 'lix_file', lixcol_row_pk
    FROM lix_diff(
      'lix_file',
      lix_latest_checkpoint_commit_id(),
      lix_active_branch_commit_id()
    )
-   WHERE row_pk = $1
+   WHERE lixcol_row_pk = $1
    RETURNING commit_id`,
-  [changedFiles.rows[0].get("row_pk")],
+  [changedFiles.rows[0].get("lixcol_row_pk")],
 );
 
 if (reverted.rows.length > 0) {
@@ -57,9 +57,10 @@ for a new branch.
 
 ## Diff rows
 
-Every relation diff exposes `row_pk`, `diff_type`, `row_count`, and a
+Every relation diff exposes `lixcol_row_pk`, `lixcol_diff_type`,
+`lixcol_row_count`, and a
 `from_<column>` / `to_<column>` pair for each column of the compared relation.
-`diff_type` is `added`, `modified`, or `removed`. Added rows have empty `from_`
+`lixcol_diff_type` is `added`, `modified`, or `removed`. Added rows have empty `from_`
 values; removed rows have empty `to_` values. Use
 `coalesce(to_path, from_path)` when displaying a path that also covers removed
 or renamed files.
@@ -69,11 +70,11 @@ reconstructing historical file bytes would turn lightweight diff reads into blob
 materialization. Query `lix_history('lix_file', commit_id)` when file bytes are
 required.
 
-`row_count` is `1` for a changed schema row. For a file it counts the underlying
+`lixcol_row_count` is `1` for a changed schema row. For a file it counts the underlying
 descriptor and content rows contributing to the aggregate:
 
 ```sql
-SELECT count(*) AS changed_files, sum(row_count) AS changed_rows
+SELECT count(*) AS changed_files, sum(lixcol_row_count) AS changed_rows
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),
@@ -98,7 +99,7 @@ added rows. Genesis comparisons of internal bootstrap schema rows are
 unsupported because those metadata rows already exist in the bootstrap root.
 
 ```sql
-SELECT row_pk, to_path
+SELECT lixcol_row_pk, to_path
 FROM lix_diff('lix_file', lix_root_commit_id(), $commit_id);
 ```
 
@@ -108,7 +109,7 @@ The insert-only command sinks consume queries selecting `(relation, row_pk)`:
 
 ```sql
 INSERT INTO lix_revert (relation, row_pk)
-SELECT 'lix_file', row_pk
+SELECT 'lix_file', lixcol_row_pk
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),
@@ -117,12 +118,12 @@ FROM lix_diff(
 WHERE coalesce(to_path, from_path) LIKE '/docs/%';
 
 INSERT INTO lix_apply (relation, row_pk)
-SELECT 'acme_task', row_pk
+SELECT 'acme_task', lixcol_row_pk
 FROM lix_diff('acme_task', $from_commit_id, $to_commit_id)
 WHERE to_done = true;
 
 INSERT INTO lix_create_checkpoint (relation, row_pk)
-SELECT 'lix_file', row_pk
+SELECT 'lix_file', lixcol_row_pk
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -63,13 +63,36 @@ no checkpoint, it returns `lix_root_commit_id()`. Use both branch-scoped
 accessors to read working changes in one query:
 
 ```sql
-SELECT row_pk, diff_type
+SELECT lixcol_row_pk, lixcol_diff_type
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),
   lix_active_branch_commit_id()
 );
 ```
+
+`lix_state_at(relation, commit_id)` returns the complete tracked state of a
+relation at one commit. Its columns are identical to the live relation, and
+entities that did not exist at that commit produce no row:
+
+```sql
+SELECT id, path, content
+FROM lix_state_at('lix_file', $1)
+WHERE id IN ($2, $3);
+```
+
+The relation argument must be a text literal. The commit may be a text
+parameter or `lix_root_commit_id()` / `lix_active_branch_commit_id()`. Primary
+key `=` and `IN` predicates are pushed into the point-in-time read, so batched
+entity lookups do not scan unrelated tracked rows. Untracked rows are never
+included.
+
+The result is scoped to the tree rooted at the supplied commit; a local-branch
+read does not inherit global rows. To reconstruct a full pinned live view,
+overlay the local state on the separately pinned global state. The overlay's
+global arm must be anti-joined against the nearest local `lix_history`
+identities, including deleted identities: a local tombstone shadows a global
+row even though `lix_state_at` itself does not expose tombstones.
 
 `lix_commit_ancestry()` returns the active head at depth `0` and every
 reachable ancestor once at its shortest depth. Pass one commit ID to use an

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -41,8 +41,9 @@ other segment text is preserved exactly: the engine does not URL-decode,
 case-fold, or Unicode-normalize paths. Filesystem adapters diagnose names that
 the target host cannot represent.
 
-The checkpoint and diff relations are read-only. `lix_diff()` exposes `row_pk`,
-`diff_type`, `row_count`, and paired `from_<column>` / `to_<column>` relation
+The checkpoint and diff relations are read-only. `lix_diff()` exposes
+`lixcol_row_pk`, `lixcol_diff_type`, `lixcol_row_count`, and paired
+`from_<column>` / `to_<column>` relation
 columns. Pass `(relation, row_pk)` to the `lix_revert`, `lix_apply`, and
 `lix_create_checkpoint` command sinks. See [Checkpoints](./checkpoints.md) and
 [Diff commands](./diff-commands.md).
@@ -51,6 +52,11 @@ For branch-scoped working changes, use `lix_latest_checkpoint_commit_id()` and
 `lix_active_branch_commit_id()` as the commit arguments to `lix_diff()`. The
 latest-checkpoint accessor returns the repository root when the active branch
 has no checkpoint.
+
+The `lixcol_` segment is reserved for engine-made columns on read surfaces.
+Registered user schemas reject column names beginning with `lixcol_` or
+containing `_lixcol_`; this keeps engine columns mechanically distinguishable
+even after `from_`/`to_` side prefixing.
 
 ## The executable column contract
 

--- a/packages/e2e/benches/tracked_state_crud/sql_session.rs
+++ b/packages/e2e/benches/tracked_state_crud/sql_session.rs
@@ -784,7 +784,7 @@ where
             &format!(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('tracked_crud_insert', '{before}', '{after}') \
-                 WHERE diff_type = 'added'"
+                 WHERE lixcol_diff_type = 'added'"
             ),
         )
         .await;

--- a/packages/e2e/benches/tracked_working_diff.rs
+++ b/packages/e2e/benches/tracked_working_diff.rs
@@ -51,9 +51,9 @@ const DEFAULT_UNRELATED_HISTORY_WIDTH: usize = 1;
 const UNRELATED_HISTORY_STORAGE_BATCH: usize = 100_000;
 const INSERT_BATCH_SIZE: usize = 500;
 const MERGE_PREVIEW_SOURCE_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000901";
-const WORKING_DIFF_SQL: &str = "SELECT row_pk, diff_type, row_count \
+const WORKING_DIFF_SQL: &str = "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
     FROM lix_diff('working_diff_row', $1, lix_active_branch_commit_id()) \
-    ORDER BY row_pk";
+    ORDER BY lixcol_row_pk";
 
 #[derive(Clone, Copy)]
 enum Shape {

--- a/packages/e2e/benches/working_diff_file_scope.rs
+++ b/packages/e2e/benches/working_diff_file_scope.rs
@@ -212,25 +212,25 @@ async fn run<StorageImpl>(
         .get::<String>("commit_id")
         .expect("benchmark checkpoint ID");
     let file_sql = format!(
-        "SELECT row_pk, diff_type, row_count \
+        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
          FROM lix_diff('lix_file', '{checkpoint}', lix_active_branch_commit_id()) \
-         WHERE row_pk ->> 0 = $1"
+         WHERE lixcol_row_pk ->> 0 = $1"
     );
     let full_sql = format!(
-        "SELECT row_pk, diff_type, row_count \
+        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
          FROM lix_diff('lix_file', '{checkpoint}', lix_active_branch_commit_id())"
     );
     let file_schema_sql = format!(
-        "SELECT row_pk, diff_type, row_count \
+        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
          FROM lix_diff('{SCHEMA_KEY}', '{checkpoint}', lix_active_branch_commit_id()) \
          WHERE to_lixcol_file_id = $1"
     );
     // Finite identity + file id: takes the existing bypass and resolves as a
     // point read. This is the floor a seekable file-scoped read aims at.
     let point_sql = format!(
-        "SELECT row_pk, diff_type, row_count \
+        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
          FROM lix_diff('{SCHEMA_KEY}', '{checkpoint}', lix_active_branch_commit_id()) \
-         WHERE row_pk = CAST($1 AS JSONB)"
+         WHERE lixcol_row_pk = CAST($1 AS JSONB)"
     );
     // Live-state read of the same file. HOT_ROW is keyed
     // `schema_key ++ file_id ++ row_pk` and `hot_scan_entries` owns a

--- a/packages/e2e/examples/branch_merge_benchmark.rs
+++ b/packages/e2e/examples/branch_merge_benchmark.rs
@@ -894,8 +894,8 @@ where
     let expected_diff = map_diff_oracle(&base, &target_before_preview);
     let diff_measure = measure_async(|| async {
         lix.execute(
-            "SELECT row_pk, diff_type, from_id, to_id \
-             FROM lix_diff('branch_bench_row', $1, $2) ORDER BY row_pk",
+            "SELECT lixcol_row_pk, lixcol_diff_type, from_id, to_id \
+             FROM lix_diff('branch_bench_row', $1, $2) ORDER BY lixcol_row_pk",
             &[
                 Value::Text(preview.base_commit_id.clone()),
                 Value::Text(preview.target_head_commit_id.clone()),
@@ -911,7 +911,7 @@ where
         .iter()
         .map(|row| {
             let row_pk = row
-                .get::<serde_json::Value>("row_pk")
+                .get::<serde_json::Value>("lixcol_row_pk")
                 .expect("diff row identity");
             let id = row_pk
                 .as_array()
@@ -919,7 +919,9 @@ where
                 .and_then(serde_json::Value::as_str)
                 .expect("single-string diff identity")
                 .to_owned();
-            let kind = row.get::<String>("diff_type").expect("diff type");
+            let kind = row
+                .get::<String>("lixcol_diff_type")
+                .expect("diff type");
             let side_id = |column| match row.value(column).expect("diff side identity column") {
                 Value::Null => None,
                 Value::Text(id) => Some(id.clone()),

--- a/packages/e2e/tests/corruption_recovery_qualification.rs
+++ b/packages/e2e/tests/corruption_recovery_qualification.rs
@@ -273,7 +273,7 @@ async fn qualify_tracked_tree_chunk<B: DurableBackend>() {
     assert_eq!(healthy.rows().len(), 8, "healthy tracked tree row count");
     let healthy_diff = lix
         .execute(
-            "SELECT 'lix_key_value' AS schema_key, diff_type \
+            "SELECT 'lix_key_value' AS schema_key, lixcol_diff_type \
              FROM lix_diff('lix_key_value', $1, $2)",
             &[
                 Value::Text(checkpoint_head.clone()),
@@ -299,7 +299,7 @@ async fn qualify_tracked_tree_chunk<B: DurableBackend>() {
         Ok(lix) => {
             let result = lix
                 .execute(
-                    "SELECT 'lix_key_value' AS schema_key, diff_type \
+                    "SELECT 'lix_key_value' AS schema_key, lixcol_diff_type \
                      FROM lix_diff('lix_key_value', $1, $2)",
                     &[Value::Text(checkpoint_head), Value::Text(updated_head)],
                 )

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -5545,9 +5545,9 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
     .unwrap();
     let selected_diff_count = lix
         .execute(
-            "SELECT coalesce(sum(row_count), 0) AS count \
+            "SELECT coalesce(sum(lixcol_row_count), 0) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-             WHERE row_pk ->> 0 = $1",
+             WHERE lixcol_row_pk ->> 0 = $1",
             &[
                 Value::Text(selected_file_id.clone()),
                 Value::Text(baseline_checkpoint.commit_id),
@@ -5561,9 +5561,9 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
     assert!(selected_diff_count > 1, "CSV must fan out beyond lix_file");
     let selected_checkpoint = lix.execute(
         "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-         SELECT 'lix_file', row_pk \
+         SELECT 'lix_file', lixcol_row_pk \
          FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id()) \
-         WHERE row_pk ->> 0 = $1 \
+         WHERE lixcol_row_pk ->> 0 = $1 \
          RETURNING commit_id",
         &[Value::Text(selected_file_id.clone())],
     )
@@ -5574,7 +5574,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
         lix.execute(
             "SELECT COUNT(*) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-             WHERE row_pk ->> 0 = $1",
+             WHERE lixcol_row_pk ->> 0 = $1",
             &[
                 Value::Text(selected_file_id.clone()),
                 Value::Text(selected_checkpoint.rows()[0].get::<String>("commit_id").unwrap()),
@@ -5591,7 +5591,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
         lix.execute(
             "SELECT COUNT(*) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-             WHERE row_pk ->> 0 = $1",
+             WHERE lixcol_row_pk ->> 0 = $1",
             &[
                 Value::Text(remaining_file_id),
                 Value::Text(selected_checkpoint.rows()[0].get::<String>("commit_id").unwrap()),

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -103,9 +103,9 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
     let checkpoint = replica
         .execute(
             "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-             SELECT 'lix_file', row_pk \
+             SELECT 'lix_file', lixcol_row_pk \
              FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id()) \
-             WHERE row_pk ->> 0 = $1 \
+             WHERE lixcol_row_pk ->> 0 = $1 \
              RETURNING commit_id",
             &[Value::Text(selected_file_id.clone())],
         )
@@ -125,7 +125,7 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
             .execute(
                 "SELECT COUNT(*) AS count \
                  FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-                 WHERE row_pk ->> 0 = $1",
+                 WHERE lixcol_row_pk ->> 0 = $1",
                 &[
                     Value::Text(selected_file_id.clone()),
                     Value::Text(checkpoint.rows()[0].get::<String>("commit_id").unwrap()),

--- a/packages/lix/benches/diff_commands.rs
+++ b/packages/lix/benches/diff_commands.rs
@@ -108,7 +108,7 @@ async fn profile_sample(rows: usize, sample: usize) {
         execute(
             &session,
             &format!(
-                "SELECT COUNT(*) AS change_count, SUM(row_count) AS atom_count \
+                "SELECT COUNT(*) AS change_count, SUM(lixcol_row_count) AS atom_count \
                  FROM {WORKING_SOURCE}"
             ),
         )
@@ -128,8 +128,8 @@ async fn profile_sample(rows: usize, sample: usize) {
             &session,
             &format!(
                 "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk FROM {WORKING_SOURCE} \
-                 ORDER BY row_pk LIMIT {selected}"
+                 SELECT 'lix_key_value', lixcol_row_pk FROM {WORKING_SOURCE} \
+                 ORDER BY lixcol_row_pk LIMIT {selected}"
             ),
         )
         .await;
@@ -142,9 +142,9 @@ async fn profile_sample(rows: usize, sample: usize) {
             &session,
             &format!(
                 "INSERT INTO lix_apply (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff('lix_key_value', '{baseline}', '{head}') \
-                 ORDER BY row_pk LIMIT {selected}"
+                 ORDER BY lixcol_row_pk LIMIT {selected}"
             ),
         )
         .await;
@@ -158,8 +158,8 @@ async fn profile_sample(rows: usize, sample: usize) {
             &session,
             &format!(
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk FROM {WORKING_SOURCE} \
-                 ORDER BY row_pk LIMIT {checkpoint_selected}"
+                 SELECT 'lix_key_value', lixcol_row_pk FROM {WORKING_SOURCE} \
+                 ORDER BY lixcol_row_pk LIMIT {checkpoint_selected}"
             ),
         )
         .await;
@@ -232,9 +232,9 @@ async fn apply_fixture(rows: usize, selected: usize) -> (Lix<Memory>, String) {
 fn command_sql(command: &str, source: &str, extra_predicate: &str, selected: usize) -> String {
     format!(
         "INSERT INTO {command} (relation, row_pk) \
-         SELECT 'lix_key_value', row_pk FROM {source} \
+         SELECT 'lix_key_value', lixcol_row_pk FROM {source} \
          WHERE true {extra_predicate} \
-         ORDER BY row_pk LIMIT {selected}"
+         ORDER BY lixcol_row_pk LIMIT {selected}"
     )
 }
 

--- a/packages/lix/examples/checkpoints.rs
+++ b/packages/lix/examples/checkpoints.rs
@@ -17,17 +17,17 @@ async fn main() -> Result<(), LixError> {
 
     let working_diffs = lix
         .execute(
-            "SELECT row_pk, diff_type, from_value, to_value
+            "SELECT lixcol_row_pk, lixcol_diff_type, from_value, to_value
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())
-             ORDER BY row_pk",
+             ORDER BY lixcol_row_pk",
             &[Value::Text(initial_checkpoint.commit_id)],
         )
         .await?;
 
     for row in working_diffs.rows() {
         // Row::get<T> performs typed extraction from ExecuteResult.
-        let row_pk = row.get::<serde_json::Value>("row_pk")?;
-        let diff_type = row.get::<String>("diff_type")?;
+        let row_pk = row.get::<serde_json::Value>("lixcol_row_pk")?;
+        let diff_type = row.get::<String>("lixcol_diff_type")?;
         println!("{diff_type} lix_key_value {row_pk}");
     }
     let checkpoint = lix.create_checkpoint().await?;

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -1218,7 +1218,9 @@ mod tests {
                 },
                 mutations: CommitStateMutationInventory::default(),
                 touched_scope_filter: Default::default(),
+                global_scope: false,
                 current_state_scoped_ranges: None,
+                row_pk_index_root_id: None,
                 snapshot_root: None,
             },
         )
@@ -1731,7 +1733,9 @@ mod tests {
                 },
                 mutations: staged.mutation_inventory().clone(),
                 touched_scope_filter: Default::default(),
+                global_scope: false,
                 current_state_scoped_ranges: None,
+                row_pk_index_root_id: None,
                 snapshot_root: None,
             },
         )
@@ -2276,7 +2280,9 @@ mod tests {
                 },
                 mutations,
                 touched_scope_filter: Default::default(),
+                global_scope: false,
                 current_state_scoped_ranges: None,
+                row_pk_index_root_id: None,
                 snapshot_root: None,
             },
         )

--- a/packages/lix/src/commit_graph/walker.rs
+++ b/packages/lix/src/commit_graph/walker.rs
@@ -1551,7 +1551,9 @@ mod tests {
                 },
                 mutations: CommitStateMutationInventory::default(),
                 touched_scope_filter: Default::default(),
+                global_scope: false,
                 current_state_scoped_ranges: None,
+                row_pk_index_root_id: None,
                 snapshot_root: None,
             },
         )

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1726,7 +1726,7 @@ mod tests {
         let broad = session
             .execute(
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     json_pointer_diff_relation(&session).await
                 ),
                 &[],
@@ -1742,10 +1742,10 @@ mod tests {
             .iter()
             .map(|row| {
                 (
-                    row.get::<serde_json::Value>("row_pk")
+                    row.get::<serde_json::Value>("lixcol_row_pk")
                         .expect("row_pk should decode")
                         .to_string(),
-                    row.get::<String>("diff_type")
+                    row.get::<String>("lixcol_diff_type")
                         .expect("diff_type should decode"),
                 )
             })
@@ -1777,8 +1777,8 @@ mod tests {
             let finite = session
                 .execute(
                     &format!(
-                        "SELECT row_pk, diff_type FROM {} \
-                         WHERE row_pk = CAST($1 AS JSONB) ORDER BY row_pk",
+                        "SELECT lixcol_row_pk, lixcol_diff_type FROM {} \
+                         WHERE lixcol_row_pk = CAST($1 AS JSONB) ORDER BY lixcol_row_pk",
                         json_pointer_diff_relation(&session).await
                     ),
                     &[crate::Value::Text(requested_row_pk.clone())],
@@ -1794,10 +1794,10 @@ mod tests {
                 .iter()
                 .map(|row| {
                     (
-                        row.get::<serde_json::Value>("row_pk")
+                        row.get::<serde_json::Value>("lixcol_row_pk")
                             .expect("row_pk should decode")
                             .to_string(),
-                        row.get::<String>("diff_type")
+                        row.get::<String>("lixcol_diff_type")
                             .expect("diff_type should decode"),
                     )
                 })
@@ -1946,13 +1946,13 @@ mod tests {
                 .iter()
                 .map(|row| {
                     (
-                        row.get::<serde_json::Value>("row_pk")
+                        row.get::<serde_json::Value>("lixcol_row_pk")
                             .expect("row_pk should decode")
                             .to_string(),
                         // `file_id` is nullable; a NULL surfaces as a decode
                         // error through the typed accessor.
                         row.get::<String>("file_id").ok(),
-                        row.get::<String>("diff_type")
+                        row.get::<String>("lixcol_diff_type")
                             .expect("diff_type should decode"),
                     )
                 })
@@ -1962,8 +1962,8 @@ mod tests {
         }
         let relation = json_pointer_diff_relation(&session).await;
         let columns = format!(
-            "SELECT row_pk, \
-             COALESCE(to_lixcol_file_id, from_lixcol_file_id) AS file_id, diff_type \
+            "SELECT lixcol_row_pk, \
+             COALESCE(to_lixcol_file_id, from_lixcol_file_id) AS file_id, lixcol_diff_type \
              FROM {relation}"
         );
 

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -3825,7 +3825,9 @@ mod tests {
             replay_debt: CommitStateReplayDebt::default(),
             mutations: CommitStateMutationInventory::default(),
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: Some(Box::new(TrackedStateCommitRoot {
                 commit_id,
                 root_id: TrackedStateRootId::new(root_hash),
@@ -3962,7 +3964,9 @@ mod tests {
             replay_debt: CommitStateReplayDebt::default(),
             mutations: CommitStateMutationInventory::default(),
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: Some(Box::new(snapshot_root)),
         };
         let _owner_control = replay_branch_control(owner, retired_ref, timestamp);
@@ -6041,7 +6045,9 @@ mod tests {
             },
             mutations,
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: None,
         }
     }

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -216,7 +216,7 @@ async fn working_diff_rows(session: &SessionContext<Memory>, schema_key: &str) -
     session
         .execute(
             &format!(
-                "SELECT row_pk FROM lix_diff('{schema_key}', $1, lix_active_branch_commit_id())"
+                "SELECT lixcol_row_pk FROM lix_diff('{schema_key}', $1, lix_active_branch_commit_id())"
             ),
             &[crate::Value::Text(checkpoint)],
         )

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -3094,7 +3094,9 @@ mod tests {
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: Default::default(),
                     touched_scope_filter: Default::default(),
+                    global_scope: false,
                     current_state_scoped_ranges: None,
+                    row_pk_index_root_id: None,
                     snapshot_root: Some(Box::new(snapshot_root)),
                 },
             )
@@ -3320,7 +3322,9 @@ mod tests {
                     },
                     mutations: Default::default(),
                     touched_scope_filter: Default::default(),
+                    global_scope: false,
                     current_state_scoped_ranges: None,
+                    row_pk_index_root_id: None,
                     snapshot_root: None,
                 },
             )
@@ -3527,7 +3531,9 @@ mod tests {
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: mutation_inventory,
                     touched_scope_filter: Default::default(),
+                    global_scope: false,
                     current_state_scoped_ranges: None,
+                    row_pk_index_root_id: None,
                     snapshot_root: Some(Box::new(snapshot_root)),
                 },
             )?;

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -93,9 +93,16 @@ pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 /// with the nullable `profile_uri` column. The schema catalog is repository
 /// data, so changing only the bundled initialization document would leave v72
 /// repositories on the historical SQL surface.
-pub(crate) const CURRENT_FORMAT_VERSION: u32 = 73;
+///
+/// `v74` authenticates a row-primary-key secondary root beside every tracked-
+/// state commit authority, including rootless replay commits. The index makes
+/// historical PK reads bounded even when the row's file scope is not known by
+/// the SQL predicate.
+pub(crate) const CURRENT_FORMAT_VERSION: u32 = 74;
 const REPOSITORY_PROTOCOL_PREFIX: &[u8] = b"tracked-default-branch.v";
-pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v73";
+pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v74";
+pub(crate) const REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP: &[u8] =
+    b"tracked-default-branch.v72-row-pk-bootstrap";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -115,6 +122,12 @@ pub(crate) enum RepositoryProtocolStatus {
 }
 
 pub(crate) fn parse_repository_protocol(value: &[u8]) -> RepositoryProtocolStatus {
+    // Explicit offline-migration fence. Older engines do not recognize this
+    // marker and therefore cannot open partially upgraded LXCS12 authorities;
+    // this engine resumes it as the v72 migration edge.
+    if value == REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP {
+        return RepositoryProtocolStatus::MigrationRequired { found_version: 72 };
+    }
     let Some(version_bytes) = value.strip_prefix(REPOSITORY_PROTOCOL_PREFIX) else {
         return RepositoryProtocolStatus::Malformed;
     };
@@ -528,6 +541,29 @@ where
                 )
             })?;
         let initial_mutations = staged_delta.mutation_inventory().clone();
+        let initial_segments = crate::tracked_state::staged_commit_delta_segment_bytes(
+            &writes,
+            plan.commit.id,
+            &initial_mutations,
+        )?;
+        let initial_members = crate::tracked_state::staged_commit_delta_members(
+            &read,
+            plan.commit.id,
+            &plan.commit.account_id,
+            &initial_mutations,
+            initial_segments,
+        )
+        .await?;
+        let mut row_pk_index_overlay = crate::tracked_state::TrackedStateChunkOverlay::new();
+        let row_pk_index_root_id = crate::tracked_state::stage_row_pk_index_from_members(
+            &read,
+            &mut writes,
+            &mut row_pk_index_overlay,
+            None,
+            &initial_members,
+            plan.commit.id,
+        )
+        .await?;
         let physical_publication =
             crate::tracked_state::stage_current_state_scoped_ranges_from_published_parent(
                 &read,
@@ -547,7 +583,9 @@ where
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: initial_mutations,
                     touched_scope_filter: physical_publication.touched_scope_filter().clone(),
+                    global_scope: true,
                     current_state_scoped_ranges: physical_publication.root(),
+                    row_pk_index_root_id,
                     snapshot_root: Some(Box::new(snapshot_root)),
                 },
                 &physical_publication,
@@ -1224,20 +1262,20 @@ mod tests {
     #[test]
     fn repository_protocol_parser_distinguishes_versions() {
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v73"),
+            parse_repository_protocol(b"tracked-default-branch.v74"),
             RepositoryProtocolStatus::Current
         );
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v72"),
-            RepositoryProtocolStatus::MigrationRequired { found_version: 72 }
+            parse_repository_protocol(b"tracked-default-branch.v73"),
+            RepositoryProtocolStatus::MigrationRequired { found_version: 73 }
         );
         assert_eq!(
             parse_repository_protocol(b"tracked-default-branch.v69"),
             RepositoryProtocolStatus::MigrationRequired { found_version: 69 }
         );
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v74"),
-            RepositoryProtocolStatus::TooNew { found_version: 74 }
+            parse_repository_protocol(b"tracked-default-branch.v75"),
+            RepositoryProtocolStatus::TooNew { found_version: 75 }
         );
         assert_eq!(
             parse_repository_protocol(b"not-a-lix-format"),

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -6,6 +6,7 @@ use crate::LixError;
 use crate::branch::{
     BranchHeadControlContext, branch_head_control_precondition, stage_branch_head_control,
 };
+use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
 use crate::hot_state::{
     CompleteWorkingDiffMode, HotTrackedSnapshot, TrackedHeadContext, TrackedWorkingDiffEpoch,
     WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
@@ -24,7 +25,7 @@ use crate::storage_adapter::StorageWriteOptions as AdapterWriteOptions;
 use crate::tracked_state::{
     CommitStateReplayDebt, TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns,
     TrackedStateScanRequest,
-    encode_commit_state_manifest_replacement_for_migration,
+    backfill_row_pk_index_for_commit, encode_commit_state_manifest_replacement_for_migration,
     load_rebuild_plans_to_nearest_available_root_bounded, stage_rebuild_plan_with_writer,
 };
 
@@ -33,6 +34,7 @@ const REPOSITORY_PROTOCOL_V69: &[u8] = b"tracked-default-branch.v69";
 const REPOSITORY_PROTOCOL_V70: &[u8] = b"tracked-default-branch.v70";
 const REPOSITORY_PROTOCOL_V71: &[u8] = b"tracked-default-branch.v71";
 const REPOSITORY_PROTOCOL_V72: &[u8] = b"tracked-default-branch.v72";
+const REPOSITORY_PROTOCOL_V73: &[u8] = b"tracked-default-branch.v73";
 const ACCOUNT_SCHEMA_KEY: &str = "lix_account";
 
 /// Bounds for explicit offline repository migrations.
@@ -153,7 +155,7 @@ where
         .map_err(storage_error)?;
     let from_version = match crate::init::repository_protocol_status(&read).await? {
         RepositoryProtocolStatus::MigrationRequired {
-            found_version: found_version @ (68 | 69 | 70 | 71 | 72),
+            found_version: found_version @ (68 | 69 | 70 | 71 | 72 | 73),
         } => found_version,
         RepositoryProtocolStatus::Current => {
             return Ok(MigrationReport {
@@ -209,7 +211,10 @@ where
         } else {
             0
         };
-        migrate_v72_account_profile_uri(&adapter, &storage, options).await?;
+        if from_version <= 72 {
+            migrate_v72_account_profile_uri(&adapter, &storage, options).await?;
+        }
+        migrate_v73_row_pk_indexes(&adapter, &storage, options).await?;
         return Ok(MigrationReport {
             from_version,
             to_version: CURRENT_FORMAT_VERSION,
@@ -306,6 +311,7 @@ where
     .await?;
     let migrated_hot_rows = migrate_v71_working_diff_epochs(&adapter, &storage, options).await?;
     migrate_v72_account_profile_uri(&adapter, &storage, options).await?;
+    migrate_v73_row_pk_indexes(&adapter, &storage, options).await?;
     Ok(MigrationReport {
         from_version: 68,
         to_version: CURRENT_FORMAT_VERSION,
@@ -401,6 +407,32 @@ async fn migrate_v72_account_profile_uri<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    // The v72 logical amendment below publishes ordinary commits. Current
+    // commit publication maintains the v74 secondary index, so bootstrap the
+    // inherited authorities while the repository is still fenced by its v72
+    // marker. Keeping the marker unchanged makes interruption retryable and
+    // lets the amendment commits inherit the index normally.
+    let marker = load_repository_protocol_marker(adapter).await?;
+    if marker.as_deref() == Some(REPOSITORY_PROTOCOL_V72) {
+        backfill_missing_row_pk_indexes(
+            adapter,
+            storage,
+            options,
+            72,
+            REPOSITORY_PROTOCOL_V72,
+            crate::init::REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP,
+            "v72 row-PK-index bootstrap",
+            false,
+        )
+        .await?;
+    } else if marker.as_deref()
+        != Some(crate::init::REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP)
+    {
+        return Err(migration_error(
+            "v72 row-PK-index bootstrap observed an unexpected protocol marker",
+        ));
+    }
+
     let read = SharedStorageAdapterRead::new(
         adapter
             .begin_read(ReadOptions::default())
@@ -510,11 +542,342 @@ where
     crate::migration::publish::publish(
         storage,
         expected_revision,
-        REPOSITORY_PROTOCOL_V72,
-        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        crate::init::REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP,
+        REPOSITORY_PROTOCOL_V73,
         crate::migration::publish::PublicationPlan::bounded(0, 0),
     )
     .await
+}
+
+async fn load_repository_protocol_marker<S>(
+    adapter: &crate::storage_adapter::StorageAdapter<S>,
+) -> Result<Option<Bytes>, LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .map_err(storage_error)?;
+    let values = crate::storage_adapter::PointReadPlan::new(
+        REPOSITORY_PROTOCOL_SPACE,
+        &[Key(Bytes::from_static(REPOSITORY_PROTOCOL_KEY))],
+    )
+    .materialize(&read, GetOptions::default())
+    .await
+    .map_err(storage_error)?;
+    Ok(values.value.into_iter().next().flatten().and_then(|value| {
+        match value {
+            ProjectedValue::FullValue(value) => Some(value),
+            ProjectedValue::KeyOnly => None,
+        }
+    }))
+}
+
+/// Backfills every commit authority's row-PK permutation before publishing
+/// v74, including rootless replay commits.
+///
+/// Tree chunks are content-addressed and may safely be staged before the
+/// authority flip. Manifest replacements and the protocol marker remain one
+/// atomic publication, so interruption either leaves a retryable v73
+/// repository or a complete v74 repository.
+async fn migrate_v73_row_pk_indexes<S>(
+    adapter: &crate::storage_adapter::StorageAdapter<S>,
+    storage: &S,
+    options: MigrationOptions,
+) -> Result<(), LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    backfill_missing_row_pk_indexes(
+        adapter,
+        storage,
+        options,
+        73,
+        REPOSITORY_PROTOCOL_V73,
+        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        "v73 row-PK-index migration",
+        true,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn backfill_missing_row_pk_indexes<S>(
+    adapter: &crate::storage_adapter::StorageAdapter<S>,
+    storage: &S,
+    options: MigrationOptions,
+    expected_version: u32,
+    expected_protocol: &'static [u8],
+    target_protocol: &'static [u8],
+    operation: &'static str,
+    preflight_reserved_columns: bool,
+) -> Result<(), LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let read = SharedStorageAdapterRead::new(
+        adapter
+            .begin_read(ReadOptions::default())
+            .await
+            .map_err(storage_error)?,
+    );
+    match crate::init::repository_protocol_status(&read).await? {
+        RepositoryProtocolStatus::MigrationRequired { found_version }
+            if found_version == expected_version => {}
+        status => {
+            return Err(migration_error(format!(
+                "{operation} observed unexpected repository status {status:?}"
+            )));
+        }
+    }
+    if preflight_reserved_columns {
+        preflight_v74_registered_schemas(&read, options).await?;
+    }
+    let expected_revision = crate::storage_adapter::load_repository_mutation_revision(&read)
+        .await
+        .map_err(storage_error)?;
+    let commit_ids = crate::tracked_state::scan_commit_state_manifest_commit_ids(&read).await?;
+    if commit_ids.len() > options.max_changes {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "{operation} exceeds configured commit bound: {} commits",
+                commit_ids.len()
+            ),
+        ));
+    }
+
+    let global_head = BranchHeadControlContext::new()
+        .reader(read.clone())
+        .load(crate::GLOBAL_BRANCH_ID)
+        .await?
+        .ok_or_else(|| migration_error("row-PK-index migration found no global branch"))?
+        .head_commit_id;
+    // Branch-family provenance was not persisted before v74. The first-parent
+    // chain is the recoverable authored lineage: merge secondary parents may
+    // come from another family and must not become global merely because the
+    // current global head reaches them.
+    let mut global_commits = BTreeSet::new();
+    let mut next_global = Some(global_head);
+    while let Some(commit_id) = next_global {
+        if !global_commits.insert(commit_id) {
+            return Err(migration_error(format!(
+                "{operation} found a cycle in the global first-parent lineage at '{commit_id}'"
+            )));
+        }
+        if global_commits.len() > options.max_changes {
+            return Err(LixError::new(
+                "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+                format!("{operation} exceeds configured global-lineage commit bound"),
+            ));
+        }
+        let ids = [commit_id];
+        let record = ChangelogContext::new()
+            .reader(read.clone())
+            .load_commits(CommitLoadRequest { commit_ids: &ids })
+            .await?
+            .into_iter()
+            .next()
+            .and_then(|(_, record)| record)
+            .ok_or_else(|| {
+                migration_error(format!(
+                    "{operation} global lineage commit '{commit_id}' is missing"
+                ))
+            })?;
+        next_global = record.parent_commit_ids.first().copied();
+    }
+
+    let mut chunk_writes = adapter.new_write_set();
+    let mut replacements = Vec::new();
+    let mut visited_rows = 0usize;
+    for commit_id in commit_ids {
+        let mut manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+            .await?
+            .ok_or_else(|| {
+                migration_error(format!(
+                    "{operation} commit '{commit_id}' has no commit-state manifest"
+                ))
+            })?;
+        if manifest.row_pk_index_root_id.is_some() {
+            continue;
+        }
+        let (root, row_count) = backfill_row_pk_index_for_commit(
+            &read,
+            &mut chunk_writes,
+            &manifest,
+            options.max_changes.saturating_sub(visited_rows),
+        )
+        .await?;
+        visited_rows = visited_rows.checked_add(row_count).ok_or_else(|| {
+            migration_error(format!("{operation} row count exceeds usize"))
+        })?;
+        manifest.global_scope = global_commits.contains(&commit_id);
+        manifest.row_pk_index_root_id = root;
+        replacements.push(manifest);
+    }
+
+    let chunk_stats = chunk_writes.stats();
+    if chunk_stats.written_bytes > options.max_preflight_bytes as u64 {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "{operation} exceeds configured byte bound: {} bytes",
+                chunk_stats.written_bytes
+            ),
+        ));
+    }
+    if chunk_stats.staged_puts != 0 || chunk_stats.staged_deletes != 0 {
+        let mut write = storage
+            .begin_write(WriteOptions {
+                await_durable: true,
+                preconditions: vec![
+                    Precondition::KeyValueEquals {
+                        space: REPOSITORY_PROTOCOL_SPACE,
+                        key: Key(Bytes::from_static(REPOSITORY_PROTOCOL_KEY)),
+                        expected: Bytes::from_static(expected_protocol),
+                    },
+                    crate::storage_adapter::repository_mutation_revision_precondition(
+                        expected_revision.clone(),
+                    ),
+                ],
+                ..WriteOptions::default()
+            })
+            .await
+            .map_err(storage_error)?;
+        if let Err(error) = chunk_writes.lower_into(&mut write).await {
+            let _ = write.rollback().await;
+            return Err(error.into());
+        }
+        write.commit().await.map_err(storage_error)?;
+    }
+    read.finish().map_err(storage_error)?;
+
+    let mut publication = crate::migration::publish::PublicationPlan::bounded(
+        replacements.len().saturating_mul(2),
+        options.max_preflight_bytes,
+    );
+    for manifest in replacements {
+        for (space, key, value) in
+            encode_commit_state_manifest_replacement_for_migration(&manifest)?
+        {
+            publication.replace_immutable(space, vec![(key, value)])?;
+        }
+    }
+    crate::migration::publish::publish(
+        storage,
+        expected_revision,
+        expected_protocol,
+        target_protocol,
+        publication,
+    )
+    .await
+}
+
+async fn preflight_v74_registered_schemas(
+    read: &(impl crate::storage_adapter::StorageAdapterRead + Clone),
+    options: MigrationOptions,
+) -> Result<(), LixError> {
+    let heads = BranchHeadControlContext::new()
+        .reader(read.clone())
+        .scan()
+        .await?
+        .into_iter()
+        .map(|(_, control)| control.head_commit_id)
+        .collect::<BTreeSet<_>>();
+    if heads.len() > options.max_changes {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "v74 schema preflight exceeds configured branch-head bound: {} heads",
+                heads.len()
+            ),
+        ));
+    }
+
+    let mut inspected = 0usize;
+    let mut inspected_bytes = 0usize;
+    for head in heads {
+        let remaining = options.max_changes.saturating_sub(inspected);
+        let rows = TrackedStateContext::new()
+            .reader(read.clone())
+            .scan_batch_at_commit(
+                &head.to_string(),
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec!["lix_registered_schema".to_owned()],
+                        file_ids: vec![crate::NullableKeyFilter::Null],
+                        ..TrackedStateFilter::default()
+                    },
+                    read_columns: TrackedStateReadColumns {
+                        columns: vec!["snapshot".to_owned()],
+                    },
+                    limit: Some(remaining.saturating_add(1)),
+                },
+            )
+            .await?;
+        inspected = inspected.checked_add(rows.len()).ok_or_else(|| {
+            migration_error("v74 schema preflight row count exceeds usize")
+        })?;
+        if inspected > options.max_changes {
+            return Err(LixError::new(
+                "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+                format!(
+                    "v74 schema preflight exceeds configured row bound: {inspected} rows"
+                ),
+            ));
+        }
+        for row in rows.iter() {
+            let schema_key = row.row_pk().as_single_string_owned().map_err(|error| {
+                migration_error(format!(
+                    "v74 schema preflight found an invalid registered-schema identity: {error}"
+                ))
+            })?;
+            let schema = match row
+                .decoded_snapshot()
+                .and_then(|typed| typed.row.get("value"))
+            {
+                Some(lix_schema::Value::Jsonb(value)) => value.clone().into_value(),
+                _ => {
+                    return Err(migration_error(format!(
+                        "v74 schema preflight could not decode registered schema '{schema_key}' at commit '{head}'"
+                    )));
+                }
+            };
+            inspected_bytes = inspected_bytes
+                .checked_add(serde_json::to_vec(&schema).map_err(|error| {
+                    migration_error(format!(
+                        "v74 schema preflight could not size registered schema '{schema_key}': {error}"
+                    ))
+                })?.len())
+                .ok_or_else(|| migration_error("v74 schema preflight byte count exceeds usize"))?;
+            if inspected_bytes > options.max_preflight_bytes {
+                return Err(LixError::new(
+                    "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+                    format!(
+                        "v74 schema preflight exceeds configured byte bound: {inspected_bytes} bytes"
+                    ),
+                ));
+            }
+            validate_v74_registered_schema(&schema_key, &schema)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_v74_registered_schema(
+    schema_key: &str,
+    schema: &serde_json::Value,
+) -> Result<(), LixError> {
+    crate::schema::parse_lix_schema(schema).map(|_| ()).map_err(|error| {
+        LixError::new(
+            "LIX_ERROR_MIGRATION_SCHEMA_INCOMPATIBLE",
+            format!(
+                "repository cannot migrate to v74 while registered schema '{schema_key}' uses a reserved column: {}. With a v73-capable engine, register a replacement schema under a new key, migrate its rows, remove the old schema, and then retry",
+                error.message
+            ),
+        )
+    })
 }
 
 async fn migrate_working_diff_epoch<S>(
@@ -874,6 +1237,24 @@ mod tests {
     use crate::storage_adapter::{PutBatch, PutEntry, StorageValue};
     use crate::tracked_state::TrackedStateRootId;
 
+    #[test]
+    fn v74_preflight_teaches_legacy_reserved_column_rename() {
+        let schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "legacy_reserved_column",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "lixcol_user_value", "type": "text", "nullable": true }
+            ],
+            "primary_key": ["id"]
+        });
+        let error = validate_v74_registered_schema("legacy_reserved_column", &schema)
+            .expect_err("v74 must reject a formerly valid reserved column name");
+        assert_eq!(error.code, "LIX_ERROR_MIGRATION_SCHEMA_INCOMPATIBLE");
+        assert!(error.message.contains("lixcol_user_value"));
+        assert!(error.message.contains("replacement schema under a new key"));
+    }
+
     #[tokio::test]
     async fn migrates_v69_with_a_marker_only_publication() {
         let storage = Memory::new();
@@ -915,6 +1296,149 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn migrates_v73_repository_to_v74() {
+        let storage = Memory::new();
+        let (_branch_id, head_commit_id, rootless_commit_id, _) =
+            seed_rooted_head_with_rootless_checkpoint_cursor(
+                &storage,
+                REPOSITORY_PROTOCOL_V73,
+            )
+            .await;
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+
+        assert_eq!(
+            inspect_lix(&storage).await.unwrap(),
+            MigrationStatus::Required {
+                from_version: 73,
+                to_version: 74,
+            }
+        );
+        let pre_migration = SharedStorageAdapterRead::new(
+            adapter.begin_read(ReadOptions::default()).await.unwrap(),
+        );
+        let pre_migration_commit_ids =
+            crate::tracked_state::scan_commit_state_manifest_commit_ids(&pre_migration)
+                .await
+                .unwrap();
+        for commit_id in pre_migration_commit_ids {
+            let manifest =
+                crate::tracked_state::load_commit_state_manifest(&pre_migration, commit_id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+            assert!(
+                manifest.row_pk_index_root_id.is_none(),
+                "v73 fixture commit '{commit_id}' must genuinely lack the new index"
+            );
+        }
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(
+                &pre_migration,
+                rootless_commit_id,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .snapshot_root
+            .is_none()
+        );
+        pre_migration.finish().unwrap();
+        let report = migrate_lix(storage.clone(), MigrationOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(report.from_version, 73);
+        assert_eq!(report.to_version, 74);
+        assert_eq!(
+            inspect_lix(&storage).await.unwrap(),
+            MigrationStatus::Current { version: 74 }
+        );
+
+        let read = SharedStorageAdapterRead::new(
+            adapter.begin_read(ReadOptions::default()).await.unwrap(),
+        );
+        let commit_ids = crate::tracked_state::scan_commit_state_manifest_commit_ids(&read)
+            .await
+            .unwrap();
+        assert!(commit_ids.contains(&head_commit_id));
+        assert!(commit_ids.contains(&rootless_commit_id));
+        for commit_id in commit_ids {
+            let manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(
+                manifest.row_pk_index_root_id.is_some(),
+                "migrated commit '{commit_id}' must carry an index authority, including an empty root"
+            );
+        }
+        let rootless = crate::tracked_state::load_commit_state_manifest(&read, rootless_commit_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            rootless.snapshot_root.is_none(),
+            "v74 backfill must index rootless history without promoting it"
+        );
+        let mut tracked = TrackedStateContext::new().reader(read.clone());
+        let keys = tracked
+            .enumerate_schema_row_pk_keys_at_commit(
+                head_commit_id,
+                "lix_key_value",
+                &[crate::row_pk::RowPk::single("migration-shared-pk")],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            keys.into_iter()
+                .map(|key| key.file_id.expect("fixture rows are file-scoped"))
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "01920000-0000-7000-8000-0000000000a1".to_owned(),
+                "01920000-0000-7000-8000-0000000000a2".to_owned(),
+            ])
+        );
+        drop(tracked);
+        read.finish().unwrap();
+    }
+
+    #[tokio::test]
+    async fn v72_index_bootstrap_uses_a_resumable_rejected_marker() {
+        let storage = Memory::new();
+        seed_rooted_head_with_rootless_checkpoint_cursor(&storage, REPOSITORY_PROTOCOL_V72).await;
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+
+        backfill_missing_row_pk_indexes(
+            &adapter,
+            &storage,
+            MigrationOptions::default(),
+            72,
+            REPOSITORY_PROTOCOL_V72,
+            crate::init::REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP,
+            "test v72 bootstrap",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            load_repository_protocol_marker(&adapter)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(crate::init::REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP)
+        );
+        assert!(
+            crate::engine::Engine::new(storage.clone()).await.is_err(),
+            "normal engine open must reject an interrupted bootstrap"
+        );
+        let report = migrate_lix(storage.clone(), MigrationOptions::default())
+            .await
+            .expect("migration should resume from the transitional marker");
+        assert_eq!(report.from_version, 72);
+        assert_eq!(report.to_version, 74);
+    }
+
     async fn seed_rooted_head_with_rootless_checkpoint_cursor(
         storage: &Memory,
         protocol: &'static [u8],
@@ -925,6 +1449,22 @@ mod tests {
             .unwrap();
         lix.execute(
             "INSERT INTO lix_key_value (key, value) VALUES ('migration-chronology-head', 'rooted')",
+            &[],
+        )
+        .await
+        .unwrap();
+        lix.execute(
+            "INSERT INTO lix_file (id, path) VALUES \
+             ('01920000-0000-7000-8000-0000000000a1', '/migration-a'), \
+             ('01920000-0000-7000-8000-0000000000a2', '/migration-b')",
+            &[],
+        )
+        .await
+        .unwrap();
+        lix.execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_file_id) VALUES \
+             ('migration-shared-pk', 'a', '01920000-0000-7000-8000-0000000000a1'), \
+             ('migration-shared-pk', 'b', '01920000-0000-7000-8000-0000000000a2')",
             &[],
         )
         .await
@@ -970,11 +1510,22 @@ mod tests {
             .expect("fixture head should already be rooted")
             .root_id
             .clone();
-        let mut checkpoint_manifest =
-            crate::tracked_state::load_commit_state_manifest(&read, checkpoint_commit_id)
-                .await
-                .unwrap()
-                .unwrap();
+        let commit_ids = crate::tracked_state::scan_commit_state_manifest_commit_ids(&read)
+            .await
+            .unwrap();
+        let mut manifests = Vec::with_capacity(commit_ids.len());
+        for commit_id in commit_ids {
+            manifests.push(
+                crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+            );
+        }
+        let checkpoint_manifest = manifests
+            .iter_mut()
+            .find(|manifest| manifest.commit_id == checkpoint_commit_id)
+            .expect("fixture checkpoint manifest should be retained");
         assert!(checkpoint_manifest.snapshot_root.is_some());
         checkpoint_manifest.snapshot_root = None;
         checkpoint_manifest.replay_debt = CommitStateReplayDebt {
@@ -982,10 +1533,13 @@ mod tests {
             rows: u64::from(checkpoint_manifest.mutations.member_count),
             bytes: 1,
         };
-        let replacements = encode_commit_state_manifest_replacement_for_migration(
-            &checkpoint_manifest,
-        )
-        .unwrap();
+        let replacements = manifests
+            .into_iter()
+            .flat_map(|mut manifest| {
+                manifest.row_pk_index_root_id = None;
+                encode_commit_state_manifest_replacement_for_migration(&manifest).unwrap()
+            })
+            .collect::<Vec<_>>();
         read.finish().unwrap();
 
         let mut fixture = storage.begin_write(WriteOptions::default()).await.unwrap();
@@ -1088,7 +1642,7 @@ mod tests {
             inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Required {
                 from_version: 70,
-                to_version: 73,
+                to_version: CURRENT_FORMAT_VERSION,
             }
         );
         assert_chronology_roots_promoted(
@@ -1151,14 +1705,14 @@ mod tests {
             inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Required {
                 from_version: 71,
-                to_version: 73,
+                to_version: CURRENT_FORMAT_VERSION,
             }
         );
         let report = migrate_lix(storage.clone(), MigrationOptions::default())
             .await
             .unwrap();
         assert_eq!(report.from_version, 71);
-        assert_eq!(report.to_version, 73);
+        assert_eq!(report.to_version, CURRENT_FORMAT_VERSION);
         assert!(
             report.hot_rows_rewritten > 0,
             "the v71 edge must repair the stale working-diff epoch before publishing v72"

--- a/packages/lix/src/migration/commit_plan.rs
+++ b/packages/lix/src/migration/commit_plan.rs
@@ -596,7 +596,9 @@ pub(super) async fn plan_commit_authorities(
             replay_debt: old.replay_debt,
             mutations,
             touched_scope_filter: CommitStateTouchedScopeFilter::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: old.snapshot_root,
         };
         stage_commit_state_manifest(&mut writes, &manifest)?;

--- a/packages/lix/src/migration/registry.rs
+++ b/packages/lix/src/migration/registry.rs
@@ -29,6 +29,10 @@ const MIGRATIONS: &[Migration] = &[
         from_version: 72,
         to_version: 73,
     },
+    Migration {
+        from_version: 73,
+        to_version: 74,
+    },
 ];
 
 pub(crate) fn registered_migrations() -> &'static [Migration] {
@@ -82,7 +86,14 @@ mod tests {
                 to_version: 73,
             })
         );
-        assert_eq!(registered_migrations().len(), 5);
+        assert_eq!(
+            migration_from(73),
+            Some(&Migration {
+                from_version: 73,
+                to_version: 74,
+            })
+        );
+        assert_eq!(registered_migrations().len(), 6);
         assert_eq!(migration_from(crate::init::CURRENT_FORMAT_VERSION), None);
     }
 }

--- a/packages/lix/src/migration/v68/commit_state_manifest.rs
+++ b/packages/lix/src/migration/v68/commit_state_manifest.rs
@@ -230,8 +230,11 @@ struct CurrentManifestWire {
     replay_debt: CommitStateReplayDebt,
     mutations: CurrentInventoryWire,
     touched_scope_filter: TouchedScopeFilterWire,
+    global_scope: bool,
     #[musli(with = storage_codec::option)]
     current_state_scoped_ranges: Option<Box<ScopedRangeAuthorityWire>>,
+    #[musli(with = storage_codec::option)]
+    row_pk_index_root_id: Option<TrackedStateRootId>,
     #[musli(with = storage_codec::option)]
     snapshot_root: Option<Box<TrackedStateCommitRoot>>,
 }
@@ -569,7 +572,9 @@ fn assemble_manifest(
             parts,
         },
         touched_scope_filter: stored.touched_scope_filter,
+        global_scope: false,
         current_state_scoped_ranges,
+        row_pk_index_root_id: None,
         snapshot_root: stored.snapshot_root,
     };
     let encoded = storage_codec::encode("upgraded v68 commit-state manifest", &wire)?;

--- a/packages/lix/src/schema/definition.rs
+++ b/packages/lix/src/schema/definition.rs
@@ -18,13 +18,7 @@ pub const fn lix_schema_definition_json() -> &'static str {
 }
 
 pub fn validate_lix_schema_definition(schema: &JsonValue) -> Result<(), LixError> {
-    lix_schema::from_value(schema.clone()).map(|_| ()).map_err(|error| {
-        schema_error(
-            LixError::CODE_SCHEMA_DEFINITION,
-            "Invalid Lix schema definition",
-            error,
-        )
-    })
+    parse_lix_schema(schema).map(|_| ())
 }
 
 pub fn validate_lix_schema(schema: &JsonValue, data: &JsonValue) -> Result<(), LixError> {
@@ -47,13 +41,25 @@ pub(crate) fn compile_lix_schema(
 }
 
 pub(crate) fn parse_lix_schema(schema: &JsonValue) -> Result<lix_schema::Schema, LixError> {
-    lix_schema::from_value(schema.clone()).map_err(|error| {
+    let parsed = lix_schema::from_value(schema.clone()).map_err(|error| {
         schema_error(
             LixError::CODE_SCHEMA_DEFINITION,
             "Invalid Lix schema definition",
             error,
         )
-    })
+    })?;
+    if let Some(column) = parsed.columns.iter().find(|column| {
+        column.name.starts_with("lixcol_") || column.name.contains("_lixcol_")
+    }) {
+        return Err(LixError::new(
+            LixError::CODE_SCHEMA_DEFINITION,
+            format!(
+                "Invalid Lix schema definition: column '{}' uses the reserved lixcol_ segment",
+                column.name
+            ),
+        ));
+    }
+    Ok(parsed)
 }
 
 pub(crate) fn format_lix_schema_validation_errors(error: lix_schema::Error) -> String {

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -5453,7 +5453,7 @@ mod tests {
         );
         let working_diff = session
             .execute(
-                "SELECT row_pk FROM lix_diff(\
+                "SELECT lixcol_row_pk FROM lix_diff(\
                  'lix_key_value', $1, lix_active_branch_commit_id())",
                 &[Value::Text(restore_target.clone())],
             )
@@ -6727,7 +6727,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('rootless_ordered_insert_probe', $1, $2) \
-                 WHERE diff_type = 'added'",
+                 WHERE lixcol_diff_type = 'added'",
                 &[
                     Value::Text(baseline.commit_id.to_string()),
                     Value::Text(head.commit_id.to_string()),
@@ -6810,7 +6810,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('rootless_ordered_insert_probe', $1, $2) \
-                 WHERE diff_type = 'modified'",
+                 WHERE lixcol_diff_type = 'modified'",
                 &[
                     Value::Text(head.commit_id.to_string()),
                     Value::Text(descendant.commit_id.to_string()),
@@ -6992,7 +6992,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('rootless_ordered_insert_probe', $1, $2) \
-                 WHERE diff_type = 'modified'",
+                 WHERE lixcol_diff_type = 'modified'",
                 &[
                     Value::Text(reseed_head.commit_id.to_string()),
                     Value::Text(rooted_fence.to_string()),
@@ -7244,7 +7244,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('columnar_lifecycle_probe', $1, $2) \
-                 WHERE diff_type = 'added'",
+                 WHERE lixcol_diff_type = 'added'",
                 &[
                     Value::Text(before_insert.to_string()),
                     Value::Text(inserted_head.to_string()),
@@ -7412,7 +7412,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('columnar_lifecycle_probe', $1, $2) \
-                 WHERE diff_type = 'modified'",
+                 WHERE lixcol_diff_type = 'modified'",
                 &[
                     Value::Text(checkpoint.commit_id.to_string()),
                     Value::Text(merged_head.to_string()),
@@ -7555,7 +7555,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('ordered_packed_update_probe', lix_root_commit_id(), lix_active_branch_commit_id()) \
-                 WHERE diff_type = 'added'",
+                 WHERE lixcol_diff_type = 'added'",
                 &[],
             )
             .await
@@ -7706,7 +7706,7 @@ mod tests {
             .execute(
                 "SELECT count(*) AS count \
                  FROM lix_diff('packed_replacement_working_diff_probe', $1, $2) \
-                 WHERE diff_type = 'modified'",
+                 WHERE lixcol_diff_type = 'modified'",
                 &[
                     Value::Text(checkpoint_commit_id.clone()),
                     Value::Text(head_commit_id.clone()),
@@ -9545,7 +9545,7 @@ mod tests {
                 .execute(
                     "SELECT COUNT(*) AS entries \
                      FROM lix_diff('packed_replacement_probe', $1, $2) \
-                     WHERE diff_type = 'modified'",
+                     WHERE lixcol_diff_type = 'modified'",
                     &[Value::Text(before.clone()), Value::Text(after.clone())],
                 )
                 .await
@@ -9713,7 +9713,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('packed_replacement_probe', $1, $2) \
-                 WHERE diff_type = 'modified'",
+                 WHERE lixcol_diff_type = 'modified'",
                 &[
                     Value::Text(second_commit_id.clone()),
                     Value::Text(merged_commit_id.clone()),

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1360,6 +1360,7 @@ fn bound_write_target(kind: &PublicSurfaceKind) -> BoundWriteTarget {
         PublicSurfaceKind::Change
         | PublicSurfaceKind::HistoryFunction
         | PublicSurfaceKind::DiffFunction
+        | PublicSurfaceKind::StateAtFunction
         | PublicSurfaceKind::Restore
         | PublicSurfaceKind::CommitAncestryFunction => {
             unreachable!("write capability checked before target binding")

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -236,6 +236,7 @@ mod tests {
             "lix_registered_schema",
             "lix_restore",
             "lix_revert",
+            "lix_state_at",
         ];
 
         assert_eq!(actual, expected);
@@ -364,7 +365,7 @@ mod tests {
             "columns": [
                 { "name": "id", "type": "text", "nullable": false },
                 { "name": "name", "type": "text", "nullable": true },
-                { "name": "lixcol_internal", "type": "text", "nullable": true },
+                { "name": "user_internal", "type": "text", "nullable": true },
             ],
             "primary_key": ["id"],
         })])

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -153,6 +153,7 @@ impl PublicCatalog {
             ])),
             PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::StateAtFunction
             | PublicSurfaceKind::CommitAncestryFunction => {
                 return None;
             }
@@ -284,6 +285,13 @@ impl PublicCatalog {
             "lix_diff",
             PublicSurfaceClass::TableFunction,
             PublicSurfaceKind::DiffFunction,
+            Vec::new(),
+            SurfaceCapabilities::read_only(),
+        ))?;
+        self.insert(surface(
+            "lix_state_at",
+            PublicSurfaceClass::TableFunction,
+            PublicSurfaceKind::StateAtFunction,
             Vec::new(),
             SurfaceCapabilities::read_only(),
         ))?;

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -138,6 +138,17 @@ pub(crate) fn derive_schema_surface_spec_from_schema(
 ) -> Result<SchemaSurfaceSpec, LixError> {
     let parsed = crate::schema::parse_lix_schema(schema)?;
     let schema_key = parsed.key.clone();
+    if let Some(column) = parsed.columns.iter().find(|column| {
+        column.name.starts_with("lixcol_") || column.name.contains("_lixcol_")
+    }) {
+        return Err(LixError::new(
+            LixError::CODE_SCHEMA_DEFINITION,
+            format!(
+                "schema '{schema_key}' column '{}' uses the reserved lixcol_ segment",
+                column.name
+            ),
+        ));
+    }
     let schema_fingerprint = *parsed
         .wire_fingerprint()
         .map_err(|error| {
@@ -480,9 +491,18 @@ mod tests {
             .as_array_mut()
             .expect("columns")
             .push(json!({ "name": "lixcol_user_value", "type": "text", "nullable": true }));
-        let reserved = derive_schema_surface_spec_from_schema(&reserved)
-            .expect("reserved-name schema should still derive");
-        assert!(!reserved.columnar_snapshot_bijective);
+        let error = derive_schema_surface_spec_from_schema(&reserved)
+            .expect_err("reserved-name schema must be rejected");
+        assert!(error.message.contains("reserved lixcol_ segment"));
+
+        let mut prefixed_reserved = path_value_schema("text");
+        prefixed_reserved["columns"]
+            .as_array_mut()
+            .expect("columns")
+            .push(json!({ "name": "from_lixcol_user_value", "type": "text", "nullable": true }));
+        let error = derive_schema_surface_spec_from_schema(&prefixed_reserved)
+            .expect_err("embedded reserved segment must be rejected");
+        assert!(error.message.contains("reserved lixcol_ segment"));
     }
 
     #[test]

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -85,6 +85,7 @@ pub(crate) enum PublicSurfaceKind {
     Branch,
     HistoryFunction,
     DiffFunction,
+    StateAtFunction,
     CommitAncestryFunction,
     Revert,
     Apply,
@@ -103,6 +104,7 @@ impl PublicSurfaceKind {
             | Self::Change => matches!(class, PublicSurfaceClass::Relation(_)),
             Self::HistoryFunction
             | Self::DiffFunction
+            | Self::StateAtFunction
             | Self::CommitAncestryFunction => class == PublicSurfaceClass::TableFunction,
             Self::Revert | Self::Apply | Self::CreateCheckpoint | Self::Restore => {
                 class == PublicSurfaceClass::CommandSink

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2879,6 +2879,7 @@ fn bind_table_function_parameters(
             let public_function_name = [
                 "lix_history",
                 "lix_diff",
+                "lix_state_at",
                 "lix_commit_ancestry",
             ]
             .into_iter()

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -214,7 +214,10 @@ impl LixInformationSchemaProvider {
             .surfaces()
             .filter(|surface| surface.class == PublicSurfaceClass::TableFunction)
         {
-            if surface.kind == PublicSurfaceKind::DiffFunction {
+            if matches!(
+                surface.kind,
+                PublicSurfaceKind::DiffFunction | PublicSurfaceKind::StateAtFunction
+            ) {
                 for relation in self.public_catalog.surfaces().filter(|relation| {
                     matches!(
                         relation.kind,
@@ -223,18 +226,29 @@ impl LixInformationSchemaProvider {
                             | PublicSurfaceKind::SchemaBase { .. }
                     )
                 }) {
-                    let provider_schema = super::providers::relation_diff_schema(
-                        self.public_catalog.as_ref(),
-                        &relation.name,
-                    )?;
+                    let provider_schema = if surface.kind == PublicSurfaceKind::DiffFunction {
+                        super::providers::relation_diff_schema(
+                            self.public_catalog.as_ref(),
+                            &relation.name,
+                        )?
+                    } else {
+                        self.public_catalog.surface_schema(&relation.name).ok_or_else(|| {
+                            DataFusionError::Execution(format!(
+                                "state relation '{}' is missing its result schema",
+                                relation.name
+                            ))
+                        })?
+                    };
                     for (position, field) in provider_schema.fields().iter().enumerate() {
                         function_catalog.push(self.public_catalog_name.clone());
                         function_schema.push(self.public_schema_name.clone());
                         function_name.push(surface.name.clone());
                         source_relation.push(Some(relation.name.clone()));
-                        argument_signature.push(
-                            "(relation TEXT, from_commit_id TEXT, to_commit_id TEXT)".to_string(),
-                        );
+                        argument_signature.push(if surface.kind == PublicSurfaceKind::DiffFunction {
+                            "(relation TEXT, from_commit_id TEXT, to_commit_id TEXT)".to_string()
+                        } else {
+                            "(relation TEXT, commit_id TEXT)".to_string()
+                        });
                         result_column.push(field.name().clone());
                         ordinal_position.push((position + 1) as u64);
                         is_nullable
@@ -254,6 +268,7 @@ impl LixInformationSchemaProvider {
                     super::providers::commit_ancestry_schema(),
                 ),
                 PublicSurfaceKind::DiffFunction => unreachable!("relation-specific diffs handled above"),
+                PublicSurfaceKind::StateAtFunction => unreachable!("relation-specific state handled above"),
                 _ => {
                     return Err(DataFusionError::Execution(format!(
                         "table function '{}' has a non-function semantic kind",

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -19,8 +19,10 @@ mod predicate_typecheck;
 mod providers;
 #[cfg(test)]
 pub(crate) use providers::{
+    arm_state_at_traversal_probe,
     file_history_anchor_probe_census, file_history_bounded_frontier_census,
     file_history_raw_probe_limit_census, reset_file_history_anchor_probe_census,
+    take_state_at_traversal_probe,
 };
 mod read_only;
 mod result_metadata;

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -176,8 +176,8 @@ impl DiffRelation {
             DataFusionError::Plan(format!("lix_diff does not support relation '{name}'"))
         })?;
         let mut fields = vec![
-            json_field("row_pk", false),
-            Field::new("diff_type", DataType::Utf8, false),
+            json_field("lixcol_row_pk", false),
+            Field::new("lixcol_diff_type", DataType::Utf8, false),
         ];
         for column in surface.columns.iter().filter(|column| column.is_public()) {
             let field = source_schema
@@ -199,7 +199,7 @@ impl DiffRelation {
                 );
             }
         }
-        fields.push(Field::new("row_count", DataType::Int64, false));
+        fields.push(Field::new("lixcol_row_count", DataType::Int64, false));
         Ok(Self {
             kind,
             schema: Arc::new(Schema::new(fields)),
@@ -235,7 +235,7 @@ where
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         if filter.column_refs().iter().any(|column| {
-            matches!(column.name.as_str(), "row_pk" | "from_id" | "to_id")
+            matches!(column.name.as_str(), "lixcol_row_pk" | "from_id" | "to_id")
                 || matches!(
                     column.name.as_str(),
                     "from_lixcol_file_id" | "to_lixcol_file_id"
@@ -313,7 +313,7 @@ where
                                         == Some(from_commit) =>
                             {
                                 TrackedHeadContext::new()
-                                    .reader(store)
+                                    .reader(store.clone())
                                     .working_diff_for_control(branch_id, control, &route.request)
                                     .await
                                     .map_err(lix_error_to_datafusion_error)?
@@ -332,8 +332,12 @@ where
                             .await
                             .map_err(lix_error_to_datafusion_error)?
                     };
+                    let from_global = commit_global_scope(&store, &from_commit_id).await?;
+                    let to_global = commit_global_scope(&store, &to_commit_id).await?;
                     let mut rows = match relation.kind {
-                        DiffRelationKind::Schema { .. } => schema_diff_rows(diff, &schema)?,
+                        DiffRelationKind::Schema { .. } => {
+                            schema_diff_rows(diff, &schema, from_global, to_global)?
+                        }
                         DiffRelationKind::File => {
                             file_diff_rows(
                                 &mut tracked,
@@ -341,6 +345,8 @@ where
                                 &schema,
                                 &from_commit_id,
                                 &to_commit_id,
+                                from_global,
+                                to_global,
                             )
                             .await?
                         }
@@ -351,6 +357,8 @@ where
                                 &schema,
                                 &from_commit_id,
                                 &to_commit_id,
+                                from_global,
+                                to_global,
                             )
                             .await?
                         }
@@ -392,7 +400,7 @@ struct DiffRoute {
 impl DiffRoute {
     fn from_filters(filters: &[Expr], relation: &DiffRelation, projection: &Schema) -> Self {
         let conjuncts = filter_conjuncts(filters);
-        let row_pk_values = optional_values(&conjuncts, "row_pk");
+        let row_pk_values = optional_values(&conjuncts, "lixcol_row_pk");
         let extracted_row_pk_values = extracted_first_row_pk_values(&conjuncts);
         let id_values =
             optional_values(&conjuncts, "from_id").or_else(|| optional_values(&conjuncts, "to_id"));
@@ -526,7 +534,7 @@ fn extracted_first_row_pk_values(conjuncts: &[Expr]) -> Option<Vec<String>> {
             let Expr::Column(column) = strip_cast(&function.args[0]) else {
                 return None;
             };
-            if column.name != "row_pk" {
+            if column.name != "lixcol_row_pk" {
                 return None;
             }
             let Expr::Literal(index, _) = strip_cast(&function.args[1]) else {
@@ -594,7 +602,29 @@ struct DiffSide {
     path: Option<String>,
 }
 
-fn schema_diff_rows(diff: TrackedStateDiff, projection: &Schema) -> Result<Vec<DiffSqlRow>> {
+async fn commit_global_scope(
+    store: &(impl StorageAdapterRead + Clone),
+    commit_id: &str,
+) -> Result<bool> {
+    let commit_id = CommitId::parse_lix(commit_id, "lix_diff commit ID")
+        .map_err(lix_error_to_datafusion_error)?;
+    crate::tracked_state::load_published_commit_state_topology(store, commit_id)
+        .await
+        .map_err(lix_error_to_datafusion_error)?
+        .map(|manifest| manifest.global_scope())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "commit '{commit_id}' has no tracked-state authority"
+            ))
+        })
+}
+
+fn schema_diff_rows(
+    diff: TrackedStateDiff,
+    projection: &Schema,
+    from_global: bool,
+    to_global: bool,
+) -> Result<Vec<DiffSqlRow>> {
     let needs_side = projection
         .fields()
         .iter()
@@ -607,7 +637,7 @@ fn schema_diff_rows(diff: TrackedStateDiff, projection: &Schema) -> Result<Vec<D
                 diff_type: diff_type(entry.kind),
                 row_count: 1,
                 from: if needs_side {
-                    diff_side(entry, entry.visible_before(), &diff)?
+                    diff_side(entry, entry.visible_before(), &diff, from_global)?
                 } else {
                     None
                 },
@@ -616,6 +646,7 @@ fn schema_diff_rows(diff: TrackedStateDiff, projection: &Schema) -> Result<Vec<D
                         entry,
                         entry.after.as_ref().filter(|row| !row.deleted),
                         &diff,
+                        to_global,
                     )?
                 } else {
                     None
@@ -629,6 +660,7 @@ fn diff_side(
     entry: &TrackedStateDiffEntry,
     row: Option<&TrackedStateDiffRow>,
     diff: &TrackedStateDiff,
+    global: bool,
 ) -> Result<Option<DiffSide>> {
     let Some(row) = row else {
         return Ok(None);
@@ -651,7 +683,7 @@ fn diff_side(
     Ok(Some(DiffSide {
         id: single_row_pk_string(entry.identity.row_pk()),
         schema_key: entry.identity.schema_key().to_string(),
-        global: entry.identity.schema_key() == crate::checkpoint::CHECKPOINT_SCHEMA_KEY,
+        global,
         file_id: entry.identity.file_id().map(str::to_string),
         row_pk: entry.identity.row_pk().clone(),
         created_at: row.created_at.to_string(),
@@ -693,6 +725,8 @@ async fn file_diff_rows<S>(
     projection: &Schema,
     from_commit_id: &str,
     to_commit_id: &str,
+    from_global: bool,
+    to_global: bool,
 ) -> Result<Vec<DiffSqlRow>>
 where
     S: StorageAdapterRead,
@@ -803,6 +837,12 @@ where
         } else {
             None
         };
+        if let Some(side) = from.as_mut() {
+            side.global = from_global;
+        }
+        if let Some(side) = to.as_mut() {
+            side.global = to_global;
+        }
         if needs_paths {
             if let Some(side) = from.as_mut() {
                 side.path = Some(
@@ -827,7 +867,7 @@ where
             row_pk,
             diff_type: diff_type(kind),
             row_count: i64::try_from(group.row_count).map_err(|_| {
-                DataFusionError::Execution("lix_diff row_count exceeds INT8".to_string())
+                DataFusionError::Execution("lix_diff lixcol_row_count exceeds INT8".to_string())
             })?,
             from,
             to,
@@ -842,6 +882,8 @@ async fn directory_diff_rows<S>(
     projection: &Schema,
     from_commit_id: &str,
     to_commit_id: &str,
+    from_global: bool,
+    to_global: bool,
 ) -> Result<Vec<DiffSqlRow>>
 where
     S: StorageAdapterRead,
@@ -850,7 +892,7 @@ where
         .fields()
         .iter()
         .any(|field| matches!(field.name().as_str(), "from_path" | "to_path"));
-    let mut rows = schema_diff_rows(diff, projection)?;
+    let mut rows = schema_diff_rows(diff, projection, from_global, to_global)?;
     if needs_paths {
         let mut from_directory_cache = HashMap::new();
         let mut to_directory_cache = HashMap::new();
@@ -1023,7 +1065,7 @@ fn diff_record_batch(schema: SchemaRef, rows: &[DiffSqlRow]) -> Result<RecordBat
 
 fn diff_column_array(field: &Field, rows: &[DiffSqlRow]) -> Result<ArrayRef> {
     match field.name().as_str() {
-        "row_pk" => Ok(Arc::new(StringArray::from(
+        "lixcol_row_pk" => Ok(Arc::new(StringArray::from(
             rows.iter()
                 .map(|row| {
                     row.row_pk
@@ -1032,10 +1074,10 @@ fn diff_column_array(field: &Field, rows: &[DiffSqlRow]) -> Result<ArrayRef> {
                 })
                 .collect::<Result<Vec<_>>>()?,
         ))),
-        "diff_type" => Ok(Arc::new(StringArray::from_iter_values(
+        "lixcol_diff_type" => Ok(Arc::new(StringArray::from_iter_values(
             rows.iter().map(|row| row.diff_type),
         ))),
-        "row_count" => Ok(Arc::new(Int64Array::from_iter_values(
+        "lixcol_row_count" => Ok(Arc::new(Int64Array::from_iter_values(
             rows.iter().map(|row| row.row_count),
         ))),
         name => {
@@ -1193,15 +1235,15 @@ mod tests {
         assert_eq!(
             &names[..6],
             &[
-                "row_pk",
-                "diff_type",
+                "lixcol_row_pk",
+                "lixcol_diff_type",
                 "from_key",
                 "to_key",
                 "from_value",
                 "to_value"
             ]
         );
-        assert_eq!(names.last(), Some(&"row_count"));
+        assert_eq!(names.last(), Some(&"lixcol_row_count"));
         assert!(!names.contains(&"diff_id"));
         assert!(!names.contains(&"before_change_id"));
         assert!(!names.contains(&"after_change_id"));
@@ -1230,7 +1272,11 @@ mod tests {
     fn relation_diff_pushes_schema_identity_without_loading_payloads() {
         let relation = DiffRelation::from_catalog(PublicCatalog::fixed_system(), "lix_key_value")
             .expect("key/value relation is registered");
-        let projection = Schema::new(vec![Field::new("row_count", DataType::Int64, false)]);
+        let projection = Schema::new(vec![Field::new(
+            "lixcol_row_count",
+            DataType::Int64,
+            false,
+        )]);
         let route = DiffRoute::from_filters(&[], &relation, &projection);
 
         assert_eq!(route.request.filter.schema_keys, vec!["lix_key_value"]);

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -1836,7 +1836,7 @@ fn directory_snapshot_from_live_row(
         .transpose()
 }
 
-fn lix_directory_record_batch(
+pub(super) fn lix_directory_record_batch(
     schema: &SchemaRef,
     rows: &MaterializedHotStateBatch,
 ) -> Result<RecordBatch, LixError> {

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -41,7 +41,6 @@ use crate::filesystem::{
     FilesystemPathSelection,
 };
 use crate::functions::FunctionProviderHandle;
-#[cfg(test)]
 use crate::hot_state::MaterializedHotStateRow;
 use crate::hot_state::{
     HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter, HotStateProjection,
@@ -4343,7 +4342,6 @@ fn file_path_resolver_key(context: &FilesystemRowContext) -> String {
     )
 }
 
-#[cfg(test)]
 async fn lix_file_record_batch(
     schema: &SchemaRef,
     blob_reader: &Arc<dyn BlobDataReader>,
@@ -4357,6 +4355,24 @@ async fn lix_file_record_batch(
     )?;
     lix_file_record_batch_from_prepared(schema, blob_reader, plugin_render, load_data, prepared)
         .await
+}
+
+pub(super) async fn lix_file_state_record_batch(
+    schema: &SchemaRef,
+    blob_reader: &Arc<dyn BlobDataReader>,
+    load_data: bool,
+    rows: Vec<MaterializedHotStateRow>,
+) -> Result<RecordBatch, LixError> {
+    let prepared = prepare_lix_file_rows(
+        MaterializedHotStateBatch::from_rows(rows),
+        &FilePathPredicate::All,
+    )?;
+    if prepared.needs_plugin_render(load_data) {
+        return Err(invalid_plugin_read_state(
+            "historical plugin-owned file is missing its durable materialization",
+        ));
+    }
+    lix_file_record_batch_from_prepared(schema, blob_reader, None, load_data, prepared).await
 }
 
 struct PreparedLixFileRows {

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -30,6 +30,9 @@ mod history_table_function;
 mod history_util;
 mod schema;
 mod schema_history;
+mod state_at;
+#[cfg(test)]
+pub(crate) use state_at::{arm_state_at_traversal_probe, take_state_at_traversal_probe};
 mod spec;
 pub(crate) use spec::{PhysicalScanKey, SpecScanExec, StatementScanKey};
 mod upsert;
@@ -89,6 +92,18 @@ where
         .is_some_and(|surface| selection.includes(surface))
     {
         diff::register_diff_function(session, ctx.changelog_query_source(), Arc::clone(&catalog));
+    }
+    if catalog
+        .surface("lix_state_at")
+        .is_some_and(|surface| selection.includes(surface))
+    {
+        state_at::register_state_at_function(
+            session,
+            ctx.changelog_query_source(),
+            Arc::clone(&catalog),
+            ctx.active_branch_id().to_string(),
+            ctx.blob_reader(),
+        );
     }
     register_read_from_catalog(
         session,
@@ -222,7 +237,7 @@ pub(crate) fn read_provider_selection(
     // live one.
     for statement in statements {
         collect_history_relation_literals(statement, &mut history_relations);
-        collect_diff_relation_literals(statement, &mut names);
+        collect_dynamic_relation_literals(statement, &mut names);
         if statement_requires_all_providers(statement) {
             requires_all = true;
             continue;
@@ -318,7 +333,7 @@ fn collect_history_relation_literals(
 /// Diff results inherit their relation's Arrow schema, so runtime schema
 /// literals must participate in snapshot-local catalog selection even though
 /// DataFusion only resolves the table-function name itself.
-fn collect_diff_relation_literals(
+fn collect_dynamic_relation_literals(
     statement: &datafusion::sql::parser::Statement,
     relations: &mut BTreeSet<String>,
 ) {
@@ -347,7 +362,9 @@ fn collect_diff_relation_literals(
             else {
                 return ControlFlow::Continue(());
             };
-            if !crate::sql2::parse::object_name_is_public_function(name, "lix_diff") {
+            if !crate::sql2::parse::object_name_is_public_function(name, "lix_diff")
+                && !crate::sql2::parse::object_name_is_public_function(name, "lix_state_at")
+            {
                 return ControlFlow::Continue(());
             }
             let Some(FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(value)))) =
@@ -367,7 +384,7 @@ fn collect_diff_relation_literals(
             let _ = statement.visit(&mut DiffRelationVisitor(relations));
         }
         DataFusionStatement::Explain(explain) => {
-            collect_diff_relation_literals(explain.statement.as_ref(), relations);
+            collect_dynamic_relation_literals(explain.statement.as_ref(), relations);
         }
         _ => {}
     }
@@ -562,6 +579,7 @@ where
             PublicSurfaceKind::SchemaBase { .. }
             | PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::StateAtFunction
             | PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
             | PublicSurfaceKind::CreateCheckpoint
@@ -676,6 +694,18 @@ where
             Arc::clone(&catalog),
         );
     }
+    if catalog
+        .surface("lix_state_at")
+        .is_some_and(|surface| selection.includes(surface))
+    {
+        state_at::register_state_at_function(
+            session,
+            read_ctx.changelog_query_source(),
+            Arc::clone(&catalog),
+            read_ctx.active_branch_id().to_string(),
+            read_ctx.blob_reader(),
+        );
+    }
     register_read_from_catalog(
         session,
         read_ctx,
@@ -769,6 +799,7 @@ async fn register_write_from_catalog(
             PublicSurfaceKind::Change
             | PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::StateAtFunction
             | PublicSurfaceKind::CommitAncestryFunction
             | PublicSurfaceKind::Restore => {}
             PublicSurfaceKind::SchemaBase { .. } => {}
@@ -1028,6 +1059,7 @@ mod tests {
                 "lix_commit_ancestry",
                 "lix_diff",
                 "lix_history",
+                "lix_state_at",
             ]
         );
         assert_eq!(
@@ -1044,8 +1076,8 @@ mod tests {
             ]
         );
         assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
-        assert_eq!(all_read + writable.len(), 20, "construction count");
-        assert_eq!(read_only.len() + writable.len(), 12, "surface count");
+        assert_eq!(all_read + writable.len(), 21, "construction count");
+        assert_eq!(read_only.len() + writable.len(), 13, "surface count");
     }
 
     #[test]

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -3720,13 +3720,13 @@ fn simple_string_primary_key_index(spec: &SchemaSurfaceSpec, column_name: &str) 
 /// decoder that visits only selected fields. This is a physical execution
 /// choice; the SQL schema and result contract are the same in both cases.
 #[derive(Clone, Copy)]
-enum RowBatchProjection {
+pub(super) enum RowBatchProjection {
     ParsedSnapshots,
     RawTrackedProjection,
 }
 
 impl RowBatchProjection {
-    fn for_request(request: &HotStateScanRequest) -> Self {
+    pub(super) fn for_request(request: &HotStateScanRequest) -> Self {
         if request.filter.row_pks.is_empty() {
             Self::RawTrackedProjection
         } else {
@@ -3735,7 +3735,7 @@ impl RowBatchProjection {
     }
 }
 
-fn row_record_batch(
+pub(super) fn row_record_batch(
     spec: &SchemaSurfaceSpec,
     schema: SchemaRef,
     rows: &MaterializedHotStateBatch,

--- a/packages/lix/src/sql2/providers/state_at.rs
+++ b/packages/lix/src/sql2/providers/state_at.rs
@@ -1,0 +1,635 @@
+use std::fmt;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::{TableFunctionImpl, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
+use datafusion::execution::context::ExecutionProps;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+
+use crate::binary_cas::BlobDataReader;
+use crate::changelog::{ChangeRecordProjection, CommitId};
+use crate::common::LixTimestamp;
+use crate::hot_state::{
+    HotStateProjection, HotStateScanRequest, MaterializedHotStateBatch,
+    MaterializedHotStateBatchBuilder, MaterializedHotStateRow,
+};
+use crate::row_pk::{RowPk, RowPkComponentType};
+use crate::sql2::SqlChangelogQuerySource;
+use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind, SchemaSurfaceSpec};
+use crate::sql2::error::lix_error_to_datafusion_error;
+use crate::sql2::udfs::{ExecutionSlots, execution_slots};
+use crate::storage_adapter::StorageAdapterRead;
+use crate::tracked_state::{
+    MaterializedTrackedStateBatch, MaterializedTrackedStateRow, TrackedStateContext,
+    TrackedStateFilter, TrackedStateKey, TrackedStateReadColumns, TrackedStateScanRequest,
+};
+
+use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
+use super::schema::{
+    RowBatchProjection, RowPrimaryKeyFilterAnalyzer, catalog_schema_spec, row_pks_from_primary_key_filters,
+};
+use super::spec::{PlannedScan, SpecTableProvider, TableSpec, projected_schema, scan_row_source};
+
+const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
+const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
+const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
+
+#[cfg(test)]
+static STATE_AT_TRAVERSAL_PROBES: OnceLock<
+    Mutex<
+        std::collections::HashMap<(std::thread::ThreadId, String), Vec<(usize, usize)>>,
+    >,
+> = OnceLock::new();
+
+#[cfg(test)]
+fn state_at_probe_key(commit_id: &str) -> (std::thread::ThreadId, String) {
+    (std::thread::current().id(), commit_id.to_owned())
+}
+
+#[cfg(test)]
+pub(crate) fn arm_state_at_traversal_probe(commit_id: &str) {
+    STATE_AT_TRAVERSAL_PROBES
+        .get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+        .lock()
+        .expect("state-at traversal probe lock should remain available")
+        .insert(state_at_probe_key(commit_id), Vec::new());
+}
+
+#[cfg(test)]
+pub(crate) fn take_state_at_traversal_probe(commit_id: &str) -> Vec<(usize, usize)> {
+    STATE_AT_TRAVERSAL_PROBES
+        .get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+        .lock()
+        .expect("state-at traversal probe lock should remain available")
+        .remove(&state_at_probe_key(commit_id))
+        .expect("state-at traversal probe should be armed")
+}
+
+#[cfg(test)]
+fn record_state_at_traversal_probe(commit_id: &str, request: &TrackedStateScanRequest) {
+    if let Some(probes) = STATE_AT_TRAVERSAL_PROBES.get()
+        && let Some(requests) = probes
+            .lock()
+            .expect("state-at traversal probe lock should remain available")
+            .get_mut(&state_at_probe_key(commit_id))
+    {
+        requests.push((request.filter.row_pks.len(), request.filter.file_ids.len()));
+    }
+}
+
+#[cfg(not(test))]
+fn record_state_at_traversal_probe(_commit_id: &str, _request: &TrackedStateScanRequest) {}
+
+#[cfg(test)]
+fn record_state_at_point_probe(commit_id: &str, requested: usize, resolved: usize) {
+    if let Some(probes) = STATE_AT_TRAVERSAL_PROBES.get()
+        && let Some(requests) = probes
+            .lock()
+            .expect("state-at traversal probe lock should remain available")
+            .get_mut(&state_at_probe_key(commit_id))
+    {
+        requests.push((requested, resolved));
+    }
+}
+
+#[cfg(not(test))]
+fn record_state_at_point_probe(_commit_id: &str, _requested: usize, _resolved: usize) {}
+
+pub(super) fn register_state_at_function<S>(
+    session: &datafusion::prelude::SessionContext,
+    query_source: SqlChangelogQuerySource<S>,
+    catalog: Arc<PublicCatalog>,
+    active_branch_id: String,
+    blob_reader: Arc<dyn BlobDataReader>,
+) where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    session.register_udtf(
+        "lix_state_at",
+        Arc::new(StateAtFunction {
+            store: query_source.store,
+            catalog,
+            slots: execution_slots(session),
+            active_branch_id,
+            blob_reader,
+        }),
+    );
+}
+
+struct StateAtFunction<S> {
+    store: S,
+    catalog: Arc<PublicCatalog>,
+    slots: Arc<ExecutionSlots>,
+    active_branch_id: String,
+    blob_reader: Arc<dyn BlobDataReader>,
+}
+
+impl<S> fmt::Debug for StateAtFunction<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("StateAtFunction").finish_non_exhaustive()
+    }
+}
+
+impl<S> TableFunctionImpl for StateAtFunction<S>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        let [relation, commit_id] = args else {
+            return Err(DataFusionError::Plan(
+                "lix_state_at requires a relation and exactly one commit ID argument".into(),
+            ));
+        };
+        let relation_name = text_argument(relation, 1, "relation name", None)?;
+        let commit_id = text_argument(commit_id, 2, "commit ID", Some(&self.slots))?;
+        let surface = self.catalog.surface(&relation_name).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "lix_state_at does not support relation '{relation_name}'"
+            ))
+        })?;
+        let schema = self.catalog.surface_schema(&relation_name).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "lix_state_at does not support relation '{relation_name}'"
+            ))
+        })?;
+        let kind = match &surface.kind {
+            PublicSurfaceKind::SchemaBase { schema_key } => StateRelationKind::Schema {
+                schema_key: schema_key.clone(),
+                spec: catalog_schema_spec(&self.catalog, schema_key)
+                    .map_err(lix_error_to_datafusion_error)?,
+            },
+            PublicSurfaceKind::File => StateRelationKind::File,
+            PublicSurfaceKind::Directory => StateRelationKind::Directory,
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "lix_state_at does not support relation '{relation_name}'"
+                )));
+            }
+        };
+        Ok(Arc::new(SpecTableProvider::new(Arc::new(StateAtSpec {
+            store: self.store.clone(),
+            relation_name,
+            kind,
+            schema,
+            commit_id,
+            root_commit_id: self.slots.root_commit_id(),
+            active_branch_id: self.active_branch_id.clone(),
+            blob_reader: Arc::clone(&self.blob_reader),
+        }))))
+    }
+}
+
+fn text_argument(
+    argument: &Expr,
+    position: usize,
+    expected: &str,
+    slots: Option<&ExecutionSlots>,
+) -> Result<String> {
+    if let (Expr::ScalarFunction(function), Some(slots)) = (argument, slots)
+        && function.args.is_empty()
+    {
+        let value = match function.func.name() {
+            "lix_root_commit_id" => slots.root_commit_id(),
+            "lix_active_branch_commit_id" => slots.active_branch_commit_id(),
+            _ => None,
+        };
+        if let Some(value) = value {
+            return Ok(value);
+        }
+    }
+    let Expr::Literal(value, _) = argument else {
+        return Err(DataFusionError::Plan(format!(
+            "lix_state_at argument {position} must be a {expected} literal or parameter"
+        )));
+    };
+    value.try_as_str().flatten().map(str::to_owned).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "lix_state_at argument {position} must be a non-null text {expected}"
+        ))
+    })
+}
+
+#[derive(Clone)]
+enum StateRelationKind {
+    Schema { schema_key: String, spec: Arc<SchemaSurfaceSpec> },
+    File,
+    Directory,
+}
+
+struct StateAtSpec<S> {
+    store: S,
+    relation_name: String,
+    kind: StateRelationKind,
+    schema: SchemaRef,
+    commit_id: String,
+    root_commit_id: Option<String>,
+    active_branch_id: String,
+    blob_reader: Arc<dyn BlobDataReader>,
+}
+
+#[async_trait]
+impl<S> TableSpec for StateAtSpec<S>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    fn table_name(&self) -> &str { "lix_state_at" }
+    fn schema(&self) -> SchemaRef { Arc::clone(&self.schema) }
+    fn table_type(&self) -> TableType { TableType::View }
+
+    fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
+        match &self.kind {
+            StateRelationKind::Schema { spec, .. } => {
+                let analyzer = RowPrimaryKeyFilterAnalyzer::new(spec);
+                if analyzer.supports(filter) {
+                    TableProviderFilterPushDown::Exact
+                } else if analyzer.contains_routable_conjunct(filter) {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            }
+            StateRelationKind::File | StateRelationKind::Directory => {
+                if exact_string_column_constraint_from_filters(std::slice::from_ref(filter), "id")
+                    .is_ok_and(|constraint| !matches!(constraint, FileIdConstraint::All))
+                {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            }
+        }
+    }
+
+    async fn plan_scan(
+        &self,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+        _props: &ExecutionProps,
+    ) -> Result<PlannedScan> {
+        let output_schema = projected_schema(&self.schema, projection);
+        let scan_limit = filters.is_empty().then_some(limit).flatten();
+        let row_pks = match &self.kind {
+            StateRelationKind::Schema { spec, .. } => row_pks_from_primary_key_filters(spec, filters)?,
+            StateRelationKind::File | StateRelationKind::Directory => {
+                match exact_string_column_constraint_from_filters(filters, "id")? {
+                    FileIdConstraint::All => None,
+                    FileIdConstraint::None => Some(Vec::new()),
+                    FileIdConstraint::Ids(ids) => Some(ids.iter().map(|id| uuid_row_pk(id)).collect::<Result<Vec<_>>>()?),
+                }
+            }
+        };
+        let contradictory = row_pks.as_ref().is_some_and(Vec::is_empty);
+        let kind = self.kind.clone();
+        let schema = Arc::clone(&output_schema);
+        let store = self.store.clone();
+        let commit_id = self.commit_id.clone();
+        let root_commit_id = self.root_commit_id.clone();
+        let active_branch_id = self.active_branch_id.clone();
+        let blob_reader = Arc::clone(&self.blob_reader);
+        let relation_name = self.relation_name.clone();
+        Ok(PlannedScan {
+            schema: Arc::clone(&output_schema),
+            ordering: None,
+            source: scan_row_source(
+                Arc::clone(&output_schema),
+                (store, kind, schema, commit_id, root_commit_id, active_branch_id, blob_reader, row_pks, contradictory),
+                move |(store, kind, schema, commit_id, root_commit_id, active_branch_id, blob_reader, row_pks, contradictory)| async move {
+                    if root_commit_id.as_deref() == Some(commit_id.as_str()) {
+                        return Ok(RecordBatch::new_empty(schema));
+                    }
+                    let commit_is_global = commit_root_is_global(store.clone(), &commit_id).await?;
+                    let mut tracked = TrackedStateContext::new().reader(store.clone());
+                    if contradictory {
+                        return Ok(RecordBatch::new_empty(schema));
+                    }
+                    let (batches, ancestor_rows) = match &kind {
+                        StateRelationKind::Schema { schema_key, .. } => {
+                            if let Some(row_pks) = row_pks.as_ref() {
+                                let rows = load_schema_points_at_commit(
+                                    &mut tracked,
+                                    &commit_id,
+                                    schema_key,
+                                    row_pks,
+                                )
+                                .await?;
+                                (Vec::new(), rows)
+                            } else {
+                                let request = tracked_request(
+                                    vec![schema_key.clone()],
+                                    None,
+                                    None,
+                                    scan_limit,
+                                );
+                                record_state_at_traversal_probe(&commit_id, &request);
+                                (
+                                    vec![tracked.scan_batch_at_commit(&commit_id, &request).await],
+                                    Vec::new(),
+                                )
+                            }
+                        }
+                        StateRelationKind::Directory => {
+                            let request = tracked_request(
+                                vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.into()],
+                                row_pks.clone(),
+                                row_pks
+                                    .as_ref()
+                                    .map(|_| vec![crate::NullableKeyFilter::Null]),
+                                None,
+                            );
+                            record_state_at_traversal_probe(&commit_id, &request);
+                            let batch = tracked.scan_batch_at_commit(&commit_id, &request).await;
+                            let ancestors = if row_pks.is_some() {
+                                match &batch {
+                                    Ok(batch) => load_ancestor_directories(&mut tracked, &commit_id, batch, "parent_id").await,
+                                    Err(_) => Ok(Vec::new()),
+                                }
+                            } else {
+                                Ok(Vec::new())
+                            }?;
+                            (vec![batch], ancestors)
+                        }
+                        StateRelationKind::File => {
+                            let file_ids = row_pks.as_ref().map(|keys| keys.iter().filter_map(single_row_pk_string).map(crate::NullableKeyFilter::Value).collect());
+                            let mut file_schema_keys = vec![FILE_DESCRIPTOR_SCHEMA_KEY.into()];
+                            if ["content", "lixcol_change_id", "lixcol_updated_at"]
+                                .iter()
+                                .any(|column| schema.index_of(column).is_ok())
+                            {
+                                file_schema_keys.push(BLOB_REF_SCHEMA_KEY.into());
+                            }
+                            let file_request = tracked_request(
+                                file_schema_keys,
+                                None,
+                                file_ids,
+                                None,
+                            );
+                            record_state_at_traversal_probe(&commit_id, &file_request);
+                            let file_batch = tracked
+                                .scan_batch_at_commit(&commit_id, &file_request)
+                                .await;
+                            if row_pks.is_some() {
+                                let ancestors = match &file_batch {
+                                    Ok(batch) => load_ancestor_directories(&mut tracked, &commit_id, batch, "directory_id").await,
+                                    Err(_) => Ok(Vec::new()),
+                                }?;
+                                (vec![file_batch], ancestors)
+                            } else {
+                                let directory_request = tracked_request(
+                                    vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.into()],
+                                    None,
+                                    None,
+                                    None,
+                                );
+                                record_state_at_traversal_probe(&commit_id, &directory_request);
+                                (vec![file_batch, tracked.scan_batch_at_commit(
+                                    &commit_id,
+                                    &directory_request,
+                                ).await], Vec::new())
+                            }
+                        }
+                    };
+                    let batches = batches.into_iter().collect::<std::result::Result<Vec<_>, _>>()
+                        .map_err(lix_error_to_datafusion_error)?;
+                    let hot = tracked_to_hot(
+                        &batches,
+                        ancestor_rows,
+                        &active_branch_id,
+                        commit_is_global,
+                    )?;
+                    let mut result = match kind {
+                        StateRelationKind::Schema { spec, .. } => {
+                            let request = HotStateScanRequest { projection: HotStateProjection::default(), ..Default::default() };
+                            super::schema::row_record_batch(&spec, schema, &hot, RowBatchProjection::for_request(&request))?
+                        }
+                        StateRelationKind::Directory => super::directory::lix_directory_record_batch(&schema, &hot)
+                            .map_err(lix_error_to_datafusion_error)?,
+                        StateRelationKind::File => super::file::lix_file_state_record_batch(
+                            &schema,
+                            &blob_reader,
+                            schema.index_of("content").is_ok(),
+                            hot.into_rows(),
+                        ).await.map_err(lix_error_to_datafusion_error)?,
+                    };
+                    if let Some(limit) = scan_limit {
+                        result = result.slice(0, result.num_rows().min(limit));
+                    }
+                    let _ = relation_name;
+                    Ok(result)
+                },
+            ),
+        })
+    }
+}
+
+async fn load_schema_points_at_commit<S: StorageAdapterRead + Clone>(
+    tracked: &mut crate::tracked_state::TrackedStateStoreReader<S>,
+    commit_id: &str,
+    schema_key: &str,
+    row_pks: &[RowPk],
+) -> Result<Vec<MaterializedTrackedStateRow>> {
+    let commit_id_typed = CommitId::parse_lix(commit_id, "lix_state_at commit ID")
+        .map_err(lix_error_to_datafusion_error)?;
+    let keys = tracked
+        .enumerate_schema_row_pk_keys_at_commit(commit_id_typed, schema_key, row_pks)
+        .await
+        .map_err(lix_error_to_datafusion_error)?;
+    record_state_at_point_probe(commit_id, row_pks.len(), keys.len());
+    Ok(tracked
+        .load_projected_batch_at_commit(commit_id, &keys, &ChangeRecordProjection::full())
+        .await
+        .map_err(lix_error_to_datafusion_error)?
+        .into_rows()
+        .into_iter()
+        .flatten()
+        .collect())
+}
+
+fn tracked_request(
+    schema_keys: Vec<String>,
+    row_pks: Option<Vec<RowPk>>,
+    file_ids: Option<Vec<crate::NullableKeyFilter<String>>>,
+    limit: Option<usize>,
+) -> TrackedStateScanRequest {
+    TrackedStateScanRequest {
+        filter: TrackedStateFilter {
+            schema_keys,
+            row_pks: row_pks.unwrap_or_default(),
+            file_ids: file_ids.unwrap_or_default(),
+            include_tombstones: false,
+            ..Default::default()
+        },
+        read_columns: TrackedStateReadColumns::default(),
+        limit,
+    }
+}
+
+async fn commit_root_is_global<S: StorageAdapterRead + Clone>(store: S, commit_id: &str) -> Result<bool> {
+    let commit_id = CommitId::parse_lix(commit_id, "lix_state_at commit ID")
+        .map_err(lix_error_to_datafusion_error)?;
+    let manifest = crate::tracked_state::load_published_commit_state_topology(&store, commit_id)
+        .await
+        .map_err(lix_error_to_datafusion_error)?
+        .ok_or_else(|| DataFusionError::Execution(format!("commit '{commit_id}' has no tracked-state authority")))?;
+    Ok(manifest.global_scope())
+}
+
+fn uuid_row_pk(id: &str) -> Result<RowPk> {
+    RowPk::from_json_values(
+        &[serde_json::Value::String(id.to_owned())],
+        &[RowPkComponentType::Uuid],
+    ).map_err(|error| DataFusionError::Plan(format!("invalid lix_state_at id: {error}")))
+}
+
+fn single_row_pk_string(row_pk: &RowPk) -> Option<String> {
+    match row_pk.as_json_array_value().ok()? {
+        serde_json::Value::Array(values) => match values.as_slice() {
+            [serde_json::Value::String(value)] => Some(value.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+async fn load_ancestor_directories<S: StorageAdapterRead>(
+    tracked: &mut crate::tracked_state::TrackedStateStoreReader<S>,
+    commit_id: &str,
+    initial: &MaterializedTrackedStateBatch,
+    parent_field: &str,
+) -> Result<Vec<MaterializedTrackedStateRow>> {
+    let mut pending = std::collections::BTreeSet::new();
+    for row in initial.iter() {
+        if let Some(parent) =
+            snapshot_text(row.decoded_snapshot(), row.snapshot_content(), parent_field)?
+        {
+            pending.insert(parent);
+        }
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut ancestors = Vec::new();
+    let load_budget = crate::transaction::MAX_DIRECTORY_PARENT_DEPTH
+        + usize::from(parent_field == "directory_id");
+    for _ in 0..load_budget {
+        let ids = pending.difference(&seen).cloned().collect::<Vec<_>>();
+        if ids.is_empty() {
+            return Ok(ancestors);
+        }
+        seen.extend(ids.iter().cloned());
+        let keys = ids
+            .iter()
+            .map(|id| {
+                Ok(TrackedStateKey {
+                    schema_key: DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                    file_id: None,
+                    row_pk: uuid_row_pk(id)?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let loaded = tracked
+            .load_projected_batch_at_commit(commit_id, &keys, &ChangeRecordProjection::full())
+            .await
+            .map_err(lix_error_to_datafusion_error)?;
+        pending.clear();
+        for row in loaded.into_rows().into_iter().flatten().filter(|row| !row.deleted) {
+            if let Some(parent) = snapshot_text(
+                row.decoded_snapshot.as_ref(),
+                row.snapshot_content.as_ref(),
+                "parent_id",
+            )? {
+                pending.insert(parent);
+            }
+            ancestors.push(row);
+        }
+    }
+    if pending.difference(&seen).next().is_none() {
+        Ok(ancestors)
+    } else {
+        Err(DataFusionError::Execution(format!(
+            "lix_state_at directory tree exceeds {} levels",
+            crate::transaction::MAX_DIRECTORY_PARENT_DEPTH
+        )))
+    }
+}
+
+fn snapshot_text(
+    decoded: Option<&Arc<crate::plugin::runtime::WasmTypedRow>>,
+    raw: Option<&crate::common::SharedStr>,
+    field: &str,
+) -> Result<Option<String>> {
+    if let Some(decoded) = decoded {
+        return match decoded.row.get(field) {
+            None | Some(lix_schema::Value::Null) => Ok(None),
+            Some(lix_schema::Value::Text(value)) => Ok(Some(value.clone())),
+            Some(lix_schema::Value::Uuid(value)) => Ok(Some(value.to_string())),
+            _ => Err(DataFusionError::Execution(format!(
+                "lix_state_at field '{field}' is not text"
+            ))),
+        };
+    }
+    let Some(raw) = raw else { return Ok(None) };
+    let value: serde_json::Value = serde_json::from_str(raw.as_str()).map_err(|error| {
+        DataFusionError::Execution(format!("invalid historical filesystem descriptor: {error}"))
+    })?;
+    Ok(value.get(field).and_then(serde_json::Value::as_str).map(str::to_owned))
+}
+
+fn tracked_to_hot(
+    batches: &[MaterializedTrackedStateBatch],
+    extra_rows: Vec<MaterializedTrackedStateRow>,
+    branch_id: &str,
+    commit_is_global: bool,
+) -> Result<MaterializedHotStateBatch> {
+    let mut builder = MaterializedHotStateBatchBuilder::with_capacity(
+        batches.iter().map(MaterializedTrackedStateBatch::len).sum::<usize>() + extra_rows.len(),
+    );
+    for row in batches.iter().flat_map(MaterializedTrackedStateBatch::iter).filter(|row| !row.deleted()) {
+        let ordinal = builder.len();
+        builder.push_owned(MaterializedHotStateRow {
+            row_pk: row.row_pk().clone(),
+            schema_key: row.schema_key().to_owned(),
+            file_id: row.file_id().map(str::to_owned),
+            snapshot_content: row.snapshot_content().cloned(),
+            metadata: row.metadata().cloned(),
+            deleted: false,
+            created_at: row.created_at(),
+            updated_at: row.updated_at(),
+            global: commit_is_global,
+            change_id: Some(row.change_id()),
+            commit_id: Some(row.commit_id()),
+            untracked: false,
+            branch_id: Arc::from(branch_id),
+        });
+        builder.set_decoded_snapshot(ordinal, row.decoded_snapshot().cloned());
+    }
+    for row in extra_rows.into_iter().filter(|row| !row.deleted) {
+        let ordinal = builder.len();
+        let created_at = LixTimestamp::parse(&row.created_at)
+            .map_err(|error| DataFusionError::Execution(format!("invalid created_at: {error}")))?;
+        let updated_at = LixTimestamp::parse(&row.updated_at)
+            .map_err(|error| DataFusionError::Execution(format!("invalid updated_at: {error}")))?;
+        let decoded_snapshot = row.decoded_snapshot.clone();
+        builder.push_owned(MaterializedHotStateRow {
+            row_pk: row.row_pk,
+            global: commit_is_global,
+            schema_key: row.schema_key,
+            file_id: row.file_id,
+            snapshot_content: row.snapshot_content,
+            metadata: row.metadata,
+            deleted: false,
+            created_at,
+            updated_at,
+            change_id: Some(row.change_id),
+            commit_id: Some(row.commit_id),
+            untracked: false,
+            branch_id: Arc::from(branch_id),
+        });
+        builder.set_decoded_snapshot(ordinal, decoded_snapshot);
+    }
+    Ok(builder.finish())
+}

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -245,7 +245,7 @@ pub(crate) async fn build_write_session_with_options(
 }
 
 fn statement_uses_execution_function(statement: &DataFusionStatement, function_name: &str) -> bool {
-    use datafusion::sql::sqlparser::ast::{Expr, Visit, Visitor};
+    use datafusion::sql::sqlparser::ast::{Expr, TableFactor, Visit, Visitor};
     use std::ops::ControlFlow;
 
     struct ExecutionFunctionVisitor<'a> {
@@ -261,6 +261,16 @@ fn statement_uses_execution_function(statement: &DataFusionStatement, function_n
                     &function.name,
                     self.function_name,
                 )
+            {
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(())
+        }
+
+        fn pre_visit_table_factor(&mut self, table: &TableFactor) -> ControlFlow<Self::Break> {
+            if self.function_name == "lix_root_commit_id"
+                && let TableFactor::Table { name, args: Some(_), .. } = table
+                && crate::sql2::parse::object_name_is_public_function(name, "lix_state_at")
             {
                 return ControlFlow::Break(());
             }

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -114,6 +114,7 @@ fn stage_bench_commit_deltas(
         &crate::tracked_state::CommitStateManifest {
             commit_id,
             change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            global_scope: false,
             replay_debt: crate::tracked_state::CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -123,6 +124,7 @@ fn stage_bench_commit_deltas(
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
             snapshot_root: None,
+            row_pk_index_root_id: None,
         },
     )?;
     Ok(staged.locators)
@@ -1844,6 +1846,7 @@ where
             &crate::tracked_state::CommitStateManifest {
                 commit_id: record.commit_id,
                 change_account_id: record.account_id.clone(),
+                global_scope: false,
                 replay_debt: crate::tracked_state::CommitStateReplayDebt {
                     depth: 1,
                     rows: 0,
@@ -1853,6 +1856,7 @@ where
                 touched_scope_filter: Default::default(),
                 current_state_scoped_ranges: None,
                 snapshot_root: None,
+                row_pk_index_root_id: None,
             },
         )?;
     }

--- a/packages/lix/src/sync/commit.rs
+++ b/packages/lix/src/sync/commit.rs
@@ -45,6 +45,8 @@ pub struct SyncCommit {
     pub parent_commit_ids: Vec<String>,
     pub account_id: String,
     pub created_at: String,
+    #[serde(default)]
+    pub global_scope: bool,
     pub selected_source_commit_id: Option<String>,
     /// Authenticated O(1) representation of a complete-state checkpoint.
     /// The source is a dependency and `state_root_id` binds the alias to the
@@ -455,6 +457,10 @@ where
             .collect(),
         account_id: record.account_id,
         created_at: record.created_at.to_string(),
+        global_scope: crate::tracked_state::load_published_commit_state_topology(store, commit_id)
+            .await?
+            .ok_or_else(|| LixError::unknown(format!("sync commit '{commit_id}' has no tracked-state authority")))?
+            .global_scope(),
         selected_source_commit_id: selected_source_commit_id.map(|source| source.to_string()),
         state_alias,
         members,
@@ -824,6 +830,7 @@ mod tests {
             parent_commit_ids: Vec::new(),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
             created_at: "2026-08-19T00:00:00Z".to_owned(),
+            global_scope: false,
             selected_source_commit_id: None,
             state_alias: None,
             members: vec![member("b", 1), member("a", 2)],
@@ -886,6 +893,7 @@ mod tests {
             parent_commit_ids: vec![parent.to_string()],
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
             created_at: "2026-08-19T00:00:00Z".to_owned(),
+            global_scope: false,
             selected_source_commit_id: None,
             state_alias: Some(SyncCommitStateAlias {
                 source_commit_id: source.to_string(),

--- a/packages/lix/src/sync/protocol.rs
+++ b/packages/lix/src/sync/protocol.rs
@@ -128,6 +128,8 @@ pub struct SyncCommitHeader {
     pub parent_commit_ids: Vec<String>,
     pub account_id: String,
     pub created_at: String,
+    #[serde(default)]
+    pub global_scope: bool,
     /// Monotonic authenticated generation used by commit topology checks.
     pub generation: u64,
     /// Optional logarithmic first-parent jump target.

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -41,11 +41,16 @@ use crate::tracked_state::{
     StagedCommitStateManifest, TRACKED_STATE_CHANGE_LOCATOR_SPACE, TrackedStateCommitDeltaRef,
     TrackedStateContext, TrackedStateDeltaRef, TrackedStateDiffRequest, TrackedStateFilter,
     TrackedStateKey, TrackedStateReadColumns, TrackedStateRootId, TrackedStateScanRequest,
-    commit_delta_member_scopes, commit_history_is_deferred, direct_change_locator,
+    TrackedStateChunkOverlay,
+    commit_delta_member_scopes, commit_history_is_deferred, deferred_commit_global_scope,
+    direct_change_locator,
     incomplete_touched_scope_filter, load_change_record_by_id, load_commit_state_manifest,
     load_published_commit_state_topology, stage_certified_commit_state_manifest_with_handle,
-    stage_change_locators, stage_commit_history_available, stage_commit_history_deferred,
+    stage_change_locators, stage_commit_history_available,
+    stage_commit_history_deferred_with_scope,
     stage_commit_state_manifest_with_handle,
+    stage_row_pk_index_from_deltas, stage_row_pk_index_from_members, staged_commit_delta_members,
+    staged_commit_delta_segment_bytes,
     stage_current_state_scoped_ranges_from_complete_state_source,
     stage_current_state_scoped_ranges_from_topology, stage_imported_addressable_commit_deltas,
 };
@@ -334,7 +339,7 @@ fn parse_sync_state_root_id(value: &str) -> Result<TrackedStateRootId, LixError>
     Ok(TrackedStateRootId::new(*hash.as_bytes()))
 }
 
-fn sync_header_from_record(record: &CommitRecord) -> SyncCommitHeader {
+fn sync_header_from_record(record: &CommitRecord, global_scope: bool) -> SyncCommitHeader {
     SyncCommitHeader {
         commit_id: record.commit_id.to_string(),
         parent_commit_ids: record
@@ -344,6 +349,7 @@ fn sync_header_from_record(record: &CommitRecord) -> SyncCommitHeader {
             .collect(),
         account_id: record.account_id.clone(),
         created_at: record.created_at.to_string(),
+        global_scope,
         generation: record.generation,
         first_parent_jump_commit_id: (record.first_parent_jump_span > 0)
             .then(|| record.first_parent_jump_commit_id.to_string()),
@@ -1065,6 +1071,7 @@ struct ParsedSyncHeader {
     parent_commit_ids: Vec<CommitId>,
     account_id: String,
     created_at: LixTimestamp,
+    global_scope: bool,
     generation: u64,
     first_parent_jump_commit_id: CommitId,
     first_parent_jump_span: u64,
@@ -1122,6 +1129,7 @@ impl ParsedSyncHeader {
             parent_commit_ids,
             account_id: header.account_id.clone(),
             created_at: parse_sync_timestamp("sync header createdAt", &header.created_at)?,
+            global_scope: header.global_scope,
             generation: header.generation,
             first_parent_jump_commit_id,
             first_parent_jump_span,
@@ -2782,6 +2790,24 @@ where
                         ),
                     ));
                 }
+                let existing_scope = match load_published_commit_state_topology(
+                    &read,
+                    header.commit_id,
+                )
+                .await?
+                {
+                    Some(topology) => Some(topology.global_scope()),
+                    None => deferred_commit_global_scope(&read, header.commit_id).await?,
+                };
+                if existing_scope.is_some_and(|scope| scope != header.global_scope) {
+                    return Err(LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!(
+                            "sync header '{}' conflicts with its existing branch scope",
+                            header.commit_id
+                        ),
+                    ));
+                }
                 records.insert(header.commit_id, existing);
             } else {
                 let record = header.record();
@@ -2799,6 +2825,7 @@ where
             if header.parent_commit_ids != commit.parent_commit_ids
                 || header.account_id != commit.account_id
                 || header.created_at != commit.created_at
+                || header.global_scope != commit.wire.global_scope
             {
                 return Err(LixError::new(
                     LixError::CODE_INVALID_PARAM,
@@ -2961,7 +2988,11 @@ where
             if snapshot_body_ids.contains(&commit_id) {
                 stage_commit_history_available(&mut writes, commit_id);
             } else {
-                stage_commit_history_deferred(&mut writes, commit_id);
+                stage_commit_history_deferred_with_scope(
+                    &mut writes,
+                    commit_id,
+                    header_by_id[&commit_id].global_scope,
+                );
             }
         }
         for (commit_id, commit) in &parsed_heads {
@@ -3058,6 +3089,7 @@ where
             })
             .await?;
 
+        let mut row_pk_index_overlay = TrackedStateChunkOverlay::new();
         for head in snapshot_body_ids.iter().copied() {
             let row_owner = branches
                 .iter()
@@ -3086,17 +3118,28 @@ where
             snapshot_root.changed_key_count = u64::try_from(parsed_heads[&head].members.len())
                 .map_err(|_| LixError::unknown("sync head mutation count exceeds u64"))?;
             snapshot_root.complete_state_fence = true;
+            let row_pk_index_root_id = stage_row_pk_index_from_deltas(
+                &read,
+                &mut writes,
+                &mut row_pk_index_overlay,
+                head_rows.iter().map(|row| row.as_root_delta()),
+                head,
+            )
+            .await?;
+            let mutations = head_mutations
+                .remove(&head)
+                .expect("head mutations were staged");
             stage_commit_state_manifest_with_handle(
                 &mut writes,
                 &CommitStateManifest {
                     commit_id: head,
                     change_account_id: parsed_heads[&head].account_id.clone(),
                     replay_debt: CommitStateReplayDebt::default(),
-                    mutations: head_mutations
-                        .remove(&head)
-                        .expect("head mutations were staged"),
+                    mutations,
                     touched_scope_filter: incomplete_touched_scope_filter(),
+                    global_scope: header_by_id[&head].global_scope,
                     current_state_scoped_ranges: None,
+                    row_pk_index_root_id,
                     snapshot_root: Some(Box::new(snapshot_root)),
                 },
             )?;
@@ -3300,9 +3343,31 @@ where
                         ),
                     ));
                 }
+                let existing_scope = match load_published_commit_state_topology(
+                    &read,
+                    header.commit_id,
+                )
+                .await?
+                {
+                    Some(topology) => Some(topology.global_scope()),
+                    None => deferred_commit_global_scope(&read, header.commit_id).await?,
+                };
+                if existing_scope.is_some_and(|scope| scope != header.global_scope) {
+                    return Err(LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!(
+                            "sync history header '{}' conflicts with its existing branch scope",
+                            header.commit_id
+                        ),
+                    ));
+                }
             } else {
                 new_records.push(header.record());
-                stage_commit_history_deferred(&mut writes, header.commit_id);
+                stage_commit_history_deferred_with_scope(
+                    &mut writes,
+                    header.commit_id,
+                    header.global_scope,
+                );
             }
         }
         if new_records.is_empty() {
@@ -3659,6 +3724,9 @@ where
                     if record.parent_commit_ids != commit.parent_commit_ids
                         || record.account_id != commit.account_id
                         || record.created_at != commit.created_at
+                        || deferred_commit_global_scope(&read, *commit_id)
+                            .await?
+                            .is_some_and(|scope| scope != commit.wire.global_scope)
                     {
                         return Err(LixError::new(
                             LixError::CODE_INVALID_PARAM,
@@ -4069,6 +4137,7 @@ where
         drop(tracked_writer);
 
         let mut staged_manifests = BTreeMap::<CommitId, StagedCommitStateManifest>::new();
+        let mut row_pk_index_overlay = TrackedStateChunkOverlay::new();
         let mut appended_records = Vec::new();
         let mut appended_changes = BTreeMap::<ChangeId, ChangeRecord>::new();
         for row in boundary_rows.values().flatten() {
@@ -4228,6 +4297,64 @@ where
                     None => CommitTouchedScopeDigest::opaque(),
                 }
             };
+            let row_pk_base_commit_id = if boundary_rows.contains_key(&commit_id) {
+                None
+            } else {
+                commit
+                    .state_alias
+                    .as_ref()
+                    .map(|(source_commit_id, _)| *source_commit_id)
+                    .or_else(|| commit.parent_commit_ids.first().copied())
+            };
+            let row_pk_base_root = row_pk_base_commit_id.and_then(|base_id| {
+                staged_manifests
+                    .get(&base_id)
+                    .and_then(|manifest| manifest.row_pk_index_root_id.as_ref())
+                    .or_else(|| {
+                        published_topologies
+                            .get(&base_id)
+                            .and_then(|manifest| manifest.row_pk_index_root_id())
+                    })
+            });
+            if row_pk_base_commit_id.is_some() && row_pk_base_root.is_none() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "sync commit '{commit_id}' has no row-PK index for serving base '{}'",
+                        row_pk_base_commit_id.expect("checked above")
+                    ),
+                ));
+            }
+            let row_pk_index_root_id = if let Some(rows) = boundary_rows.get(&commit_id) {
+                stage_row_pk_index_from_deltas(
+                    &read,
+                    &mut writes,
+                    &mut row_pk_index_overlay,
+                    rows.iter().map(ParsedSnapshotRow::as_root_delta),
+                    commit_id,
+                )
+                .await?
+            } else {
+                let staged_segments =
+                    staged_commit_delta_segment_bytes(&writes, commit_id, &mutations)?;
+                let row_pk_members = staged_commit_delta_members(
+                    &read,
+                    commit_id,
+                    &commit.account_id,
+                    &mutations,
+                    staged_segments,
+                )
+                .await?;
+                stage_row_pk_index_from_members(
+                    &read,
+                    &mut writes,
+                    &mut row_pk_index_overlay,
+                    row_pk_base_root,
+                    &row_pk_members,
+                    commit_id,
+                )
+                .await?
+            };
             let staged_manifest = if boundary_rows.contains_key(&commit_id) {
                 stage_commit_state_manifest_with_handle(
                     &mut writes,
@@ -4237,7 +4364,9 @@ where
                         replay_debt: CommitStateReplayDebt::default(),
                         mutations,
                         touched_scope_filter: incomplete_touched_scope_filter(),
+                        global_scope: commit.wire.global_scope,
                         current_state_scoped_ranges: None,
+                        row_pk_index_root_id,
                         snapshot_root: Some(Box::new(
                             imported_roots
                                 .remove(&commit_id)
@@ -4311,7 +4440,9 @@ where
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations,
                     touched_scope_filter: publication.touched_scope_filter().clone(),
+                    global_scope: commit.wire.global_scope,
                     current_state_scoped_ranges: publication.root(),
+                    row_pk_index_root_id,
                     snapshot_root: Some(Box::new(
                         imported_roots
                             .remove(&commit_id)
@@ -5061,7 +5192,15 @@ where
             let record = load_commit_record(&read, commit_id)
                 .await?
                 .expect("validated history boundary remains present");
-            commit_headers.push(sync_header_from_record(&record));
+            let global_scope = match load_published_commit_state_topology(&read, record.commit_id)
+                .await?
+            {
+                Some(topology) => topology.global_scope(),
+                None => deferred_commit_global_scope(&read, record.commit_id)
+                    .await?
+                    .unwrap_or(false),
+            };
+            commit_headers.push(sync_header_from_record(&record, global_scope));
         }
         let mut boundaries = Vec::with_capacity(boundary_ids.len());
         for commit_id in boundary_ids {
@@ -5602,7 +5741,7 @@ mod tests {
             .expect("load ancestor")
             .expect("ancestor exists");
         drop(read);
-        let mut merge_header = sync_header_from_record(&ancestor_record);
+        let mut merge_header = sync_header_from_record(&ancestor_record, false);
         merge_header.commit_id = merge.to_string();
         // The walker is LIFO. Put the absent parent last so it is visited
         // before the known ancestor and cannot mask the reachable path.
@@ -9198,6 +9337,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn deferred_history_body_rejects_header_scope_mismatch() {
+        let authority = open_lix().await.expect("authority should open");
+        let base = authority
+            .pull_sync_repository(None, 1)
+            .await
+            .expect("base snapshot should load");
+        let replica = replica_from_snapshot(&authority, &base).await;
+        write_key_value(&authority, "scope-mismatch", "body").await;
+        let snapshot = authority
+            .pull_sync_repository(None, 1)
+            .await
+            .expect("updated snapshot should load");
+        let (_, head) = default_head(&snapshot);
+        let history = authority
+            .sync_history(&head, 1)
+            .await
+            .expect("history should load");
+        replica
+            .import_sync_history_headers(&history.commit_headers)
+            .await
+            .expect("certified headers should import");
+        let mut rows = Vec::new();
+        for boundary in &history.boundaries {
+            let page = authority
+                .pull_sync_snapshot_rows(
+                    &boundary.commit_id,
+                    &boundary.commit_id,
+                    None,
+                    super::super::MAX_SYNC_REQUEST_ITEMS,
+                )
+                .await
+                .expect("boundary rows should load");
+            assert!(page.continuation.is_none());
+            rows.extend(page.rows);
+        }
+
+        let mut forged = history.commits.clone();
+        forged[0].global_scope = !forged[0].global_scope;
+        let error = replica
+            .import_sync_history_boundaries(&forged, &history.boundaries, &rows)
+            .await
+            .expect_err("history body must retain the header's immutable scope");
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+        assert!(
+            error.message.contains("body disagrees with its header"),
+            "unexpected error: {}",
+            error.message
+        );
+    }
+
+    #[tokio::test]
     async fn history_headers_reject_self_and_duplicate_parents() {
         let authority = open_lix().await.expect("authority should open");
         write_key_value(&authority, "header-parent", "child").await;
@@ -10258,7 +10448,7 @@ mod tests {
         );
         let peer_diff = peer
             .execute(
-                "SELECT row_pk, diff_type \
+                "SELECT lixcol_row_pk, lixcol_diff_type \
                  FROM lix_diff('lix_file', $1, lix_active_branch_commit_id())",
                 &[Value::Text(pushed_checkpoint.to_owned())],
             )
@@ -10343,7 +10533,7 @@ mod tests {
 
         let diff = replica
             .execute(
-                "SELECT diff_type FROM lix_diff('lix_file', $1, $2)",
+                "SELECT lixcol_diff_type FROM lix_diff('lix_file', $1, $2)",
                 &[Value::Text(checkpoint), Value::Text(head)],
             )
             .await
@@ -10351,7 +10541,7 @@ mod tests {
         assert_eq!(diff.rows().len(), 1);
         assert_eq!(
             diff.rows()[0]
-                .get::<String>("diff_type")
+                .get::<String>("lixcol_diff_type")
                 .expect("diff type should decode"),
             "modified",
         );
@@ -10533,7 +10723,7 @@ mod tests {
         let diff = loop {
             match replica
                 .execute(
-                    "SELECT row_pk ->> 0 AS file_id FROM lix_diff('lix_file', $1, $2)",
+                    "SELECT lixcol_row_pk ->> 0 AS file_id FROM lix_diff('lix_file', $1, $2)",
                     &[
                         Value::Text(previous_checkpoint.clone()),
                         Value::Text(latest_checkpoint.clone()),

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -1737,6 +1737,7 @@ mod tests {
             parent_commit_ids: Vec::new(),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
             created_at: "2026-01-01T00:00:00Z".to_owned(),
+            global_scope: false,
             selected_source_commit_id: None,
             state_alias: None,
             members: vec![super::super::commit::SyncCommitMember {

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -586,8 +586,8 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk = CAST('[\"selected\"]' AS JSONB)",
+                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
             )
             .await,
             &[],
@@ -595,7 +595,7 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
         .await
         .expect("selected working diff should be hot")
         .rows()[0]
-        .get::<serde_json::Value>("row_pk")
+        .get::<serde_json::Value>("lixcol_row_pk")
         .expect("selected primary key should decode");
     let head_commit_id_text = replica
         .lix
@@ -694,7 +694,7 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT row_pk FROM __LIX_RELATION_DIFF__ ORDER BY row_pk",
+                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ ORDER BY lixcol_row_pk",
             )
             .await,
             &[],
@@ -704,7 +704,7 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
     assert_eq!(remaining.rows().len(), 1);
     assert_eq!(
         remaining.rows()[0]
-            .get::<serde_json::Value>("row_pk")
+            .get::<serde_json::Value>("lixcol_row_pk")
             .expect("remaining row key"),
         serde_json::json!(["remaining"]),
     );
@@ -746,8 +746,8 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 				&replica.lix,
 				"lix_key_value",
 				"INSERT INTO lix_create_checkpoint (relation, row_pk) \
-				 SELECT 'lix_key_value', row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE row_pk = CAST('[\"working-00\"]' AS JSONB) \
+				 SELECT 'lix_key_value', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+				 WHERE lixcol_row_pk = CAST('[\"working-00\"]' AS JSONB) \
 				 RETURNING commit_id",
 			)
 			.await,
@@ -762,7 +762,7 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT row_pk FROM __LIX_RELATION_DIFF__ ORDER BY row_pk",
+				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ ORDER BY lixcol_row_pk",
 			)
 			.await,
 			&[],
@@ -771,7 +771,9 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 		.expect("unselected snapshot-local diff should remain readable");
 	assert_eq!(remaining.rows().len(), 49);
 	assert_eq!(
-		remaining.rows()[0].get::<serde_json::Value>("row_pk").unwrap(),
+		remaining.rows()[0]
+			.get::<serde_json::Value>("lixcol_row_pk")
+			.unwrap(),
 		serde_json::json!(["working-01"]),
 	);
 }
@@ -815,8 +817,8 @@ async fn partial_checkpoint_rebases_hot_epoch_without_cold_history(_sim: Simulat
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk = CAST('[\"owner-00\"]' AS JSONB)",
+                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                 WHERE lixcol_row_pk = CAST('[\"owner-00\"]' AS JSONB)",
             )
             .await,
             &[],
@@ -824,7 +826,7 @@ async fn partial_checkpoint_rebases_hot_epoch_without_cold_history(_sim: Simulat
         .await
         .expect("working diff should already be HOT")
         .rows()[0]
-        .get::<serde_json::Value>("row_pk")
+        .get::<serde_json::Value>("lixcol_row_pk")
         .expect("selected primary key should decode");
     assert!(
         crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
@@ -982,8 +984,8 @@ async fn partial_file_checkpoint_rebases_hot_epoch(_sim: Simulation) {
                 &replica.lix,
                 "lix_file",
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_file', row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk ->> 0 = $1 RETURNING commit_id",
+                 SELECT 'lix_file', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                 WHERE lixcol_row_pk ->> 0 = $1 RETURNING commit_id",
             )
             .await,
             &[Value::Text(selected_file_id)],
@@ -1105,8 +1107,8 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk ->> 0 = 'selected-recreate' RETURNING commit_id",
+                 SELECT 'lix_key_value', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                 WHERE lixcol_row_pk ->> 0 = 'selected-recreate' RETURNING commit_id",
             )
             .await,
             &[],
@@ -1136,7 +1138,7 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk ->> 0 = 'selected-recreate'",
+                 WHERE lixcol_row_pk ->> 0 = 'selected-recreate'",
             )
             .await,
             &[],
@@ -1154,7 +1156,7 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk ->> 0 = 'remaining'",
+                 WHERE lixcol_row_pk ->> 0 = 'remaining'",
             )
             .await,
             &[],
@@ -1174,7 +1176,7 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk ->> 0 = 'remaining'",
+                 WHERE lixcol_row_pk ->> 0 = 'remaining'",
             )
             .await,
             &[],
@@ -1262,7 +1264,7 @@ async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simul
                 &working_diff_sql(
                     &replica.lix,
                     "lix_file",
-                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE row_pk ->> 0 = $1",
+                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE lixcol_row_pk ->> 0 = $1",
                 )
                 .await,
                 &[Value::Text(selected_file_id.clone())],
@@ -1285,8 +1287,8 @@ async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simul
                     &replica.lix,
                     "lix_file",
                     "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                     SELECT 'lix_file', row_pk FROM __LIX_RELATION_DIFF__ \
-                     WHERE row_pk ->> 0 = $1 RETURNING commit_id",
+                     SELECT 'lix_file', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                     WHERE lixcol_row_pk ->> 0 = $1 RETURNING commit_id",
                 )
                 .await,
                 &[Value::Text(selected_file_id.clone())],
@@ -1314,7 +1316,7 @@ async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simul
                 &working_diff_sql(
                     &replica.lix,
                     "lix_file",
-                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE row_pk ->> 0 = $1",
+                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE lixcol_row_pk ->> 0 = $1",
                 )
                 .await,
                 &[Value::Text(selected_file_id)],
@@ -1366,8 +1368,8 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE row_pk = CAST('[\"selected\"]' AS JSONB)",
+				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+				 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
 			)
 			.await,
 			&[],
@@ -1375,7 +1377,7 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 		.await
 		.unwrap()
 		.rows()[0]
-		.get::<serde_json::Value>("row_pk")
+		.get::<serde_json::Value>("lixcol_row_pk")
 		.unwrap();
 	replica
 		.lix
@@ -1419,8 +1421,8 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE row_pk = CAST('[\"selected\"]' AS JSONB)",
+				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+				 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
 			)
 			.await,
 			&[],
@@ -1428,7 +1430,7 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 		.await
 		.unwrap()
 		.rows()[0]
-		.get::<serde_json::Value>("row_pk")
+		.get::<serde_json::Value>("lixcol_row_pk")
 		.unwrap();
 	let head_commit_id = replica
 		.lix
@@ -1567,8 +1569,8 @@ async fn partial_checkpoint_uncertified_index_uses_hot_primary_fallback(_sim: Si
                 &replica.lix,
                 "lix_key_value",
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE coalesce(row_pk ->> 0, '') = 'selected' RETURNING commit_id",
+                 SELECT 'lix_key_value', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                 WHERE coalesce(lixcol_row_pk ->> 0, '') = 'selected' RETURNING commit_id",
             )
             .await,
             &[],
@@ -1593,7 +1595,7 @@ async fn partial_checkpoint_uncertified_index_uses_hot_primary_fallback(_sim: Si
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT row_pk ->> 0 AS key FROM __LIX_RELATION_DIFF__",
+                "SELECT lixcol_row_pk ->> 0 AS key FROM __LIX_RELATION_DIFF__",
             )
             .await,
             &[],
@@ -1622,8 +1624,8 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE row_pk = CAST('[\"selected\"]' AS JSONB)",
+                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+                 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
             )
             .await,
             &[],
@@ -1631,7 +1633,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
         .await
         .unwrap()
         .rows()[0]
-        .get::<serde_json::Value>("row_pk")
+        .get::<serde_json::Value>("lixcol_row_pk")
         .unwrap();
 
     crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
@@ -1654,7 +1656,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT diff_type, row_pk FROM __LIX_RELATION_DIFF__",
+                "SELECT lixcol_diff_type, lixcol_row_pk FROM __LIX_RELATION_DIFF__",
             )
             .await,
             &[],
@@ -1662,10 +1664,15 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
         .await
         .unwrap();
     assert_eq!(remaining.rows().len(), 1);
-    assert_eq!(remaining.rows()[0].get::<String>("diff_type").unwrap(), "removed");
     assert_eq!(
         remaining.rows()[0]
-            .get::<serde_json::Value>("row_pk")
+            .get::<String>("lixcol_diff_type")
+            .unwrap(),
+        "removed"
+    );
+    assert_eq!(
+        remaining.rows()[0]
+            .get::<serde_json::Value>("lixcol_row_pk")
             .unwrap(),
         serde_json::json!(["removed"]),
     );
@@ -1678,7 +1685,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
                     &replica.lix,
                     "lix_key_value",
                     "SELECT COUNT(*) AS count FROM __LIX_RELATION_DIFF__ \
-                     WHERE diff_type = 'removed'",
+                     WHERE lixcol_diff_type = 'removed'",
                 )
                 .await,
                 &[],
@@ -1720,8 +1727,8 @@ async fn stale_partial_checkpoint_epoch_repairs_in_migration(_sim: Simulation) {
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE row_pk = CAST('[\"selected\"]' AS JSONB)",
+				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
+				 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
 			)
 			.await,
 			&[],
@@ -1729,7 +1736,7 @@ async fn stale_partial_checkpoint_epoch_repairs_in_migration(_sim: Simulation) {
 		.await
 		.unwrap()
 		.rows()[0]
-		.get::<serde_json::Value>("row_pk")
+		.get::<serde_json::Value>("lixcol_row_pk")
 		.unwrap();
 	replica
 		.lix

--- a/packages/lix/src/test_support.rs
+++ b/packages/lix/src/test_support.rs
@@ -571,7 +571,9 @@ fn stage_test_commit_state_manifest(
         replay_debt,
         mutations,
         touched_scope_filter: Default::default(),
+        global_scope: false,
         current_state_scoped_ranges: None,
+        row_pk_index_root_id: None,
         snapshot_root: snapshot_root.map(Box::new),
     };
     crate::tracked_state::stage_commit_state_manifest(writes, &manifest)

--- a/packages/lix/src/tracked_state/bench_support.rs
+++ b/packages/lix/src/tracked_state/bench_support.rs
@@ -56,6 +56,7 @@ fn stage_bench_commit_deltas(
         &CommitStateManifest {
             commit_id,
             change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            global_scope: false,
             replay_debt: CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -65,6 +66,7 @@ fn stage_bench_commit_deltas(
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
             snapshot_root: None,
+            row_pk_index_root_id: None,
         },
     )?;
     Ok(locators)
@@ -547,6 +549,7 @@ where
         let merged = CommitStateManifest {
             commit_id: merge_id,
             change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            global_scope: false,
             replay_debt: CommitStateReplayDebt {
                 depth: self
                     .current_manifest
@@ -561,6 +564,7 @@ where
             touched_scope_filter: publication.touched_scope_filter().clone(),
             current_state_scoped_ranges: publication.root(),
             snapshot_root: None,
+            row_pk_index_root_id: None,
         };
         super::storage::stage_certified_commit_state_manifest(&mut writes, &merged, &publication)
             .expect("stage certified benchmark merge manifest");
@@ -769,6 +773,7 @@ fn bench_current_state_manifest(
     CommitStateManifest {
         commit_id,
         change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+        global_scope: false,
         replay_debt: CommitStateReplayDebt {
             depth: replay_depth,
             rows: u64::from(mutations.member_count),
@@ -778,6 +783,7 @@ fn bench_current_state_manifest(
         touched_scope_filter,
         current_state_scoped_ranges,
         snapshot_root: None,
+        row_pk_index_root_id: None,
     }
 }
 

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -1095,6 +1095,53 @@ impl<S> TrackedStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    /// Enumerates every file-scoped identity that has used one of the exact
+    /// row PKs by this commit. The returned catalog is a monotonic superset;
+    /// callers must point-resolve the identities to filter deleted rows.
+    pub(crate) async fn enumerate_schema_row_pk_keys_at_commit(
+        &mut self,
+        commit_id: CommitId,
+        schema_key: &str,
+        row_pks: &[RowPk],
+    ) -> Result<Vec<TrackedStateKey>, LixError> {
+        if row_pks.is_empty() {
+            return Ok(Vec::new());
+        }
+        let manifest = storage::load_commit_state_manifest(&self.store, commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("commit '{commit_id}' has no commit-state manifest"),
+                )
+            })?;
+        let Some(root) = manifest.row_pk_index_root_id.as_ref() else {
+            if manifest
+                .snapshot_root
+                .as_ref()
+                .is_some_and(|root| root.row_count_estimate == 0)
+            {
+                return Ok(Vec::new());
+            }
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "commit '{commit_id}' has no row-PK index for point-in-time lookup"
+                ),
+            ));
+        };
+        let request = crate::tracked_state::row_pk_index_scan_request(schema_key, row_pks, false)?;
+        let entries = self.tree.scan(&self.store, root, &request).await?;
+        entries
+            .into_iter()
+            .map(|(key, _)| {
+                crate::tracked_state::decode_row_pk_index_key(
+                    &encode_key(&key),
+                )
+            })
+            .collect()
+    }
+
     pub(crate) async fn scan_batch_at_commit(
         &mut self,
         commit_id: &str,
@@ -4408,7 +4455,7 @@ where
                     )
                 })?,
         };
-        let root_id = source.root_id;
+        let root_id = source.root_id.clone();
         self.staged_roots.insert(
             commit_id.to_string(),
             TrackedStateCommitRoot {
@@ -5557,7 +5604,9 @@ mod tests {
             replay_debt: Default::default(),
             mutations: Default::default(),
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: Some(Box::new(snapshot_root)),
         };
         storage::stage_commit_state_manifest(writes, &manifest)

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -16,6 +16,7 @@ mod diff_id;
 mod merge;
 pub(crate) mod mutation_directory;
 pub(crate) mod replacement_part;
+mod row_pk_index;
 mod row_materialization;
 mod scoped_current_state;
 pub(crate) mod scoped_range;
@@ -58,6 +59,10 @@ pub(crate) use replacement_part::{
     EncodedReplacementPart, REPLACEMENT_PART_MAX_ROWS, REPLACEMENT_PART_TARGET_BYTES,
     ReplacementPartRowRef, encode_replacement_part_with_compressor,
 };
+pub(crate) use row_pk_index::{
+    backfill_row_pk_index_for_commit, decode_row_pk_index_key, row_pk_index_scan_request,
+    stage_row_pk_index_from_deltas, stage_row_pk_index_from_members,
+};
 pub(crate) use row_materialization::{
     MaterializedTrackedStateBatch, MaterializedTrackedStateExactBatch,
     MaterializedTrackedStateRowRef, materialize_batch_from_index_entries,
@@ -89,7 +94,9 @@ pub(crate) use storage::{
     CommitDeltaReplacementScope, EnvelopeCertifiedNativeProjectionBatch,
     EnvelopeCertifiedNativeProjectionSegment, ExclusiveRowSnapshotBatch,
     OrderedAddressableCommitDeltaStage, PublishedCommitStateTopology, StagedCommitStateManifest,
+    TrackedStateChunkOverlay,
     commit_delta_contains_schema, commit_delta_member_scopes, commit_history_is_deferred,
+    deferred_commit_global_scope,
     complete_state_fence_change_owner_commit_ids, direct_change_locator,
     deferred_commit_history_ids,
     encode_commit_state_manifest_replacement_for_migration, load_authoritative_live_change_records,
@@ -108,7 +115,9 @@ pub(crate) use storage::{
     stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_history_available,
-    stage_commit_history_deferred, stage_commit_state_manifest_with_handle,
+    stage_commit_history_deferred, stage_commit_history_deferred_with_scope,
+    stage_commit_state_manifest_with_handle,
+    staged_commit_delta_members, staged_commit_delta_segment_bytes,
     stage_current_state_scoped_ranges_from_complete_state_source,
     sync_history_required_for_commits,
     stage_current_state_scoped_ranges_from_published_parent,

--- a/packages/lix/src/tracked_state/row_pk_index.rs
+++ b/packages/lix/src/tracked_state/row_pk_index.rs
@@ -1,0 +1,411 @@
+//! Secondary commit-root identities ordered by `(schema_key, row_pk, file_id)`.
+//!
+//! The primary tracked-state tree is ordered by `(schema_key, file_id, row_pk)`.
+//! Re-encoding an identity as an otherwise ordinary tracked-state key lets the
+//! same persistent tree implementation serve row-primary-key prefix lookups.
+
+use crate::row_pk::RowPk;
+use crate::tracked_state::codec::{decode_key, encode_key_ref};
+use crate::tracked_state::types::{
+    CommitStateManifest, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
+    TrackedStateMutation, TrackedStateMutationBatch, TrackedStateRootId,
+    TrackedStateTreeScanRequest,
+};
+use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
+use crate::{LixError, NullableKeyFilter};
+
+const NULL_FILE_ID_TAG: &str = "n";
+const VALUE_FILE_ID_TAG: &str = "v";
+
+/// Re-encodes a primary-tree identity for the row-PK secondary tree.
+pub(crate) fn encode_row_pk_index_key(key: TrackedStateKeyRef<'_>) -> Result<Vec<u8>, LixError> {
+    let row_pk = typed_row_pk_text(key.row_pk)?;
+    let file_identity = match key.file_id {
+        Some(file_id) => RowPk::from_shared_parts(
+            [
+                VALUE_FILE_ID_TAG.into(),
+                serde_json::to_string(file_id)
+                    .map_err(|error| {
+                        row_pk_index_error(format!("failed to encode file ID: {error}"))
+                    })?
+                    .into(),
+            ]
+            .into_iter(),
+        ),
+        None => RowPk::from_shared_parts([NULL_FILE_ID_TAG.into()].into_iter()),
+    }
+    .map_err(row_pk_index_error)?;
+    Ok(encode_key_ref(TrackedStateKeyRef {
+        schema_key: key.schema_key,
+        file_id: Some(&row_pk),
+        row_pk: &file_identity,
+    }))
+}
+
+/// Decodes one row-PK secondary-tree identity back to its primary-tree form.
+pub(crate) fn decode_row_pk_index_key(encoded: &[u8]) -> Result<TrackedStateKey, LixError> {
+    let encoded = decode_key(encoded)?;
+    let row_pk = encoded
+        .file_id
+        .as_deref()
+        .ok_or_else(|| row_pk_index_error("secondary identity is missing its row-PK prefix"))?;
+    let row_pk_value = serde_json::from_str(row_pk)
+        .map_err(|_| row_pk_index_error("secondary identity has an invalid row-PK prefix"))?;
+    let row_pk = RowPk::from_typed_json_array_value(&row_pk_value).map_err(row_pk_index_error)?;
+    let parts = encoded.row_pk.into_parts();
+    let file_id = match parts.as_slice() {
+        [tag] if tag == NULL_FILE_ID_TAG => None,
+        [tag, file_id] if tag == VALUE_FILE_ID_TAG => Some(
+            serde_json::from_str(file_id)
+                .map_err(|_| row_pk_index_error("secondary identity has an invalid file ID"))?,
+        ),
+        _ => {
+            return Err(row_pk_index_error(
+                "secondary identity has an invalid file-id suffix",
+            ));
+        }
+    };
+    Ok(TrackedStateKey {
+        schema_key: encoded.schema_key,
+        file_id,
+        row_pk,
+    })
+}
+
+/// Builds the bounded tree request for one schema and an exact row-PK set.
+pub(crate) fn row_pk_index_scan_request(
+    schema_key: &str,
+    row_pks: &[RowPk],
+    include_tombstones: bool,
+) -> Result<TrackedStateTreeScanRequest, LixError> {
+    Ok(TrackedStateTreeScanRequest {
+        schema_keys: vec![schema_key.to_owned()],
+        file_ids: row_pks
+            .iter()
+            .map(typed_row_pk_text)
+            .map(|value| value.map(NullableKeyFilter::Value))
+            .collect::<Result<Vec<_>, _>>()?,
+        include_tombstones,
+        ..TrackedStateTreeScanRequest::default()
+    })
+}
+
+/// Retains the primary batch and derives its row-PK-index counterpart.
+///
+/// Values are immutable byte slices, so the secondary batch shares them rather
+/// than decoding and re-encoding lifecycle metadata.
+pub(crate) fn with_row_pk_index_mutations(
+    primary: TrackedStateMutationBatch,
+) -> Result<(TrackedStateMutationBatch, TrackedStateMutationBatch), LixError> {
+    let primary = primary.into_mutations();
+    let mut secondary = Vec::with_capacity(primary.len());
+    for mutation in &primary {
+        let key = decode_key(&mutation.encoded_key)?;
+        let encoded_key = encode_row_pk_index_key(TrackedStateKeyRef {
+            schema_key: &key.schema_key,
+            file_id: key.file_id.as_deref(),
+            row_pk: &key.row_pk,
+        })?;
+        secondary.push(TrackedStateMutation::from_shared(
+            encoded_key.into(),
+            mutation.encoded_value.clone(),
+        ));
+    }
+    Ok((
+        TrackedStateMutationBatch::from_shared(primary),
+        TrackedStateMutationBatch::from_shared(secondary),
+    ))
+}
+
+/// Stages the monotonic identity catalog transition for one commit.
+pub(crate) async fn stage_row_pk_index_from_members(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    overlay: &mut super::storage::TrackedStateChunkOverlay,
+    base_root: Option<&TrackedStateRootId>,
+    members: &[super::storage::CommitDeltaMember],
+    commit_id: crate::changelog::CommitId,
+) -> Result<Option<TrackedStateRootId>, LixError> {
+    let mut primary = crate::tracked_state::codec::TrackedStateMutationBatchBuilder::with_row_capacity(
+        members.len(),
+    );
+    for member in members {
+        primary.push(
+            TrackedStateKeyRef {
+                schema_key: &member.key.schema_key,
+                file_id: member.key.file_id.as_deref(),
+                row_pk: &member.key.row_pk,
+            },
+            TrackedStateIndexValueRef {
+                change_id: member.value.change_id,
+                commit_id: member.value.commit_id,
+                // This tree is an identity catalog, not current-state
+                // membership. Preserve deleted identities for later exact
+                // canonical resolution.
+                deleted: false,
+                created_at: member.value.created_at,
+                updated_at: member.value.updated_at,
+            },
+        );
+    }
+    let (_, secondary) = with_row_pk_index_mutations(primary.finish())?;
+    let result = super::tree::TrackedStateTree::new()
+        .apply_mutations_with_overlay(
+            store,
+            writes,
+            overlay,
+            base_root,
+            secondary,
+            Some(&commit_id.to_string()),
+        )
+        .await?;
+    Ok(Some(result.root_id))
+}
+
+/// Stages a complete identity catalog from an already materialized state.
+pub(crate) async fn stage_row_pk_index_from_deltas<'a>(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    overlay: &mut super::storage::TrackedStateChunkOverlay,
+    deltas: impl IntoIterator<Item = crate::tracked_state::TrackedStateDeltaRef<'a>>,
+    commit_id: crate::changelog::CommitId,
+) -> Result<Option<TrackedStateRootId>, LixError> {
+    let deltas = deltas.into_iter().collect::<Vec<_>>();
+    let mut primary = crate::tracked_state::codec::TrackedStateMutationBatchBuilder::with_row_capacity(
+        deltas.len(),
+    );
+    for delta in deltas {
+        primary.push(
+            TrackedStateKeyRef {
+                schema_key: delta.schema_key,
+                file_id: delta.file_id,
+                row_pk: delta.row_pk,
+            },
+            TrackedStateIndexValueRef {
+                change_id: delta.change_id,
+                commit_id: delta.commit_id,
+                deleted: false,
+                created_at: delta.created_at,
+                updated_at: delta.updated_at,
+            },
+        );
+    }
+    let (_, secondary) = with_row_pk_index_mutations(primary.finish())?;
+    let result = super::tree::TrackedStateTree::new()
+        .apply_mutations_with_overlay(
+            store,
+            writes,
+            overlay,
+            None,
+            secondary,
+            Some(&commit_id.to_string()),
+        )
+        .await?;
+    Ok(Some(result.root_id))
+}
+
+/// Offline v73 backfill for one immutable commit authority.
+pub(crate) async fn backfill_row_pk_index_for_commit(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    manifest: &CommitStateManifest,
+    max_rows: usize,
+) -> Result<(Option<TrackedStateRootId>, usize), LixError> {
+    let mut reader = crate::tracked_state::TrackedStateContext::new().reader(store);
+    let mut rows = Vec::new();
+    if manifest.snapshot_root.is_none() {
+        rows = reader
+            .scan_batch_at_commit(
+                &manifest.commit_id.to_string(),
+                &crate::tracked_state::TrackedStateScanRequest {
+                    limit: Some(max_rows.saturating_add(1)),
+                    ..Default::default()
+                },
+            )
+            .await?
+            .into_rows();
+    } else {
+        let mut exclusive_after = None;
+        loop {
+            let remaining = max_rows.saturating_sub(rows.len());
+            let request = crate::tracked_state::TrackedStateScanRequest {
+                limit: Some(remaining.saturating_add(1).min(4096)),
+                ..Default::default()
+            };
+            let page = reader
+                .scan_batch_at_commit_page(
+                    &manifest.commit_id.to_string(),
+                    &request,
+                    exclusive_after.as_ref(),
+                )
+                .await?;
+            if page.len() == 0 {
+                break;
+            }
+            let page_rows = page.into_rows();
+            let last = page_rows.last().expect("non-empty page has a final row");
+            exclusive_after = Some(TrackedStateKey {
+                schema_key: last.schema_key.clone(),
+                file_id: last.file_id.clone(),
+                row_pk: last.row_pk.clone(),
+            });
+            rows.extend(page_rows);
+            if rows.len() > max_rows {
+                break;
+            }
+        }
+    }
+    if rows.len() > max_rows {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "v73 row-PK-index migration exceeds configured row bound while scanning commit '{}'",
+                manifest.commit_id
+            ),
+        ));
+    }
+    let mut primary = crate::tracked_state::codec::TrackedStateMutationBatchBuilder::with_row_capacity(
+        rows.len(),
+    );
+    for row in &rows {
+        primary.push(
+            TrackedStateKeyRef {
+                schema_key: &row.schema_key,
+                file_id: row.file_id.as_deref(),
+                row_pk: &row.row_pk,
+            },
+            TrackedStateIndexValueRef {
+                change_id: row.change_id,
+                commit_id: row.commit_id,
+                deleted: false,
+                created_at: crate::common::LixTimestamp::parse(&row.created_at)
+                    .map_err(row_pk_index_error)?,
+                updated_at: crate::common::LixTimestamp::parse(&row.updated_at)
+                    .map_err(row_pk_index_error)?,
+            },
+        );
+    }
+    let (_, secondary) = with_row_pk_index_mutations(primary.finish())?;
+    let mut overlay = super::storage::TrackedStateChunkOverlay::new();
+    let result = super::tree::TrackedStateTree::new()
+        .apply_mutations_with_overlay(
+            store,
+            writes,
+            &mut overlay,
+            None,
+            secondary,
+            Some(&manifest.commit_id.to_string()),
+        )
+        .await?;
+    Ok((Some(result.root_id), rows.len()))
+}
+
+fn typed_row_pk_text(row_pk: &RowPk) -> Result<String, LixError> {
+    serde_json::to_string(&row_pk.as_typed_json_array_value()?)
+        .map_err(|error| row_pk_index_error(format!("failed to encode row PK: {error}")))
+}
+
+fn row_pk_index_error(message: impl std::fmt::Display) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked-state row-PK index {message}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
+    use crate::tracked_state::codec::{TrackedStateMutationBatchBuilder, encode_value_ref};
+    use crate::tracked_state::types::TrackedStateIndexValueRef;
+
+    fn identities() -> Vec<TrackedStateKey> {
+        vec![
+            TrackedStateKey {
+                schema_key: "schema".to_owned(),
+                file_id: None,
+                row_pk: RowPk::single("row"),
+            },
+            TrackedStateKey {
+                schema_key: "schema".to_owned(),
+                file_id: Some("01920000-0000-7000-8000-000000000001".to_owned()),
+                row_pk: RowPk::tuple(vec!["row".to_owned(), "part".to_owned()]).unwrap(),
+            },
+            TrackedStateKey {
+                schema_key: "schema\0escaped".to_owned(),
+                file_id: Some("file\0escaped".to_owned()),
+                row_pk: RowPk::uuid_from_canonical("01920000-0000-7000-8000-000000000002")
+                    .unwrap(),
+            },
+        ]
+    }
+
+    #[test]
+    fn synthetic_identity_round_trips_null_values_composites_and_escapes() {
+        for expected in identities() {
+            let encoded = encode_row_pk_index_key(TrackedStateKeyRef {
+                schema_key: &expected.schema_key,
+                file_id: expected.file_id.as_deref(),
+                row_pk: &expected.row_pk,
+            })
+            .unwrap();
+            assert_eq!(decode_row_pk_index_key(&encoded).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn typed_row_pk_prefix_does_not_alias_uuid_and_text() {
+        let uuid = RowPk::uuid_from_canonical("01920000-0000-7000-8000-000000000002").unwrap();
+        let text = RowPk::single("01920000-0000-7000-8000-000000000002");
+        assert_ne!(typed_row_pk_text(&uuid).unwrap(), typed_row_pk_text(&text).unwrap());
+    }
+
+    #[test]
+    fn scan_request_binds_row_pk_as_the_tree_file_prefix() {
+        let row_pks = vec![RowPk::single("a"), RowPk::single("b")];
+        let request = row_pk_index_scan_request("schema", &row_pks, false).unwrap();
+        assert_eq!(request.schema_keys, ["schema"]);
+        assert!(request.row_pks.is_empty());
+        assert!(!request.include_tombstones);
+        assert_eq!(
+            request.file_ids,
+            row_pks
+                .iter()
+                .map(|row_pk| NullableKeyFilter::Value(typed_row_pk_text(row_pk).unwrap()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn mutation_transform_preserves_primary_and_shares_values() {
+        let key = identities().remove(1);
+        let value = TrackedStateIndexValueRef {
+            change_id: ChangeId::for_test_label("row-pk-index-change"),
+            commit_id: CommitId::for_test_label("row-pk-index-commit"),
+            deleted: false,
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(1),
+            updated_at: LixTimestamp::from_unix_millis_utc_lossy(2),
+        };
+        let mut builder = TrackedStateMutationBatchBuilder::with_row_capacity(1);
+        builder.push(
+            TrackedStateKeyRef {
+                schema_key: &key.schema_key,
+                file_id: key.file_id.as_deref(),
+                row_pk: &key.row_pk,
+            },
+            value,
+        );
+        let original = builder.finish();
+        let original_key = original.as_slice()[0].encoded_key.clone();
+        let original_value = original.as_slice()[0].encoded_value.clone();
+        let (primary, secondary) = with_row_pk_index_mutations(original).unwrap();
+        assert_eq!(primary.as_slice()[0].encoded_key, original_key);
+        assert_eq!(secondary.as_slice()[0].encoded_value, original_value);
+        assert_eq!(
+            decode_row_pk_index_key(&secondary.as_slice()[0].encoded_key).unwrap(),
+            key
+        );
+        assert_eq!(secondary.as_slice()[0].encoded_value, encode_value_ref(value));
+    }
+}

--- a/packages/lix/src/tracked_state/scoped_current_state.rs
+++ b/packages/lix/src/tracked_state/scoped_current_state.rs
@@ -984,7 +984,9 @@ mod tests {
             },
             mutations,
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: None,
         }
     }

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -141,9 +141,11 @@ const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD18";
 // Version 10 splits the authority header from a separately keyed mutation
 // catalog and authenticates a content-addressed hierarchical part directory.
 // Version 11 adds the detached complete-state fence to snapshot-root metadata.
-// V10 remains readable because deployed repositories already contain these
-// immutable headers; the sync wire protocol itself has no compatibility lane.
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS11";
+// Version 12 authenticates the secondary `(schema_key, row_pk, file_id)`
+// identity tree beside the canonical snapshot root. V10 and V11 remain
+// readable for offline migration and historical compatibility.
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS12";
+const COMMIT_STATE_MANIFEST_V11_FORMAT_MAGIC: &[u8] = b"LXCS11";
 const COMMIT_STATE_MANIFEST_V10_FORMAT_MAGIC: &[u8] = b"LXCS10";
 // Version 3 authenticates direct-part ownership bitmaps. LXMI1 has a
 // materially different packed shape and is deliberately rejected.
@@ -743,8 +745,11 @@ struct StoredCommitStateManifest {
     #[musli(with = storage_codec::option)]
     mutation_directory_root: Option<super::mutation_directory::MutationDirectoryRoot>,
     touched_scope_filter: crate::tracked_state::types::CommitStateTouchedScopeFilter,
+    global_scope: bool,
     #[musli(with = storage_codec::option)]
     current_state_scoped_ranges: Option<Box<CurrentStateScopedRangeRoot>>,
+    #[musli(with = storage_codec::option)]
+    row_pk_index_root_id: Option<TrackedStateRootId>,
     #[musli(with = storage_codec::option)]
     snapshot_root: Option<Box<TrackedStateCommitRoot>>,
 }
@@ -772,6 +777,27 @@ struct StoredCommitStateManifestV10 {
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
+struct StoredCommitStateManifestV11 {
+    commit_id: CommitId,
+    change_account_id: String,
+    replay_debt: crate::tracked_state::CommitStateReplayDebt,
+    #[musli(with = storage_codec::option)]
+    selected_source_commit_id: Option<[u8; 16]>,
+    mutation_inventory_digest: [u8; 32],
+    mutation_transition_digest: [u8; 32],
+    mutation_member_count: u32,
+    mutation_part_count: u32,
+    #[musli(with = storage_codec::option)]
+    mutation_directory_root: Option<super::mutation_directory::MutationDirectoryRoot>,
+    touched_scope_filter: crate::tracked_state::types::CommitStateTouchedScopeFilter,
+    #[musli(with = storage_codec::option)]
+    current_state_scoped_ranges: Option<Box<CurrentStateScopedRangeRoot>>,
+    #[musli(with = storage_codec::option)]
+    snapshot_root: Option<Box<TrackedStateCommitRootV11>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
 struct TrackedStateCommitRootV10 {
     commit_id: CommitId,
     root_id: TrackedStateRootId,
@@ -779,6 +805,49 @@ struct TrackedStateCommitRootV10 {
     changed_key_count: u64,
     row_count_estimate: u64,
     tree_height: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct TrackedStateCommitRootV11 {
+    commit_id: CommitId,
+    root_id: TrackedStateRootId,
+    parent_roots: Vec<crate::tracked_state::types::TrackedStateCommitRootParent>,
+    changed_key_count: u64,
+    row_count_estimate: u64,
+    tree_height: u32,
+    complete_state_fence: bool,
+}
+
+impl From<StoredCommitStateManifestV11> for StoredCommitStateManifest {
+    fn from(stored: StoredCommitStateManifestV11) -> Self {
+        Self {
+            commit_id: stored.commit_id,
+            change_account_id: stored.change_account_id,
+            replay_debt: stored.replay_debt,
+            selected_source_commit_id: stored.selected_source_commit_id,
+            mutation_inventory_digest: stored.mutation_inventory_digest,
+            mutation_transition_digest: stored.mutation_transition_digest,
+            mutation_member_count: stored.mutation_member_count,
+            mutation_part_count: stored.mutation_part_count,
+            mutation_directory_root: stored.mutation_directory_root,
+            touched_scope_filter: stored.touched_scope_filter,
+            global_scope: false,
+            current_state_scoped_ranges: stored.current_state_scoped_ranges,
+            row_pk_index_root_id: None,
+            snapshot_root: stored.snapshot_root.map(|root| {
+                Box::new(TrackedStateCommitRoot {
+                    commit_id: root.commit_id,
+                    root_id: root.root_id,
+                    parent_roots: root.parent_roots,
+                    changed_key_count: root.changed_key_count,
+                    row_count_estimate: root.row_count_estimate,
+                    tree_height: root.tree_height,
+                    complete_state_fence: root.complete_state_fence,
+                })
+            }),
+        }
+    }
 }
 
 impl From<StoredCommitStateManifestV10> for StoredCommitStateManifest {
@@ -794,7 +863,9 @@ impl From<StoredCommitStateManifestV10> for StoredCommitStateManifest {
             mutation_part_count: stored.mutation_part_count,
             mutation_directory_root: stored.mutation_directory_root,
             touched_scope_filter: stored.touched_scope_filter,
+            global_scope: false,
             current_state_scoped_ranges: stored.current_state_scoped_ranges,
+            row_pk_index_root_id: None,
             snapshot_root: stored.snapshot_root.map(|root| {
                 Box::new(TrackedStateCommitRoot {
                     commit_id: root.commit_id,
@@ -3571,6 +3642,14 @@ impl PublishedCommitStateTopology {
 
     pub(crate) fn current_state_scoped_ranges(&self) -> Option<&CurrentStateScopedRangeRoot> {
         self.header.current_state_scoped_ranges.as_deref()
+    }
+
+    pub(crate) fn row_pk_index_root_id(&self) -> Option<&TrackedStateRootId> {
+        self.header.row_pk_index_root_id.as_ref()
+    }
+
+    pub(crate) fn global_scope(&self) -> bool {
+        self.header.global_scope
     }
 
     pub(crate) fn complete_state_source_commit_id(&self) -> Option<CommitId> {
@@ -9353,11 +9432,25 @@ fn authoritative_live_change_matches(
 /// The marker is staged atomically with the commit header. Its presence keeps
 /// a header-only replica from being confused with an authored empty commit.
 pub(crate) fn stage_commit_history_deferred(writes: &mut StorageWriteSet, commit_id: CommitId) {
+    stage_commit_history_deferred_with_scope(writes, commit_id, false);
+}
+
+/// Marks one known commit's tracked history as deferred while retaining the
+/// immutable branch-family provenance carried by its sync header.
+pub(crate) fn stage_commit_history_deferred_with_scope(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    global_scope: bool,
+) {
     writes.put(
         TRACKED_STATE_COMMIT_HISTORY_DEFERRED_SPACE,
         StorageKey(Bytes::from(commit_key(commit_id))),
         StorageValue {
-            bytes: Bytes::from_static(b"deferred"),
+            bytes: Bytes::from_static(if global_scope {
+                b"deferred-global"
+            } else {
+                b"deferred-local"
+            }),
         },
     );
 }
@@ -9390,6 +9483,32 @@ pub(crate) async fn commit_history_is_deferred(
     )
     .await?;
     Ok(result.value.into_iter().next().flatten().is_some())
+}
+
+/// Returns the immutable branch-family provenance retained with a deferred
+/// sync header. Legacy `deferred` markers predate global history and therefore
+/// decode as local scope.
+pub(crate) async fn deferred_commit_global_scope(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<bool>, LixError> {
+    let Some(bytes) = get_one(
+        store,
+        TRACKED_STATE_COMMIT_HISTORY_DEFERRED_SPACE,
+        commit_key(commit_id),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    match bytes.as_ref() {
+        b"deferred" | b"deferred-local" => Ok(Some(false)),
+        b"deferred-global" => Ok(Some(true)),
+        _ => Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("commit '{commit_id}' has an invalid deferred-history marker"),
+        )),
+    }
 }
 
 pub(crate) async fn has_deferred_commit_history(
@@ -16073,7 +16192,9 @@ fn encode_commit_state_manifest(
         })?,
         mutation_directory_root: stored_inventory.directory_root.clone(),
         touched_scope_filter: manifest.touched_scope_filter.clone(),
+        global_scope: manifest.global_scope,
         current_state_scoped_ranges: manifest.current_state_scoped_ranges.clone(),
+        row_pk_index_root_id: manifest.row_pk_index_root_id.clone(),
         snapshot_root: manifest.snapshot_root.clone(),
     };
     let header_payload = storage_codec::encode("tracked_state commit_state_manifest", &header)?;
@@ -16385,7 +16506,9 @@ fn assemble_commit_state_manifest(
         replay_debt: stored.replay_debt,
         mutations,
         touched_scope_filter: stored.touched_scope_filter,
+        global_scope: stored.global_scope,
         current_state_scoped_ranges: stored.current_state_scoped_ranges,
+        row_pk_index_root_id: stored.row_pk_index_root_id,
         snapshot_root: stored.snapshot_root,
     };
     if u32::try_from(manifest.mutations.part_count()).ok() != Some(stored.mutation_part_count) {
@@ -16472,7 +16595,9 @@ fn assemble_shallow_commit_state_manifest(
         replay_debt: stored.replay_debt,
         mutations,
         touched_scope_filter: stored.touched_scope_filter,
+        global_scope: stored.global_scope,
         current_state_scoped_ranges: stored.current_state_scoped_ranges,
+        row_pk_index_root_id: stored.row_pk_index_root_id,
         snapshot_root: stored.snapshot_root,
     })
 }
@@ -16495,6 +16620,10 @@ fn decode_stored_commit_state_manifest(
 ) -> Result<StoredCommitStateManifest, LixError> {
     let stored = if let Some(payload) = bytes.strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC) {
         storage_codec::decode("tracked_state commit_state_manifest", payload)?
+    } else if let Some(payload) = bytes.strip_prefix(COMMIT_STATE_MANIFEST_V11_FORMAT_MAGIC) {
+        let stored: StoredCommitStateManifestV11 =
+            storage_codec::decode("tracked_state v11 commit_state_manifest", payload)?;
+        stored.into()
     } else if let Some(payload) = bytes.strip_prefix(COMMIT_STATE_MANIFEST_V10_FORMAT_MAGIC) {
         let stored: StoredCommitStateManifestV10 =
             storage_codec::decode("tracked_state v10 commit_state_manifest", payload)?;
@@ -17686,7 +17815,9 @@ mod tests {
             },
             mutations,
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: None,
         }
     }
@@ -22396,7 +22527,9 @@ mod tests {
                 parts: Vec::new(),
             },
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: None,
         }
     }
@@ -22454,7 +22587,9 @@ mod tests {
                 parts,
             },
             touched_scope_filter: Default::default(),
+            global_scope: false,
             current_state_scoped_ranges: None,
+            row_pk_index_root_id: None,
             snapshot_root: None,
         }
     }
@@ -22708,6 +22843,64 @@ mod tests {
             .expect("deployed v10 manifest should remain readable");
         assert_eq!(decoded, stored);
         assert!(!decoded.snapshot_root.unwrap().complete_state_fence);
+    }
+
+    #[test]
+    fn commit_state_manifest_v11_decodes_without_a_row_pk_index() {
+        let mut manifest = commit_state_manifest_fixture();
+        manifest.replay_debt = CommitStateReplayDebt::default();
+        manifest.snapshot_root = Some(Box::new(TrackedStateCommitRoot {
+            commit_id: manifest.commit_id,
+            root_id: TrackedStateRootId::new([1; 32]),
+            parent_roots: Vec::new(),
+            changed_key_count: 1,
+            row_count_estimate: 1,
+            tree_height: 1,
+            complete_state_fence: true,
+        }));
+        let encoded = encode_commit_state_manifest(&manifest).expect("current fixture should encode");
+        let stored: super::StoredCommitStateManifest = storage_codec::decode(
+            "tracked_state current commit_state_manifest fixture",
+            encoded
+                .header
+                .strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC)
+                .expect("fixture has current magic"),
+        )
+        .expect("current fixture header should decode");
+        let legacy = super::StoredCommitStateManifestV11 {
+            commit_id: stored.commit_id,
+            change_account_id: stored.change_account_id.clone(),
+            replay_debt: stored.replay_debt,
+            selected_source_commit_id: stored.selected_source_commit_id,
+            mutation_inventory_digest: stored.mutation_inventory_digest,
+            mutation_transition_digest: stored.mutation_transition_digest,
+            mutation_member_count: stored.mutation_member_count,
+            mutation_part_count: stored.mutation_part_count,
+            mutation_directory_root: stored.mutation_directory_root.clone(),
+            touched_scope_filter: stored.touched_scope_filter.clone(),
+            current_state_scoped_ranges: stored.current_state_scoped_ranges.clone(),
+            snapshot_root: stored.snapshot_root.as_ref().map(|root| {
+                Box::new(super::TrackedStateCommitRootV11 {
+                    commit_id: root.commit_id,
+                    root_id: root.root_id.clone(),
+                    parent_roots: root.parent_roots.clone(),
+                    changed_key_count: root.changed_key_count,
+                    row_count_estimate: root.row_count_estimate,
+                    tree_height: root.tree_height,
+                    complete_state_fence: root.complete_state_fence,
+                })
+            }),
+        };
+        let payload =
+            storage_codec::encode("tracked_state v11 commit_state_manifest fixture", &legacy)
+                .expect("v11 fixture should encode");
+        let mut bytes = super::COMMIT_STATE_MANIFEST_V11_FORMAT_MAGIC.to_vec();
+        bytes.extend_from_slice(&payload);
+
+        let decoded = super::decode_stored_commit_state_manifest(&bytes)
+            .expect("deployed v11 manifest should remain readable");
+        assert_eq!(decoded.row_pk_index_root_id, None);
+        assert!(decoded.snapshot_root.unwrap().complete_state_fence);
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/types.rs
+++ b/packages/lix/src/tracked_state/types.rs
@@ -508,8 +508,17 @@ pub(crate) struct CommitStateManifest {
     pub(crate) replay_debt: CommitStateReplayDebt,
     pub(crate) mutations: CommitStateMutationInventory,
     pub(crate) touched_scope_filter: CommitStateTouchedScopeFilter,
+    /// Immutable branch scope in which this commit was authored.
+    pub(crate) global_scope: bool,
     #[musli(with = crate::storage_codec::option)]
     pub(crate) current_state_scoped_ranges: Option<Box<CurrentStateScopedRangeRoot>>,
+    /// Monotonic identity catalog ordered by `(schema_key, row_pk, file_id)`.
+    ///
+    /// The catalog is published for every commit, including rootless replay
+    /// commits. Entries may outlive a row deletion; readers resolve each
+    /// candidate against canonical point-in-time state before returning it.
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) row_pk_index_root_id: Option<TrackedStateRootId>,
     /// Canonical snapshot metadata when this commit was published as a root
     /// fence. The tree chunks are rebuildable by content hash; this immutable
     /// pointer is the authority that permits readers to serve them.

--- a/packages/lix/src/transaction/bench_support.rs
+++ b/packages/lix/src/transaction/bench_support.rs
@@ -692,7 +692,9 @@ mod tests {
 
         let inserted = fixture.insert_all_accounting().await;
         assert_eq!(inserted.logical_rows, BULK_ROWS);
-        assert!(inserted.staged_puts < 30, "{inserted:?}");
+        // The v74 row-PK index adds a bounded set of authenticated tree chunks
+        // while remaining independent of one-put-per-row publication.
+        assert!(inserted.staged_puts < 50, "{inserted:?}");
         assert_eq!(fixture.read_all().await, BULK_ROWS);
 
         let point_update = fixture.update_one_by_pk_accounting().await;
@@ -709,14 +711,15 @@ mod tests {
         // of being mirrored into a reverse-index space.
         //
         // The json_store epoch is the tenth staged put; the two retirement
-        // authority records bring the fixed total to twelve. They add one
+        // authority records and two row-PK index updates bring the fixed total
+        // to fourteen. They add one
         // space, batch, and storage call independent of repository scale. The
         // json_store epoch itself costs no extra space, batch, or call — the
         // revision space is already in this write set and its one-byte keys are
         // adjacent — and it is what lets the payload sweep reclaim superseded
         // out-of-band JSON at all: those rows are content addressed, so a
         // publisher can resolve onto a row an earlier sweep plan marked dead.
-        assert_eq!(point_update.staged_puts, 12, "{point_update:?}");
+        assert_eq!(point_update.staged_puts, 14, "{point_update:?}");
         assert_eq!(point_update.touched_spaces, 9, "{point_update:?}");
         assert_eq!(point_update.put_batches, 9, "{point_update:?}");
 
@@ -729,7 +732,7 @@ mod tests {
         bulk_fixture.insert_all().await;
         let updated = bulk_fixture.update_all_accounting().await;
         assert_eq!(updated.logical_rows, BULK_ROWS);
-        assert!(updated.staged_puts < 30, "{updated:?}");
+        assert!(updated.staged_puts < 50, "{updated:?}");
         assert_eq!(bulk_fixture.read_all().await, BULK_ROWS);
 
         let deleted = bulk_fixture.delete_all_accounting().await;

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -720,6 +720,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             &staged_delta_index,
             &checkpoint_state_sources,
             &staged_snapshot_roots,
+            &commit_rows
+                .iter()
+                .filter(|commit| commit.global_scope)
+                .map(|commit| commit.commit_id)
+                .collect(),
         )?
     } else {
         Vec::new()
@@ -2260,6 +2265,7 @@ fn materialize_staged_sync_commits(
     staged_delta_index: &StagedCommitDeltaIndex,
     checkpoint_state_sources: &BTreeMap<CommitId, CommitId>,
     staged_snapshot_roots: &BTreeMap<CommitId, TrackedStateCommitRoot>,
+    global_commit_ids: &BTreeSet<CommitId>,
 ) -> Result<Vec<crate::sync::SyncCommit>, LixError> {
     use crate::sync::{
         SyncCommit, SyncCommitMemberRef, SyncCommitStateAlias, encode_sync_commit_member,
@@ -2464,6 +2470,7 @@ fn materialize_staged_sync_commits(
                 .collect(),
             account_id: staged.record.account_id.clone(),
             created_at: staged.record.created_at.to_string(),
+            global_scope: global_commit_ids.contains(commit_id),
             selected_source_commit_id: selected_source_commit_id.map(|id| id.to_string()),
             state_alias,
             members,
@@ -6257,6 +6264,7 @@ where
     Box::pin(async move {
         let mut published_manifests =
             BTreeMap::<CommitId, crate::tracked_state::StagedCommitStateManifest>::new();
+        let mut row_pk_index_overlay = crate::tracked_state::TrackedStateChunkOverlay::new();
         if staged_commits.len() != commit_rows.len()
             || commit_rows
                 .iter()
@@ -6272,6 +6280,11 @@ where
             .sort_unstable_by_key(|staged| (staged.record.generation, staged.record.commit_id));
         for staged in publication_order {
             let record = &staged.record;
+            let global_scope = commit_rows
+                .iter()
+                .find(|commit| commit.commit_id == record.commit_id)
+                .expect("publication order was validated against finalized commits")
+                .global_scope;
             let rootless = rootless_commit_ids.contains(&record.commit_id);
             let snapshot_root = snapshot_roots.get(&record.commit_id).cloned();
             if rootless == snapshot_root.is_some() {
@@ -6508,6 +6521,88 @@ where
                 crate::tracked_state::incomplete_touched_scope_filter,
                 |publication| publication.touched_scope_filter().clone(),
             );
+            let row_pk_base_commit_id = if complete_state_fence {
+                snapshot_root
+                    .as_ref()
+                    .and_then(|root| root.parent_roots.first())
+                    .map(|source| source.commit_id)
+            } else {
+                mutations.selected_source_commit_id().or(first_parent)
+            };
+            let loaded_row_pk_base = if let Some(base_id) = row_pk_base_commit_id
+                && !published_manifests.contains_key(&base_id)
+                && !external_parent_manifests.contains_key(&base_id)
+            {
+                crate::tracked_state::load_published_commit_state_topology(read, base_id).await?
+            } else {
+                None
+            };
+            let mut row_pk_base_root = row_pk_base_commit_id.and_then(|base_id| {
+                published_manifests
+                    .get(&base_id)
+                    .and_then(|manifest| manifest.row_pk_index_root_id.clone())
+                    .or_else(|| {
+                        external_parent_manifests
+                            .get(&base_id)
+                            .and_then(|manifest| manifest.row_pk_index_root_id().cloned())
+                    })
+                    .or_else(|| {
+                        loaded_row_pk_base
+                            .as_ref()
+                            .and_then(|manifest| manifest.row_pk_index_root_id().cloned())
+                    })
+            });
+            if row_pk_base_commit_id.is_some() && row_pk_base_root.is_none() {
+                let base_id = row_pk_base_commit_id.expect("checked above");
+                let base_rows = TrackedStateContext::new()
+                    .reader(&*read)
+                    .scan_batch_at_commit(
+                        &base_id.to_string(),
+                        &TrackedStateScanRequest::default(),
+                    )
+                    .await?
+                    .into_rows();
+                row_pk_base_root = crate::tracked_state::stage_row_pk_index_from_deltas(
+                    read,
+                    writes,
+                    &mut row_pk_index_overlay,
+                    base_rows.iter().map(|row| TrackedStateDeltaRef {
+                        schema_key: &row.schema_key,
+                        file_id: row.file_id.as_deref(),
+                        row_pk: &row.row_pk,
+                        change_id: row.change_id,
+                        commit_id: row.commit_id,
+                        deleted: false,
+                        created_at: LixTimestamp::expect_parse("created_at", &row.created_at),
+                        updated_at: LixTimestamp::expect_parse("updated_at", &row.updated_at),
+                    }),
+                    base_id,
+                )
+                .await?;
+            }
+            let staged_segments =
+                crate::tracked_state::staged_commit_delta_segment_bytes(
+                    writes,
+                    record.commit_id,
+                    &mutations,
+                )?;
+            let row_pk_members = crate::tracked_state::staged_commit_delta_members(
+                read,
+                record.commit_id,
+                &record.account_id,
+                &mutations,
+                staged_segments,
+            )
+            .await?;
+            let row_pk_index_root_id = crate::tracked_state::stage_row_pk_index_from_members(
+                read,
+                writes,
+                &mut row_pk_index_overlay,
+                row_pk_base_root.as_ref(),
+                &row_pk_members,
+                record.commit_id,
+            )
+            .await?;
             if mutations.replacement_generation.is_some() {
                 mutations.parts.clear();
             }
@@ -6521,7 +6616,9 @@ where
                 },
                 mutations,
                 touched_scope_filter,
+                global_scope,
                 current_state_scoped_ranges,
+                row_pk_index_root_id,
                 snapshot_root: snapshot_root.map(Box::new),
             };
             let staged_manifest = if let Some(publication) = catalog_publication.as_ref() {
@@ -6699,6 +6796,7 @@ struct FinalizedCommitRow {
     parent_commit_ids: Vec<CommitId>,
     created_at: LixTimestamp,
     selected_change_batches: Vec<StagedCommitChangeBatch>,
+    global_scope: bool,
 }
 
 struct PendingTrackedRoot {
@@ -6732,6 +6830,7 @@ async fn finalize_commit_rows(
             parent_commit_ids: vec![intermediate.parent_commit_id],
             created_at,
             selected_change_batches,
+            global_scope: intermediate.branch_id == crate::GLOBAL_BRANCH_ID,
         });
         tracked_roots.push(PendingTrackedRoot {
             branch_id: intermediate.branch_id,
@@ -6782,6 +6881,7 @@ async fn finalize_commit_rows(
             parent_commit_ids: parent_commit_ids.clone(),
             created_at: timestamp,
             selected_change_batches,
+            global_scope: branch_id == crate::GLOBAL_BRANCH_ID,
         });
         tracked_roots.push(PendingTrackedRoot {
             branch_id,
@@ -9776,12 +9876,14 @@ mod tests {
                 parent_commit_ids: vec![CommitId::for_test_label("parent-commit")],
                 created_at: ts("2026-01-01T00:00:01Z"),
                 selected_change_batches: Vec::new(),
+                global_scope: false,
             },
             FinalizedCommitRow {
                 commit_id: CommitId::for_test_label("parent-commit"),
                 parent_commit_ids: Vec::new(),
                 created_at: ts("2026-01-01T00:00:00Z"),
                 selected_change_batches: Vec::new(),
+                global_scope: false,
             },
         ];
         let mut rootless_commit_ids = BTreeSet::from([CommitId::for_test_label("parent-commit")]);
@@ -9918,6 +10020,7 @@ mod tests {
                     .unwrap_or_default(),
                 created_at: ts("2026-01-01T00:00:00Z"),
                 selected_change_batches: Vec::new(),
+                global_scope: false,
             })
             .collect::<Vec<_>>();
         let row_indices = commit_ids
@@ -10892,6 +10995,7 @@ mod tests {
                     )
                 })
                 .collect(),
+            global_scope: false,
         }];
         let loaded = load_selected_change_records(&read, &commit_rows)
             .await

--- a/packages/lix/src/transaction/mod.rs
+++ b/packages/lix/src/transaction/mod.rs
@@ -9,6 +9,7 @@ mod staged_commit_changes;
 mod staging;
 mod stale_commit;
 mod validation;
+pub(crate) use validation::MAX_DIRECTORY_PARENT_DEPTH;
 
 #[cfg(feature = "storage-benches")]
 pub mod bench {

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -55,7 +55,7 @@ const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
-const MAX_DIRECTORY_PARENT_DEPTH: usize = 1024;
+pub(crate) const MAX_DIRECTORY_PARENT_DEPTH: usize = 1024;
 
 /// Immutable view of the final transaction write set before persistence.
 ///

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -810,7 +810,7 @@ simulation_test!(
         let working_diffs = main
             .execute(
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2013,8 +2013,8 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT diff_type, from_value, to_value FROM {} \
-                     WHERE row_pk = CAST('[\"branch-baseline\"]' AS JSONB)",
+                    "SELECT lixcol_diff_type, from_value, to_value FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"branch-baseline\"]' AS JSONB)",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2073,8 +2073,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "INSERT INTO lix_revert (relation, row_pk) \
-                     SELECT 'lix_key_value', row_pk FROM {} \
-                     WHERE row_pk = CAST('[\"branch-revert\"]' AS JSONB)",
+                     SELECT 'lix_key_value', lixcol_row_pk FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"branch-revert\"]' AS JSONB)",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2132,8 +2132,8 @@ simulation_test!(
         let rows = main
             .execute(
                 &format!(
-                    "SELECT diff_type, from_value FROM {} \
-                     WHERE row_pk = CAST('[\"merge-baseline\"]' AS JSONB)",
+                    "SELECT lixcol_diff_type, from_value FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"merge-baseline\"]' AS JSONB)",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2185,8 +2185,8 @@ simulation_test!(
         let narrow = draft
             .execute(
                 &format!(
-                    "SELECT diff_type, from_value FROM {} \
-                     WHERE row_pk = CAST('[\"branch-delete\"]' AS JSONB)",
+                    "SELECT lixcol_diff_type, from_value FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"branch-delete\"]' AS JSONB)",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2208,7 +2208,7 @@ simulation_test!(
         let broad = draft
             .execute(
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2288,7 +2288,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2370,7 +2370,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2432,8 +2432,8 @@ simulation_test!(
         let rows = main
             .execute(
                 &format!(
-                    "SELECT diff_type, from_value FROM {} \
-                     WHERE row_pk = CAST('[\"switch-baseline\"]' AS JSONB)",
+                    "SELECT lixcol_diff_type, from_value FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"switch-baseline\"]' AS JSONB)",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2488,7 +2488,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT row_pk FROM {}",
+                    "SELECT lixcol_row_pk FROM {}",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -95,13 +95,13 @@ simulation_test!(
         let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = raw_session
             .observe(
-                "SELECT row_pk, diff_type \
+                "SELECT lixcol_row_pk, lixcol_diff_type \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \
                    lix_active_branch_commit_id()\
                  ) \
-                 ORDER BY row_pk",
+                 ORDER BY lixcol_row_pk",
                 &[],
             )
             .expect("checkpoint-to-head diff should open as one observed query");

--- a/packages/lix/tests/integration/sql.rs
+++ b/packages/lix/tests/integration/sql.rs
@@ -96,6 +96,7 @@ mod diff_commands;
 mod diff_relation;
 mod schema_history;
 mod schema_view;
+mod state_at;
 mod errors;
 mod history_conformance;
 mod information_schema;

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -33,9 +33,9 @@ async fn checkpoints_example_sql_contract() {
         .expect("active head commit ID should decode");
     let working_diffs = lix
         .execute(
-            "SELECT row_pk, diff_type
+            "SELECT lixcol_row_pk, lixcol_diff_type
              FROM lix_diff('lix_key_value', $1, $2)
-             ORDER BY row_pk",
+             ORDER BY lixcol_row_pk",
             &[Value::Text(root_commit_id), Value::Text(head_commit_id)],
         )
         .await
@@ -43,13 +43,13 @@ async fn checkpoints_example_sql_contract() {
     assert_eq!(working_diffs.len(), 1);
     assert_eq!(
         working_diffs.rows()[0]
-            .get::<serde_json::Value>("row_pk")
+            .get::<serde_json::Value>("lixcol_row_pk")
             .expect("row_pk is JSON"),
         json!(["checkpoint-demo"])
     );
     assert_eq!(
         working_diffs.rows()[0]
-            .get::<String>("diff_type")
+            .get::<String>("lixcol_diff_type")
             .expect("diff_type is text"),
         "added"
     );
@@ -152,7 +152,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -166,8 +166,8 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} \
-                     WHERE row_pk = CAST('[\"checkpoint-key\"]' AS JSONB)",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"checkpoint-key\"]' AS JSONB)",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -181,8 +181,8 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT row_pk FROM {} \
-                     WHERE row_pk = CAST('[\"other-key\"]' AS JSONB)",
+                    "SELECT lixcol_row_pk FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"other-key\"]' AS JSONB)",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -515,7 +515,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT row_pk, diff_type FROM {} ORDER BY row_pk",
+                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -536,8 +536,8 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT diff_type FROM {} \
-                     WHERE row_pk = CAST('[\"working-removed\"]' AS JSONB)",
+                    "SELECT lixcol_diff_type FROM {} \
+                     WHERE lixcol_row_pk = CAST('[\"working-removed\"]' AS JSONB)",
                     key_value_diff_relation(&session).await
                 ),
             )

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -32,7 +32,7 @@ simulation_test!(
         let working = select_rows(
             &session,
             &format!(
-                "SELECT row_pk, diff_type FROM lix_diff('lix_key_value', '{baseline}', '{original_head}') ORDER BY row_pk"
+                "SELECT lixcol_row_pk, lixcol_diff_type FROM lix_diff('lix_key_value', '{baseline}', '{original_head}') ORDER BY lixcol_row_pk"
             ),
         )
         .await;
@@ -48,11 +48,11 @@ simulation_test!(
         let reverted = session
             .execute(
                 "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff(\
                    'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
                  ) \
-                 WHERE row_pk ->> 0 IN ('a', 'b') \
+                 WHERE lixcol_row_pk ->> 0 IN ('a', 'b') \
                  RETURNING commit_id",
                 &[],
             )
@@ -73,9 +73,9 @@ simulation_test!(
         let applied = session
             .execute(
                 "INSERT INTO lix_apply (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff('lix_key_value', lix_root_commit_id(), $1) \
-                 WHERE row_pk ->> 0 IN ('a', 'b') \
+                 WHERE lixcol_row_pk ->> 0 IN ('a', 'b') \
                  RETURNING commit_id",
                 &[Value::Text(original_head)],
             )
@@ -88,11 +88,11 @@ simulation_test!(
         let checkpointed = session
             .execute(
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff(\
                    'lix_key_value', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()\
                  ) \
-                 WHERE row_pk = CAST('[\"a\"]' AS JSONB) \
+                 WHERE lixcol_row_pk = CAST('[\"a\"]' AS JSONB) \
                  RETURNING commit_id",
                 &[],
             )
@@ -114,7 +114,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT row_pk FROM lix_diff('lix_key_value', '{checkpoint_commit_id}', '{child_head}')"
+                    "SELECT lixcol_row_pk FROM lix_diff('lix_key_value', '{checkpoint_commit_id}', '{child_head}')"
                 ),
             )
             .await,
@@ -124,7 +124,7 @@ simulation_test!(
         let empty = session
             .execute(
                 "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff('lix_key_value', $1, $2) WHERE 1 = 0 \
                  RETURNING commit_id",
                 &[
@@ -198,7 +198,7 @@ simulation_test!(
         let reverted = session
             .execute(
                 "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \
@@ -223,7 +223,7 @@ simulation_test!(
         let applied = session
             .execute(
                 "INSERT INTO lix_apply (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \
@@ -309,8 +309,8 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT diff_type FROM lix_diff('lix_key_value', '{checkpoint_id}', '{head}') \
-                     WHERE row_pk = CAST('[\"recycled\"]' AS JSONB)"
+                    "SELECT lixcol_diff_type FROM lix_diff('lix_key_value', '{checkpoint_id}', '{head}') \
+                     WHERE lixcol_row_pk = CAST('[\"recycled\"]' AS JSONB)"
                 ),
             )
             .await,
@@ -366,9 +366,9 @@ simulation_test!(
         let checkpointed = session
             .execute(
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', row_pk \
+                 SELECT 'lix_key_value', lixcol_row_pk \
                  FROM lix_diff('lix_key_value', $1, $2) \
-                 WHERE row_pk ->> 0 IN ('a', 'b', 'c') \
+                 WHERE lixcol_row_pk ->> 0 IN ('a', 'b', 'c') \
                  RETURNING commit_id",
                 &[Value::Text(baseline), Value::Text(head)],
             )
@@ -428,7 +428,7 @@ simulation_test!(
         let checkpoint = session
             .execute(
                 "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_file', row_pk FROM lix_diff('lix_file', $1, $2) \
+                 SELECT 'lix_file', lixcol_row_pk FROM lix_diff('lix_file', $1, $2) \
                  WHERE to_path = '/docs/nested/readme.txt' RETURNING commit_id",
                 &[Value::Text(baseline), Value::Text(head)],
             )

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -29,7 +29,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT row_pk, diff_type, from_key, to_key, from_value, to_value, row_count \
+                "SELECT lixcol_row_pk, lixcol_diff_type, from_key, to_key, from_value, to_value, lixcol_row_count \
                  FROM lix_diff('lix_key_value', '{baseline}', '{inserted}')"
             ),
         )
@@ -49,7 +49,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_key, to_key, from_value, to_value \
+                "SELECT lixcol_diff_type, from_key, to_key, from_value, to_value \
                  FROM lix_diff('lix_key_value', '{inserted}', '{baseline}')"
             ),
         )
@@ -79,7 +79,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
             &session,
             "SELECT count(*) FROM lix_diff(\
                  'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
-             ) WHERE row_pk = CAST('[\"note\"]' AS JSONB)",
+             ) WHERE lixcol_row_pk = CAST('[\"note\"]' AS JSONB)",
         )
         .await,
         vec![vec![Value::Integer(1)]],
@@ -103,9 +103,9 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_value, to_value, row_count \
+                "SELECT lixcol_diff_type, from_value, to_value, lixcol_row_count \
                  FROM lix_diff('lix_key_value', '{inserted}', '{updated}') \
-                 WHERE row_pk = CAST('[\"note\"]' AS JSONB)"
+                 WHERE lixcol_row_pk = CAST('[\"note\"]' AS JSONB)"
             ),
         )
         .await,
@@ -218,7 +218,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
     let added = select_rows(
         &session,
         &format!(
-            "SELECT row_pk, diff_type, from_path, to_path, row_count \
+            "SELECT lixcol_row_pk, lixcol_diff_type, from_path, to_path, lixcol_row_count \
              FROM lix_diff('lix_file', '{baseline}', '{inserted}')"
         ),
     )
@@ -232,7 +232,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path, row_count \
+                "SELECT lixcol_diff_type, from_path, to_path, lixcol_row_count \
                  FROM lix_diff('lix_file', '{inserted}', '{baseline}')"
             ),
         )
@@ -257,7 +257,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
             &session,
             &format!(
                 "SELECT count(*) FROM lix_diff('lix_file', '{baseline}', '{inserted}') \
-                 WHERE row_pk ->> 0 = '{file_id}'"
+                 WHERE lixcol_row_pk ->> 0 = '{file_id}'"
             ),
         )
         .await,
@@ -268,7 +268,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT count(*), sum(row_count) \
+                "SELECT count(*), sum(lixcol_row_count) \
                  FROM lix_diff('lix_file', '{baseline}', '{inserted}')"
             ),
         )
@@ -291,7 +291,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path FROM lix_diff('lix_file', '{inserted}', '{renamed}')"
+                "SELECT lixcol_diff_type, from_path, to_path FROM lix_diff('lix_file', '{inserted}', '{renamed}')"
             ),
         )
         .await,
@@ -316,7 +316,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path FROM lix_diff('lix_file', '{renamed}', '{removed}')"
+                "SELECT lixcol_diff_type, from_path, to_path FROM lix_diff('lix_file', '{renamed}', '{removed}')"
             ),
         )
         .await,
@@ -330,7 +330,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path \
+                "SELECT lixcol_diff_type, from_path, to_path \
                  FROM lix_diff('lix_file', '{removed}', '{renamed}')"
             ),
         )
@@ -366,7 +366,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path, row_count \
+                "SELECT lixcol_diff_type, from_path, to_path, lixcol_row_count \
                  FROM lix_diff('lix_directory', '{baseline}', '{inserted}')"
             ),
         )
@@ -393,7 +393,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path \
+                "SELECT lixcol_diff_type, from_path, to_path \
                  FROM lix_diff('lix_directory', '{inserted}', '{renamed}')"
             ),
         )
@@ -419,7 +419,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_path, to_path \
+                "SELECT lixcol_diff_type, from_path, to_path \
                  FROM lix_diff('lix_directory', '{renamed}', '{removed}')"
             ),
         )
@@ -465,4 +465,95 @@ simulation_test!(relation_diff_requires_explicit_relation_and_commit_ids, |sim| 
         .expect_err("aggregate file bytes are deliberately unsupported");
     assert!(file_content.message.contains("does not support content projection"));
     assert!(file_content.message.contains("lix_history"));
+});
+
+simulation_test!(relation_diff_fences_machinery_from_user_column_names, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+
+    let reserved = session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"reserved_name_collision\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"from_lixcol_user_value\",\"type\":\"text\",\"nullable\":true}],\"primary_key\":[\"id\"]}' AS JSONB), false, false)",
+            &[],
+        )
+        .await
+        .expect_err("schema registration must reject the reserved lixcol_ segment");
+    assert!(reserved.message.contains("reserved lixcol_ segment"));
+
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"diff_name_collision\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"diff_type\",\"type\":\"text\",\"nullable\":false},{\"name\":\"row_count\",\"type\":\"int8\",\"nullable\":false},{\"name\":\"depth\",\"type\":\"int8\",\"nullable\":false},{\"name\":\"from_path\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB), false, false)",
+            &[],
+        )
+        .await
+        .expect("collision schema should register");
+    let baseline = engine
+        .load_branch_head_commit_id(sim.main_branch_id())
+        .await
+        .expect("baseline head should load")
+        .expect("baseline head should exist")
+        .to_string();
+
+    session
+        .execute(
+            "INSERT INTO diff_name_collision (id, diff_type, row_count, depth, from_path) \
+             VALUES ('row-1', 'user-kind', 7, 3, '/user-path')",
+            &[],
+        )
+        .await
+        .expect("collision row should insert");
+    let head = engine
+        .load_branch_head_commit_id(sim.main_branch_id())
+        .await
+        .expect("updated head should load")
+        .expect("updated head should exist")
+        .to_string();
+
+    assert_eq!(
+        select_rows(
+            &session,
+            &format!(
+                "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count, \
+                 from_diff_type, to_diff_type, from_row_count, to_row_count, \
+                 from_depth, to_depth, from_from_path, to_from_path \
+                 FROM lix_diff('diff_name_collision', '{baseline}', '{head}')"
+            ),
+        )
+        .await,
+        vec![vec![
+            Value::Jsonb(json!(["row-1"]).into()),
+            Value::Text("added".to_string()),
+            Value::Integer(1),
+            Value::Null,
+            Value::Text("user-kind".to_string()),
+            Value::Null,
+            Value::Integer(7),
+            Value::Null,
+            Value::Integer(3),
+            Value::Null,
+            Value::Text("/user-path".to_string()),
+        ]]
+    );
+
+    for retired in ["row_pk", "diff_type", "row_count"] {
+        let error = session
+            .execute(
+                &format!(
+                    "SELECT {retired} FROM lix_diff('diff_name_collision', '{baseline}', '{head}')"
+                ),
+                &[],
+            )
+            .await
+            .expect_err("retired diff machinery alias must not exist");
+        assert!(
+            error.message.contains(retired),
+            "error should identify retired column {retired}: {}",
+            error.message
+        );
+    }
 });

--- a/packages/lix/tests/integration/sql/history_conformance.rs
+++ b/packages/lix/tests/integration/sql/history_conformance.rs
@@ -745,7 +745,7 @@ simulation_test!(
 
         for sql in [
             "EXPLAIN SELECT * FROM lix_history('lix_file')",
-            "EXPLAIN SELECT row_pk FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id())",
+            "EXPLAIN SELECT lixcol_row_pk FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id())",
         ] {
             session
                 .execute(sql, &[])
@@ -791,6 +791,7 @@ simulation_test!(history_discovery_has_no_suffix_surfaces, |sim| async move {
             vec![Value::Text("lix_commit_ancestry".to_string())],
             vec![Value::Text("lix_diff".to_string())],
             vec![Value::Text("lix_history".to_string())],
+            vec![Value::Text("lix_state_at".to_string())],
         ],
     );
 });

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -141,8 +141,8 @@ simulation_test!(
              WHERE function_name = 'lix_diff' \
                AND source_relation IN ('lix_file', 'lix_key_value') \
                AND result_column IN (\
-                 'row_pk', 'diff_type', 'from_path', 'to_path', \
-                 'from_value', 'to_value', 'row_count'\
+                 'lixcol_row_pk', 'lixcol_diff_type', 'from_path', 'to_path', \
+                 'from_value', 'to_value', 'lixcol_row_count'\
                ) \
              ORDER BY source_relation, ordinal_position",
                 &[],
@@ -155,14 +155,14 @@ simulation_test!(
             vec![
                 vec![
                     Value::Text("lix_file".to_string()),
-                    Value::Text("row_pk".to_string()),
+                    Value::Text("lixcol_row_pk".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Text("JSONB".to_string()),
                 ],
                 vec![
                     Value::Text("lix_file".to_string()),
-                    Value::Text("diff_type".to_string()),
+                    Value::Text("lixcol_diff_type".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
@@ -183,21 +183,21 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_file".to_string()),
-                    Value::Text("row_count".to_string()),
+                    Value::Text("lixcol_row_count".to_string()),
                     Value::Text("BIGINT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
-                    Value::Text("row_pk".to_string()),
+                    Value::Text("lixcol_row_pk".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Text("JSONB".to_string()),
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
-                    Value::Text("diff_type".to_string()),
+                    Value::Text("lixcol_diff_type".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
@@ -218,7 +218,7 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
-                    Value::Text("row_count".to_string()),
+                    Value::Text("lixcol_row_count".to_string()),
                     Value::Text("BIGINT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -247,9 +247,9 @@ simulation_test!(
             super::select_rows(
                 &session,
                 &format!(
-                    "SELECT diff_type, to_id \
+                    "SELECT lixcol_diff_type, to_id \
                      FROM lix_diff('lix_file', '{baseline}', '{renamed_head}') \
-                     WHERE row_pk ->> 0 = '{file_id}'"
+                     WHERE lixcol_row_pk ->> 0 = '{file_id}'"
                 ),
             )
             .await,
@@ -263,9 +263,9 @@ simulation_test!(
             super::select_rows(
                 &session,
                 &format!(
-                    "SELECT diff_type, to_id \
+                    "SELECT lixcol_diff_type, to_id \
                      FROM lix_diff('lix_file', '{baseline}', '{renamed_head}') \
-                     WHERE row_pk ->> 0 = '{file_id}'"
+                     WHERE lixcol_row_pk ->> 0 = '{file_id}'"
                 ),
             )
             .await,

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -1,0 +1,557 @@
+use lix::Value;
+use serde_json::json;
+
+use super::assert_rows_eq;
+
+simulation_test!(state_at_reads_tracked_schema_state_at_a_commit, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('state-at-key', CAST('{\"v\":1}' AS JSONB))",
+            &[],
+        )
+        .await
+        .expect("row should insert");
+    let commit = session
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("commit should load");
+    let [Value::Text(commit_id)] = commit.rows()[0].values() else {
+        panic!("expected commit id");
+    };
+
+    session
+        .execute(
+            "UPDATE lix_key_value SET value = CAST('{\"v\":2}' AS JSONB) WHERE key = 'state-at-key'",
+            &[],
+        )
+        .await
+        .expect("row should update");
+
+    crate::sql2::arm_state_at_traversal_probe(commit_id);
+    let result = session
+        .execute(
+            "SELECT key, value, lixcol_untracked FROM lix_state_at('lix_key_value', $1) \
+             WHERE key IN ('state-at-key', 'absent')",
+            &[Value::Text(commit_id.clone())],
+        )
+        .await
+        .expect("historical state should load");
+    assert_rows_eq(
+        result,
+        vec![vec![
+            Value::Text("state-at-key".into()),
+            Value::Jsonb(json!({ "v": 1 }).into()),
+            Value::Boolean(false),
+        ]],
+    );
+    assert_eq!(
+        crate::sql2::take_state_at_traversal_probe(commit_id),
+        vec![(2, 1)],
+        "schema primary-key IN must resolve only matching identities before exact tree reads"
+    );
+
+    let root = session
+        .execute(
+            "SELECT key FROM lix_state_at('lix_key_value', lix_root_commit_id())",
+            &[],
+        )
+        .await
+        .expect("root state should load");
+    assert!(root.rows().is_empty());
+
+    let contradiction = session
+        .execute(
+            "SELECT key FROM lix_state_at('lix_key_value', $1) WHERE key = 'a' AND key = 'b'",
+            &[Value::Text(commit_id.clone())],
+        )
+        .await
+        .expect("contradictory point state should load");
+    assert!(contradiction.rows().is_empty());
+});
+
+simulation_test!(state_at_primary_key_keeps_duplicate_file_scopes, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+    let first = "01991b1d-6d8b-7000-8000-000000000011";
+    let second = "01991b1d-6d8b-7000-8000-000000000012";
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, content) VALUES \
+             ($1, '/state-at-first', CAST('a' AS BYTEA)), \
+             ($2, '/state-at-second', CAST('b' AS BYTEA))",
+            &[Value::Text(first.into()), Value::Text(second.into())],
+        )
+        .await
+        .expect("files should insert");
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_file_id) VALUES \
+             ('shared-pk', 'first', $1)",
+            &[Value::Text(first.into())],
+        )
+        .await
+        .expect("first scoped row should insert");
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_file_id) VALUES \
+             ('shared-pk', 'second', $1)",
+            &[Value::Text(second.into())],
+        )
+        .await
+        .expect("second scoped row should insert");
+    let commit = session
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("commit should load");
+    let [Value::Text(commit_id)] = commit.rows()[0].values() else {
+        panic!("expected commit id");
+    };
+
+    crate::sql2::arm_state_at_traversal_probe(commit_id);
+    let result = session
+        .execute(
+            "SELECT lixcol_file_id, value \
+             FROM lix_state_at('lix_key_value', $1) \
+             WHERE key = 'shared-pk' ORDER BY lixcol_file_id",
+            &[Value::Text(commit_id.clone())],
+        )
+        .await
+        .expect("both scoped identities should load");
+    assert_rows_eq(
+        result,
+        vec![
+            vec![Value::Text(first.into()), Value::Jsonb(json!("first").into())],
+            vec![Value::Text(second.into()), Value::Jsonb(json!("second").into())],
+        ],
+    );
+    assert_eq!(
+        crate::sql2::take_state_at_traversal_probe(commit_id),
+        vec![(1, 2)],
+        "one primary-key prefix must discover both file-scoped identities"
+    );
+});
+
+simulation_test!(state_at_materializes_historical_file_content_and_path, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+    let id = "01991b1d-6d8b-7000-8000-000000000001";
+
+    session
+        .execute(
+            &format!(
+                "INSERT INTO lix_file (id, path, content) VALUES ('{id}', '/nested/before.txt', CAST('before' AS BYTEA))"
+            ),
+            &[],
+        )
+        .await
+        .expect("file should insert");
+    let commit = session
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("commit should load");
+    let [Value::Text(commit_id)] = commit.rows()[0].values() else {
+        panic!("expected commit id");
+    };
+
+    session
+        .execute(
+            &format!("UPDATE lix_file SET path = '/after.txt', content = CAST('after' AS BYTEA) WHERE id = '{id}'"),
+            &[],
+        )
+        .await
+        .expect("file should update");
+
+    let result = session
+        .execute(
+            "SELECT id, path, content FROM lix_state_at('lix_file', $1) WHERE id = $2",
+            &[Value::Text(commit_id.clone()), Value::Text(id.into())],
+        )
+        .await
+        .expect("historical file should load");
+    assert_rows_eq(
+        result,
+        vec![vec![
+            Value::Text(id.into()),
+            Value::Text("/nested/before.txt".into()),
+            Value::Blob(b"before".to_vec().into()),
+        ]],
+    );
+});
+
+simulation_test!(state_at_matches_live_columns_and_unchanged_row_metadata, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('stable', 'value')",
+            &[],
+        )
+        .await
+        .expect("stable row should insert");
+    let commit = session
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("commit should load");
+    let [Value::Text(commit_id)] = commit.rows()[0].values() else {
+        panic!("expected commit id");
+    };
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('later', 'unrelated')",
+            &[],
+        )
+        .await
+        .expect("unrelated row should insert");
+
+    let live = session
+        .execute("SELECT * FROM lix_key_value WHERE key = 'stable'", &[])
+        .await
+        .expect("live row should load");
+    let historical = session
+        .execute(
+            "SELECT * FROM lix_state_at('lix_key_value', $1) WHERE key = 'stable'",
+            &[Value::Text(commit_id.clone())],
+        )
+        .await
+        .expect("historical row should load");
+    assert_eq!(historical.columns(), live.columns());
+    assert_eq!(historical.rows(), live.rows());
+});
+
+simulation_test!(state_at_omits_deleted_and_untracked_rows, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('deleted', 'before')",
+            &[],
+        )
+        .await
+        .expect("tracked row should insert");
+    let before_delete = session
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("commit should load");
+    let [Value::Text(before_delete_id)] = before_delete.rows()[0].values() else {
+        panic!("expected commit id");
+    };
+    session
+        .execute("DELETE FROM lix_key_value WHERE key = 'deleted'", &[])
+        .await
+        .expect("tracked row should delete");
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_untracked) \
+             VALUES ('untracked', 'local', true)",
+            &[],
+        )
+        .await
+        .expect("untracked row should insert");
+
+    let before = session
+        .execute(
+            "SELECT key FROM lix_state_at('lix_key_value', $1) WHERE key = 'deleted'",
+            &[Value::Text(before_delete_id.clone())],
+        )
+        .await
+        .expect("pre-deletion row should load");
+    assert_eq!(before.rows().len(), 1);
+
+    let head = session
+        .execute(
+            "SELECT key FROM lix_state_at('lix_key_value', lix_active_branch_commit_id()) \
+             WHERE key IN ('deleted', 'untracked')",
+            &[],
+        )
+        .await
+        .expect("head state should load");
+    assert!(head.rows().is_empty());
+});
+
+simulation_test!(state_at_rejects_internal_relations_and_unknown_commits, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+
+    let internal = session
+        .execute(
+            "SELECT * FROM lix_state_at('lix_file_descriptor', lix_active_branch_commit_id())",
+            &[],
+        )
+        .await
+        .expect_err("internal descriptor relation must be rejected");
+    assert!(internal.message.contains("does not support relation"));
+
+    let unknown = session
+        .execute(
+            "SELECT * FROM lix_state_at('lix_key_value', '0000000000000000000000000000000000000000000000000000000000000000')",
+            &[],
+        )
+        .await
+        .expect_err("unknown commit must fail");
+    assert!(
+        unknown.message.contains("commit") || unknown.message.contains("root"),
+        "unknown commit should produce a commit/root error: {}",
+        unknown.message
+    );
+});
+
+simulation_test!(state_at_branch_scope_is_session_independent, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let local = sim.wrap_session(
+        engine.open_session().await.expect("local session should open"),
+        &engine,
+    );
+    let global = sim.wrap_session(
+        engine
+            .open_session_at(lix::GLOBAL_BRANCH_ID)
+            .await
+            .expect("global session should open"),
+        &engine,
+    );
+    let global_before = global
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("global parent commit should load");
+    let [Value::Text(global_before_id)] = global_before.rows()[0].values() else {
+        panic!("expected global parent commit id");
+    };
+
+    global
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global) \
+             VALUES ('composed', 'global-value', true)",
+            &[],
+        )
+        .await
+        .expect("global row should insert");
+    let global_commit = global
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("global commit should load");
+    let [Value::Text(global_commit_id)] = global_commit.rows()[0].values() else {
+        panic!("expected global commit id");
+    };
+    local
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('composed', 'local-value')",
+            &[],
+        )
+        .await
+        .expect("local override should insert");
+    let local_commit = local
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("local commit should load");
+    let [Value::Text(local_commit_id)] = local_commit.rows()[0].values() else {
+        panic!("expected local commit id");
+    };
+
+    let global_state = local
+        .execute(
+            "SELECT value, lixcol_global \
+             FROM lix_state_at('lix_key_value', $1) \
+             WHERE key = 'composed'",
+            &[Value::Text(global_commit_id.clone())],
+        )
+        .await
+        .expect("global branch state should load from a local session");
+    assert_rows_eq(
+        global_state,
+        vec![vec![
+            Value::Jsonb(json!("global-value").into()),
+            Value::Boolean(true),
+        ]],
+    );
+    let global_diff = local
+        .execute(
+            "SELECT to_lixcol_global \
+             FROM lix_diff('lix_key_value', $1, $2) \
+             WHERE to_key = 'composed'",
+            &[
+                Value::Text(global_before_id.clone()),
+                Value::Text(global_commit_id.clone()),
+            ],
+        )
+        .await
+        .expect("global diff metadata should load");
+    assert_rows_eq(global_diff, vec![vec![Value::Boolean(true)]]);
+
+    global
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global) \
+             VALUES ('later-global', 'later', true)",
+            &[],
+        )
+        .await
+        .expect("global head should advance");
+    let pinned_again = local
+        .execute(
+            "SELECT lixcol_global FROM lix_state_at('lix_key_value', $1) \
+             WHERE key = 'composed'",
+            &[Value::Text(global_commit_id.clone())],
+        )
+        .await
+        .expect("pinned global metadata should remain immutable");
+    assert_rows_eq(pinned_again, vec![vec![Value::Boolean(true)]]);
+
+    let local_state = global
+        .execute(
+            "SELECT value, lixcol_global \
+             FROM lix_state_at('lix_key_value', $1) \
+             WHERE key = 'composed'",
+            &[Value::Text(local_commit_id.clone())],
+        )
+        .await
+        .expect("local branch state should load from a global session");
+    assert_rows_eq(
+        local_state,
+        vec![vec![
+            Value::Jsonb(json!("local-value").into()),
+            Value::Boolean(false),
+        ]],
+    );
+
+    let live = local
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'composed'",
+            &[],
+        )
+        .await
+        .expect("composed live view should load");
+    assert_rows_eq(live, vec![vec![Value::Jsonb(json!("local-value").into())]]);
+});
+
+simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let local = sim.wrap_session(
+        engine.open_session().await.expect("local session should open"),
+        &engine,
+    );
+    let global = sim.wrap_session(
+        engine
+            .open_session_at(lix::GLOBAL_BRANCH_ID)
+            .await
+            .expect("global session should open"),
+        &engine,
+    );
+
+    global
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global) VALUES \
+             ('global-only', 'global-only-value', true), \
+             ('overridden', 'global-old-value', true), \
+             ('suppressed', 'global-suppressed-value', true)",
+            &[],
+        )
+        .await
+        .expect("global rows should insert");
+    let global_commit = global
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("global commit should load");
+    let [Value::Text(global_commit_id)] = global_commit.rows()[0].values() else {
+        panic!("expected global commit id");
+    };
+
+    local
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES \
+             ('overridden', 'local-value'), ('suppressed', 'local-before-delete')",
+            &[],
+        )
+        .await
+        .expect("local override should insert");
+    local
+        .execute("DELETE FROM lix_key_value WHERE key = 'suppressed'", &[])
+        .await
+        .expect("local tombstone should suppress the global row");
+    let local_commit = local
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("local commit should load");
+    let [Value::Text(local_commit_id)] = local_commit.rows()[0].values() else {
+        panic!("expected local commit id");
+    };
+
+    let composed = local
+        .execute(
+            "WITH ranked_local_history AS ( \
+                 SELECT lixcol_row_pk, lixcol_file_id, \
+                        row_number() OVER ( \
+                            PARTITION BY lixcol_row_pk, lixcol_file_id \
+                            ORDER BY lixcol_depth, lixcol_observed_commit_id, lixcol_change_id \
+                        ) AS rn \
+                 FROM lix_history('lix_key_value', $1) \
+             ), local_shadow AS ( \
+                 SELECT lixcol_row_pk, lixcol_file_id \
+                 FROM ranked_local_history WHERE rn = 1 \
+             ), local_state AS ( \
+                 SELECT * FROM lix_state_at('lix_key_value', $1) \
+                 WHERE key IN ('global-only', 'overridden', 'suppressed') \
+             ), global_state AS ( \
+                 SELECT * FROM lix_state_at('lix_key_value', $2) \
+                 WHERE key IN ('global-only', 'overridden', 'suppressed') \
+             ) \
+             SELECT key, value FROM local_state \
+             UNION ALL \
+             SELECT global_state.key, global_state.value \
+             FROM global_state \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 FROM local_shadow \
+                 WHERE local_shadow.lixcol_row_pk = global_state.lixcol_row_pk \
+                   AND local_shadow.lixcol_file_id \
+                       IS NOT DISTINCT FROM global_state.lixcol_file_id \
+             ) \
+             ORDER BY key",
+            &[
+                Value::Text(local_commit_id.clone()),
+                Value::Text(global_commit_id.clone()),
+            ],
+        )
+        .await
+        .expect("pinned branch states should compose with the local shadow set");
+    let expected = vec![
+            vec![
+                Value::Text("global-only".into()),
+                Value::Jsonb(json!("global-only-value").into()),
+            ],
+            vec![
+                Value::Text("overridden".into()),
+                Value::Jsonb(json!("local-value").into()),
+            ],
+        ];
+    assert_rows_eq(composed, expected.clone());
+
+    let live = local
+        .execute(
+            "SELECT key, value FROM lix_key_value \
+             WHERE key IN ('global-only', 'overridden', 'suppressed') ORDER BY key",
+            &[],
+        )
+        .await
+        .expect("live composed view should load");
+    assert_rows_eq(live, expected);
+});

--- a/packages/lix/tests/integration/sql/udfs.rs
+++ b/packages/lix/tests/integration/sql/udfs.rs
@@ -169,7 +169,7 @@ simulation_test!(
             .expect("draft should diverge");
         let diff = draft
             .execute(
-                "SELECT row_pk FROM lix_diff(\
+                "SELECT lixcol_row_pk FROM lix_diff(\
                  'lix_key_value', lix_latest_checkpoint_commit_id(), \
                  lix_active_branch_commit_id())",
                 &[],

--- a/packages/lix/tests/integration/version_control_model_fuzz.rs
+++ b/packages/lix/tests/integration/version_control_model_fuzz.rs
@@ -696,9 +696,9 @@ async fn assert_working_diff(
         .unwrap_or_else(|error| panic!("{label}: checkpoint ID should be text: {error:?}"));
     let rows = session
         .execute(
-            "SELECT row_pk, diff_type \
+            "SELECT lixcol_row_pk, lixcol_diff_type \
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id()) \
-             ORDER BY row_pk",
+             ORDER BY lixcol_row_pk",
             &[Value::Text(checkpoint)],
         )
         .await
@@ -708,7 +708,7 @@ async fn assert_working_diff(
         // `row_pk` is the JSON primary-key tuple, `["<key>"]` for
         // `lix_key_value`.
         let row_pk = row
-            .get::<JsonValue>("row_pk")
+            .get::<JsonValue>("lixcol_row_pk")
             .unwrap_or_else(|error| panic!("{label}: row_pk should be json: {error:?}"));
         let Some(key) = row_pk
             .as_array()
@@ -721,7 +721,7 @@ async fn assert_working_diff(
             continue;
         }
         let diff_type = row
-            .get::<String>("diff_type")
+            .get::<String>("lixcol_diff_type")
             .unwrap_or_else(|error| panic!("{label}: diff_type should be text: {error:?}"));
         actual.push((key.to_string(), diff_type));
     }

--- a/packages/lix/tests/migration_v68.rs
+++ b/packages/lix/tests/migration_v68.rs
@@ -40,7 +40,7 @@ async fn current_format_inspection_recognizes_v68_golden_snapshot() {
             .expect("v68 format inspection should succeed"),
         MigrationStatus::Required {
             from_version: 68,
-            to_version: 73,
+            to_version: 74,
         }
     );
 }
@@ -53,7 +53,7 @@ async fn migrates_external_v68_authority_and_plugin_and_engine_tombstones() {
         inspect_lix(&storage).await.unwrap(),
         MigrationStatus::Required {
             from_version: 68,
-            to_version: 73,
+            to_version: 74,
         }
     );
     let report = migrate_lix(storage.clone(), MigrationOptions::default())
@@ -152,19 +152,19 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
         .await
         .expect("v68 fixture should migrate");
     assert_eq!(report.from_version, 68);
-    assert_eq!(report.to_version, 73);
+    assert_eq!(report.to_version, 74);
     assert!(report.changes_rewritten >= 2);
     assert!(report.commit_members_rewritten >= 2);
     assert!(report.hot_rows_rewritten >= 1);
     assert_eq!(
         inspect_lix(&storage).await.unwrap(),
-        MigrationStatus::Current { version: 73 }
+        MigrationStatus::Current { version: 74 }
     );
     let retry = migrate_lix(storage.clone(), MigrationOptions::default())
         .await
         .expect("migration retry should be idempotent");
-    assert_eq!(retry.from_version, 73);
-    assert_eq!(retry.to_version, 73);
+    assert_eq!(retry.from_version, 74);
+    assert_eq!(retry.to_version, 74);
     assert_eq!(retry.changes_rewritten, 0);
 
     let migrated_snapshot = storage

--- a/packages/lix/tests/migration_v72.rs
+++ b/packages/lix/tests/migration_v72.rs
@@ -23,7 +23,7 @@ async fn migrates_profile_uri_and_persists_updates_across_cold_reopen() {
             .expect("v72 format inspection should succeed"),
         MigrationStatus::Required {
             from_version: 72,
-            to_version: 73,
+            to_version: 74,
         }
     );
     let Err(open_error) = open_lix().with_storage(storage.clone()).await else {
@@ -35,10 +35,10 @@ async fn migrates_profile_uri_and_persists_updates_across_cold_reopen() {
         .await
         .expect("v72 account schema should migrate");
     assert_eq!(report.from_version, 72);
-    assert_eq!(report.to_version, 73);
+    assert_eq!(report.to_version, 74);
     assert_eq!(
         inspect_lix(&storage).await.unwrap(),
-        MigrationStatus::Current { version: 73 }
+        MigrationStatus::Current { version: 74 }
     );
 
     let lix = open_lix()


### PR DESCRIPTION
## Summary

- add branch-scoped `lix_state_at(relation, commit_id)` for immutable typed, file, and directory reads
- reserve `lixcol_` machinery columns and hard-cut diff metadata to `lixcol_row_pk`, `lixcol_diff_type`, and `lixcol_row_count`
- introduce repository format v74 with an authenticated row-primary-key history index, immutable branch-scope provenance, resumable migration, and sync compatibility
- document tombstone-preserving local/global composition and add a release changenote

## Validation

- `cargo test -p lix --features all-simulations` (3,344 passed; 26 ignored; external tests and 10 doctests passed)
- correctness, API, and performance reviews by independent sub-agents; no remaining P0/P1 findings
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

`cargo nextest` is not installed in the environment; the complete Cargo test suite was run instead.