### PR TITLE
fix(session): keep armed observations from deadlocking switch_branch

### DIFF
--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1476,7 +1476,17 @@ where
         // Live rows and lix_active_branch_commit_id() must describe one
         // state. Refresh a stale local composite handle lazily on access;
         // global writes stay O(1) instead of fanning out over every branch.
-        self.refresh_active_branch_base_if_stale().await?;
+        //
+        // Never on the observe path (deferred file-view acknowledgement is
+        // its marker): the observation loop runs this execute under its own
+        // waitable-operation guard, and a refresh that needs session write
+        // access would drain operations and self-deadlock on that guard. The
+        // loop refreshes before taking the guard instead, and a bump landing
+        // in between also re-runs the evaluation, so the next iteration
+        // observes the refreshed base.
+        if !defer_file_view_acknowledgement {
+            self.refresh_active_branch_base_if_stale().await?;
+        }
 
         let exact_filesystem_read = exact_filesystem_read_route(&statement, params);
         let exact_schema_point_read = exact_filesystem_read

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -264,6 +264,11 @@ where
     ) -> Result<ExecuteResult, LixError> {
         let mut retry = crate::sync::SyncDemandRetry::default();
         loop {
+            // Refresh a stale base before entering the operation guard: the
+            // refresh may need session write access, which drains waitable
+            // operations — taking it while holding this observation's own
+            // guard would self-deadlock.
+            session.refresh_active_branch_base_if_stale().await?;
             let operation_guard = session.begin_waitable_session_operation().await?;
             let rows = Box::pin(session.execute_for_observe(sql, params)).await;
             drop(operation_guard);

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -112,7 +112,6 @@ pub(crate) use storage::{
     load_local_commit_delta_members_with_payloads, load_local_selected_change_owner_commit_ids,
     load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
     load_published_commit_state_topology, load_retained_commit_snapshots_for_schemas,
-    missing_commit_state_manifest_error,
     scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_members,
     scan_commit_delta_values, scan_commit_state_manifest_commit_ids,
     selected_change_selection_fingerprint,


### PR DESCRIPTION
An armed observation (`events.next()` pending) evaluates its query under its own waitable-operation guard. Since #1638, `switch_branch` bumps the observer invalidation generation before its boundary refresh, so the re-evaluation races in and its lazy `refresh_active_branch_base_if_stale()` can need session write access — which drains waitable operations, waiting on the observation's own guard. `switch_branch` meanwhile waits on the observation: both sides deadlock. Reproduces with a pure-Rust armed-observe + `switch_branch` scenario (and in atelier's "preserves main content when switching" test, 60s timeout).

Fix:
- The observe loop refreshes a stale base **before** taking its operation guard.
- The in-execute lazy refresh is skipped on the observe path. A generation bump landing between the pre-guard refresh and the guarded execute re-runs the evaluation anyway, so the next iteration observes the refreshed base — no stale reads.

Reordering `switch_branch` (refresh before bump) is not an option: the refresh's staleness gate keys off the bumped generation, and the reorder breaks the bounded-base-refresh invariants (4 lib tests).

Verified: full `lix --lib` suite (2925 passed, 1 known load-flake passes standalone), the 4 base-refresh sentinel tests, `sync_mode` e2e (17 passed), and atelier's full suite (1093 passed) against the rebuilt native engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)