### PR TITLE
fix(session): retry expired reads inside the lazy base refresh

### DIFF
--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1625,7 +1625,33 @@ where
         Ok(result)
     }
 
+    /// Runs the base refresh under the shared bounded expired-read policy.
+    ///
+    /// The refresh's reads run outside the execute read loop's retry
+    /// protection, and on cross-context stores a concurrent commit can
+    /// invalidate them at any point — during sync churn that made every
+    /// stale-base execute surface `LIX_STORAGE_READ_EXPIRED` on its first
+    /// expiry. The unit is safe to restart: it re-reads the generation and
+    /// branch heads from scratch and stores the generation only on success.
     pub(super) async fn refresh_active_branch_base_if_stale(&self) -> Result<(), LixError> {
+        let mut retry = ExpiredReadRetryState::default();
+        loop {
+            match self.refresh_active_branch_base_if_stale_inner().await {
+                Err(error) => {
+                    let Some(delay) = retry.next_delay(&error) else {
+                        return Err(error);
+                    };
+                    tokio::task::yield_now().await;
+                    if !delay.is_zero() {
+                        crate::sync::sleep(delay).await;
+                    }
+                }
+                result => return result,
+            }
+        }
+    }
+
+    async fn refresh_active_branch_base_if_stale_inner(&self) -> Result<(), LixError> {
         let invalidation_generation = self.observe_invalidation.generation();
         if self.base_refresh_generation.load(Ordering::SeqCst) == invalidation_generation {
             return Ok(());

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -414,6 +414,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_base_execute_retries_an_expired_refresh_read() {
+        // The lazy base refresh reads outside the execute read loop's retry
+        // protection; a concurrent commit expiring its coherent read must be
+        // retried, not surfaced from a one-shot execute.
+        let expire_reads = Arc::new(AtomicU64::new(0));
+        let storage = ExpiringStorage {
+            inner: Memory::new(),
+            expire_reads: Arc::clone(&expire_reads),
+        };
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize storage");
+        let engine = Engine::new(storage).await.expect("open engine");
+        let session = engine
+            .open_session_at(&receipt.main_branch_id)
+            .await
+            .expect("open pinned main session");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observed', 'yes')",
+                &[],
+            )
+            .await
+            .expect("insert commits");
+        // The insert left the base stale; expire the refresh's next read.
+        expire_reads.store(1, Ordering::SeqCst);
+        let rows = session
+            .execute("SELECT value FROM lix_key_value WHERE key = 'observed'", &[])
+            .await
+            .expect("a transient expired refresh read must not fail the execute");
+        assert_eq!(rows.rows().len(), 1);
+    }
+
+    #[tokio::test]
     async fn transient_expired_read_reevaluates_instead_of_erroring_the_stream() {
         let expire_reads = Arc::new(AtomicU64::new(0));
         let storage = ExpiringStorage {


### PR DESCRIPTION
Second finding from lixray's deployed two-client Preview-sync E2E ([opral/lixray#291](https://github.com/opral/lixray/pull/291)): after #1643 fixed the observe stream, the test got much further and then crashed the Atelier shell with the same `LIX_STORAGE_READ_EXPIRED` — this time from a one-shot execute.

Root cause: `refresh_active_branch_base_if_stale` reads (`begin_read`, branch-head loads, commit-node load) run *before* the execute read loop's bounded expired-read retry protection, and the read path — unlike the write path's auto-commit retry — has nothing above the refresh either. On OPFS, where any cross-tab commit invalidates open coherent reads, every stale-base execute could surface the transient on its first expiry.

The refresh now runs under the shared `ExpiredReadRetryState` policy (same 3s budget and backoff as the execute read loop and repository open). The unit is safe to restart: it re-reads the generation and branch heads from scratch and stores the generation only on success. No locks are held between attempts, so there is no interaction with the write lease or collaboration gate.

Regression test: a stale-base execute whose refresh read expires once must succeed (fails without the fix, since the injected error propagated before any retry). Full `lix --lib` (2885 passed) and CI-config clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)