### PR TITLE
fix(migration): fail closed on clock-skewed base inference, add v75 changenotes

### DIFF
--- a/.changenotes/migration-report-drops-hot-rows-rewritten.md
+++ b/.changenotes/migration-report-drops-hot-rows-rewritten.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+`MigrationReport` no longer carries the `hot_rows_rewritten` field.
+
+The field belonged to the retired pre-v72 migration chain and always reported zero on every path the v75 migration supports. Callers logging or persisting migration reports should drop the field; `changes_rewritten` and `commit_members_rewritten` remain.

--- a/.changenotes/v75-complete-snapshot-commits.md
+++ b/.changenotes/v75-complete-snapshot-commits.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Repository format v75 makes every commit a complete state snapshot: `lix_commit.base_commit_id` names the exact global commit whose state composes beneath a local commit's overlay, so branch-scoped and point-in-time reads (`lix_state_at`) are exact rather than replay-derived.
+
+Existing repositories require the explicit offline migration (`migrate_lix`) before opening. The migration upgrades v72–v74 repositories in place — inferring each local commit's base chronologically, repairing filesystem trees that v72-era partial checkpoints left without their ancestor directories, and fencing every step so an interruption is either cleanly retryable or refused by older engines. Repositories below v72, or repositories whose commit timestamps contradict the chronological inference, are rejected with an explicit error instead of migrating on guessed history.

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -1114,16 +1114,21 @@ where
         } else {
             let newest_not_after = global_chronology
                 .partition_point(|(created_at, _, _)| *created_at <= record.created_at);
-            // Clock skew across devices can stamp a local commit earlier
-            // than every global-lineage commit — the lineage root carries
-            // the creating device's clock. Clamp to the oldest lineage
-            // commit instead of failing the migration forever: a synced
-            // local commit observed at least the state the lineage began
-            // with.
-            let index = newest_not_after.saturating_sub(1);
-            let (_, _, base) = global_chronology
-                .get(index)
-                .expect("the global lineage walk pushed at least the head");
+            // A local commit stamped before every global-lineage commit
+            // means the timestamps contradict the chronological premise
+            // itself (device clock skew). Fail closed before any write: a
+            // guessed base would permanently misattribute every later
+            // `lix_state_at` read at this commit with no error, ever. The
+            // named commit gives the operator something to investigate.
+            let Some((_, _, base)) = newest_not_after
+                .checked_sub(1)
+                .and_then(|index| global_chronology.get(index))
+            else {
+                return Err(migration_error(format!(
+                    "{operation} local commit '{}' predates every global-lineage commit",
+                    record.commit_id
+                )));
+            };
             Some(*base)
         };
         let upgraded = crate::changelog::CommitRecord {


### PR DESCRIPTION
Addresses the request-changes on #1645:

- **Reverts the clock-skew clamp from #1642.** A local commit stamped before every global-lineage commit means the timestamps contradict the chronological inference's premise; a clamped `base_commit_id` is a guessed permanent fact that silently misattributes every later `lix_state_at` read at that commit. The migration now fails closed — deterministically, before any write, naming the commit — matching the fail-closed posture of the rest of the chain (truncation bounds, format_version guard, rewrite fences).
- **Adds the missing changenotes** for the v75 / `base_commit_id` complete-snapshot cut and for dropping `MigrationReport.hot_rows_rewritten`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)