### PR TITLE
fix: ancestry-resolved repairs, provenance-correct HOT diffs, switch rollback

### DIFF
--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -510,6 +510,122 @@ where
     Ok(members_injected)
 }
 
+fn migration_snapshot_text(
+    row: &crate::tracked_state::MaterializedTrackedStateRow,
+    field: &str,
+) -> Option<String> {
+    let snapshot = row.decoded_snapshot.as_ref()?;
+    match snapshot.row.get(field) {
+        Some(lix_schema::Value::Text(value)) => Some(value.clone()),
+        Some(lix_schema::Value::Uuid(value)) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+struct CommitGraphNode {
+    parents: Vec<crate::changelog::CommitId>,
+    base: Option<crate::changelog::CommitId>,
+}
+
+/// Every commit whose state the given commit resolves: the causal parent
+/// closure plus, for local commits, the pinned global base lineage their
+/// trees compose beneath the local overlay.
+fn commit_ancestors(
+    commit_id: crate::changelog::CommitId,
+    commit_graph: &BTreeMap<crate::changelog::CommitId, CommitGraphNode>,
+) -> BTreeSet<crate::changelog::CommitId> {
+    let mut seen = BTreeSet::new();
+    let mut worklist = vec![commit_id];
+    while let Some(current) = worklist.pop() {
+        if !seen.insert(current) {
+            continue;
+        }
+        if let Some(node) = commit_graph.get(&current) {
+            worklist.extend(node.parents.iter().copied());
+            if let Some(base) = node.base {
+                worklist.push(base);
+            }
+        }
+    }
+    seen
+}
+
+/// Expands the missing set to its full ancestor-directory closure, resolving
+/// each directory to its version as of the repaired commit: only candidate
+/// rows owned by one of the commit's ancestors are admissible, and the
+/// causally newest admissible version wins — a version is superseded exactly
+/// when its owning commit is a strict ancestor of another admissible
+/// version's owner. Wall-clock timestamps never rank versions: synchronized
+/// commit headers carry remote clocks and are not monotonic along the graph.
+/// An id with no admissible version, or with causally incomparable surviving
+/// versions, fails closed.
+fn resolve_missing_directory_closure(
+    present: &BTreeSet<String>,
+    referenced: &BTreeSet<String>,
+    ancestors: &BTreeSet<crate::changelog::CommitId>,
+    candidates: &BTreeMap<String, Vec<crate::tracked_state::MaterializedTrackedStateRow>>,
+    commit_graph: &BTreeMap<crate::changelog::CommitId, CommitGraphNode>,
+) -> Result<BTreeMap<String, crate::tracked_state::MaterializedTrackedStateRow>, (String, &'static str)>
+{
+    let mut resolved = BTreeMap::new();
+    let mut worklist = referenced
+        .difference(present)
+        .cloned()
+        .collect::<Vec<_>>();
+    while let Some(id) = worklist.pop() {
+        if resolved.contains_key(&id) {
+            continue;
+        }
+        let admissible = candidates
+            .get(&id)
+            .into_iter()
+            .flatten()
+            .filter(|row| ancestors.contains(&row.commit_id))
+            .collect::<Vec<_>>();
+        if admissible.is_empty() {
+            return Err((id, "no tree owned by that commit's ancestry carries it"));
+        }
+        let mut owner_ancestry = BTreeMap::new();
+        for row in &admissible {
+            owner_ancestry
+                .entry(row.commit_id)
+                .or_insert_with(|| commit_ancestors(row.commit_id, commit_graph));
+        }
+        let mut winner: Option<&crate::tracked_state::MaterializedTrackedStateRow> = None;
+        let mut ambiguous = false;
+        for row in &admissible {
+            let strictly_superseded = admissible.iter().any(|other| {
+                owner_ancestry[&other.commit_id].contains(&row.commit_id)
+                    && !owner_ancestry[&row.commit_id].contains(&other.commit_id)
+            });
+            if strictly_superseded {
+                continue;
+            }
+            match winner {
+                None => winner = Some(row),
+                Some(current) if current.change_id == row.change_id => {}
+                Some(_) => ambiguous = true,
+            }
+        }
+        if ambiguous {
+            return Err((
+                id,
+                "its surviving versions are causally incomparable merge ancestors",
+            ));
+        }
+        let row = winner
+            .expect("a non-empty admissible set has a maximal element")
+            .clone();
+        if let Some(parent) = migration_snapshot_text(&row, "parent_id")
+            && !present.contains(&parent)
+        {
+            worklist.push(parent);
+        }
+        resolved.insert(id, row);
+    }
+    Ok(resolved)
+}
+
 /// Repairs filesystem closure inside every commit tree before v75 publishes.
 ///
 /// v72-era partial checkpoints on migrated repositories could commit a file
@@ -520,8 +636,9 @@ where
 /// change record, resolved to the version current as of the repaired
 /// commit: among every candidate row version found in any commit tree, only
 /// those whose owning commit is an ancestor of the repaired commit are
-/// admissible, and the newest such version wins — a later rename or move at
-/// a branch head never leaks backward into history. No new change records
+/// admissible, and the causally newest such version wins — a later rename
+/// or move at a branch head never leaks backward into history, and
+/// wall-clock order never decides between versions. No new change records
 /// are created and commit deltas stay untouched, so touched-scope digests
 /// remain valid; the referenced owning commits are already retained by the
 /// commits whose trees carry them.
@@ -541,18 +658,6 @@ where
     const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
     const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 
-    fn snapshot_text(
-        row: &crate::tracked_state::MaterializedTrackedStateRow,
-        field: &str,
-    ) -> Option<String> {
-        let snapshot = row.decoded_snapshot.as_ref()?;
-        match snapshot.row.get(field) {
-            Some(lix_schema::Value::Text(value)) => Some(value.clone()),
-            Some(lix_schema::Value::Uuid(value)) => Some(value.to_string()),
-            _ => None,
-        }
-    }
-
     fn index_value_ref(
         row: &crate::tracked_state::MaterializedTrackedStateRow,
     ) -> Result<crate::tracked_state::TrackedStateIndexValueRef, LixError> {
@@ -565,81 +670,6 @@ where
             updated_at: crate::common::LixTimestamp::parse(&row.updated_at)
                 .map_err(|error| migration_error(format!("repair updated_at: {error}")))?,
         })
-    }
-
-    struct CommitGraphNode {
-        created_at: crate::common::LixTimestamp,
-        parents: Vec<crate::changelog::CommitId>,
-        base: Option<crate::changelog::CommitId>,
-    }
-
-    /// Every commit whose state the given commit resolves: the causal parent
-    /// closure plus, for local commits, the pinned global base lineage their
-    /// trees compose beneath the local overlay.
-    fn commit_ancestors(
-        commit_id: crate::changelog::CommitId,
-        commit_graph: &BTreeMap<crate::changelog::CommitId, CommitGraphNode>,
-    ) -> BTreeSet<crate::changelog::CommitId> {
-        let mut seen = BTreeSet::new();
-        let mut worklist = vec![commit_id];
-        while let Some(current) = worklist.pop() {
-            if !seen.insert(current) {
-                continue;
-            }
-            if let Some(node) = commit_graph.get(&current) {
-                worklist.extend(node.parents.iter().copied());
-                if let Some(base) = node.base {
-                    worklist.push(base);
-                }
-            }
-        }
-        seen
-    }
-
-    /// Expands the missing set to its full ancestor-directory closure,
-    /// resolving each directory to its version as of the repaired commit:
-    /// only candidate rows owned by one of the commit's ancestors are
-    /// admissible, and the newest such version wins. Returns the first id no
-    /// admissible candidate resolves.
-    fn resolve_missing_directory_closure(
-        present: &BTreeSet<String>,
-        referenced: &BTreeSet<String>,
-        ancestors: &BTreeSet<crate::changelog::CommitId>,
-        candidates: &BTreeMap<String, Vec<crate::tracked_state::MaterializedTrackedStateRow>>,
-        commit_graph: &BTreeMap<crate::changelog::CommitId, CommitGraphNode>,
-    ) -> Result<BTreeMap<String, crate::tracked_state::MaterializedTrackedStateRow>, String> {
-        let mut resolved = BTreeMap::new();
-        let mut worklist = referenced
-            .difference(present)
-            .cloned()
-            .collect::<Vec<_>>();
-        while let Some(id) = worklist.pop() {
-            if resolved.contains_key(&id) {
-                continue;
-            }
-            let row = candidates
-                .get(&id)
-                .into_iter()
-                .flatten()
-                .filter(|row| ancestors.contains(&row.commit_id))
-                .max_by_key(|row| {
-                    (
-                        commit_graph.get(&row.commit_id).map(|node| node.created_at),
-                        row.commit_id,
-                    )
-                })
-                .cloned();
-            let Some(row) = row else {
-                return Err(id);
-            };
-            if let Some(parent) = snapshot_text(&row, "parent_id")
-                && !present.contains(&parent)
-            {
-                worklist.push(parent);
-            }
-            resolved.insert(id, row);
-        }
-        Ok(resolved)
     }
 
     fn push_missing_directories(
@@ -720,7 +750,6 @@ where
             commit_graph.insert(
                 record.commit_id,
                 CommitGraphNode {
-                    created_at: record.created_at,
                     parents: record.parent_commit_ids.clone(),
                     base: record.base_commit_id,
                 },
@@ -770,15 +799,15 @@ where
         for row in &rows {
             match row.schema_key.as_str() {
                 DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
-                    if let Some(id) = snapshot_text(row, "id") {
+                    if let Some(id) = migration_snapshot_text(row, "id") {
                         present.insert(id);
                     }
-                    if let Some(parent) = snapshot_text(row, "parent_id") {
+                    if let Some(parent) = migration_snapshot_text(row, "parent_id") {
                         referenced.insert(parent);
                     }
                 }
                 FILE_DESCRIPTOR_SCHEMA_KEY => {
-                    if let Some(directory) = snapshot_text(row, "directory_id") {
+                    if let Some(directory) = migration_snapshot_text(row, "directory_id") {
                         referenced.insert(directory);
                     }
                 }
@@ -787,7 +816,7 @@ where
         }
         for row in rows {
             if row.schema_key == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
-                && let Some(id) = snapshot_text(&row, "id")
+                && let Some(id) = migration_snapshot_text(&row, "id")
             {
                 // Every distinct version of the directory row is a repair
                 // candidate; admissibility per commit is decided by
@@ -820,10 +849,10 @@ where
             &candidates,
             &commit_graph,
         )
-        .map_err(|id| {
+        .map_err(|(id, reason)| {
             migration_error(format!(
                 "{operation} cannot resolve directory '{id}' referenced by commit \
-                 '{commit_id}' from any tree owned by that commit's ancestry"
+                 '{commit_id}': {reason}"
             ))
         })?;
         let missing = missing_rows.keys().cloned().collect::<Vec<_>>();
@@ -1745,6 +1774,98 @@ mod tests {
                 version: CURRENT_FORMAT_VERSION,
             }
         );
+    }
+
+    fn repair_candidate_row(
+        directory_id: &str,
+        created_at: &str,
+        change_label: &str,
+        commit_id: CommitId,
+    ) -> crate::tracked_state::MaterializedTrackedStateRow {
+        crate::tracked_state::MaterializedTrackedStateRow {
+            row_pk: crate::row_pk::RowPk::single(directory_id),
+            schema_key: "lix_directory_descriptor".to_string(),
+            file_id: None,
+            snapshot_content: None,
+            decoded_snapshot: None,
+            metadata: None,
+            deleted: false,
+            created_at: created_at.to_string(),
+            updated_at: created_at.to_string(),
+            change_id: crate::changelog::ChangeId::for_test_label(change_label),
+            commit_id,
+        }
+    }
+
+    fn repair_test_commit(label: u128) -> CommitId {
+        CommitId::with_change_address_space(uuid::Uuid::from_u128(label))
+    }
+
+    #[test]
+    fn repair_resolution_ranks_versions_causally_not_by_wall_clock() {
+        // Chain A <- B <- C. The version owned by ancestor A carries a LATER
+        // wall clock than the causally newer version owned by B: clocks are
+        // not monotonic along the graph, so B's version must win.
+        let a = repair_test_commit(0xA1);
+        let b = repair_test_commit(0xB2);
+        let c = repair_test_commit(0xC3);
+        let mut graph = BTreeMap::new();
+        graph.insert(a, CommitGraphNode { parents: vec![], base: None });
+        graph.insert(b, CommitGraphNode { parents: vec![a], base: None });
+        graph.insert(c, CommitGraphNode { parents: vec![b], base: None });
+        let mut candidates = BTreeMap::new();
+        candidates.insert(
+            "d1".to_string(),
+            vec![
+                repair_candidate_row("d1", "2026-01-05T00:00:00.000Z", "stale-late-clock", a),
+                repair_candidate_row("d1", "2026-01-01T00:00:00.000Z", "current-early-clock", b),
+            ],
+        );
+        let present = BTreeSet::new();
+        let referenced = BTreeSet::from(["d1".to_string()]);
+        let ancestors = commit_ancestors(c, &graph);
+
+        let resolved =
+            resolve_missing_directory_closure(&present, &referenced, &ancestors, &candidates, &graph)
+                .expect("linear versions resolve");
+        assert_eq!(
+            resolved["d1"].change_id,
+            crate::changelog::ChangeId::for_test_label("current-early-clock"),
+            "the causally newest admissible version wins regardless of clocks"
+        );
+    }
+
+    #[test]
+    fn repair_resolution_fails_closed_on_incomparable_versions() {
+        // Merge M of B and D, each owning a different version of the same
+        // directory: no causal winner exists, so the repair must refuse
+        // rather than guess.
+        let a = repair_test_commit(0xA1);
+        let b = repair_test_commit(0xB2);
+        let d = repair_test_commit(0xD4);
+        let m = repair_test_commit(0xE5);
+        let mut graph = BTreeMap::new();
+        graph.insert(a, CommitGraphNode { parents: vec![], base: None });
+        graph.insert(b, CommitGraphNode { parents: vec![a], base: None });
+        graph.insert(d, CommitGraphNode { parents: vec![a], base: None });
+        graph.insert(m, CommitGraphNode { parents: vec![b, d], base: None });
+        let mut candidates = BTreeMap::new();
+        candidates.insert(
+            "d1".to_string(),
+            vec![
+                repair_candidate_row("d1", "2026-01-01T00:00:00.000Z", "left-version", b),
+                repair_candidate_row("d1", "2026-01-02T00:00:00.000Z", "right-version", d),
+            ],
+        );
+        let present = BTreeSet::new();
+        let referenced = BTreeSet::from(["d1".to_string()]);
+        let ancestors = commit_ancestors(m, &graph);
+
+        let (id, reason) =
+            resolve_missing_directory_closure(&present, &referenced, &ancestors, &candidates, &graph)
+                .expect_err("incomparable merge-ancestor versions must fail closed");
+        assert_eq!(id, "d1");
+        assert!(reason.contains("incomparable"), "got reason: {reason}");
     }
 
     #[tokio::test]

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -517,11 +517,14 @@ where
 /// files reference directories absent from the same tree. Every strict v75
 /// read of such a tree fails. The repair injects the missing directory rows
 /// as tree index entries referencing the directory's existing authoritative
-/// change record, resolved from the branch heads' trees or from any commit
-/// tree that still carries the descriptor — the recoverable sources. No new
-/// change records are created and commit deltas stay untouched, so
-/// touched-scope digests remain valid; the referenced owning commits are
-/// already retained by the commits whose trees carry them.
+/// change record, resolved to the version current as of the repaired
+/// commit: among every candidate row version found in any commit tree, only
+/// those whose owning commit is an ancestor of the repaired commit are
+/// admissible, and the newest such version wins — a later rename or move at
+/// a branch head never leaks backward into history. No new change records
+/// are created and commit deltas stay untouched, so touched-scope digests
+/// remain valid; the referenced owning commits are already retained by the
+/// commits whose trees carry them.
 ///
 /// Tree-chunk writes commit here — content-addressed, safe if orphaned by a
 /// crash — while the returned manifests must be published by the caller
@@ -564,35 +567,79 @@ where
         })
     }
 
-    /// Expands the missing set to its full ancestor closure through `source`,
-    /// or reports the first directory id no recoverable source resolves.
-    fn missing_directory_closure(
+    struct CommitGraphNode {
+        created_at: crate::common::LixTimestamp,
+        parents: Vec<crate::changelog::CommitId>,
+        base: Option<crate::changelog::CommitId>,
+    }
+
+    /// Every commit whose state the given commit resolves: the causal parent
+    /// closure plus, for local commits, the pinned global base lineage their
+    /// trees compose beneath the local overlay.
+    fn commit_ancestors(
+        commit_id: crate::changelog::CommitId,
+        commit_graph: &BTreeMap<crate::changelog::CommitId, CommitGraphNode>,
+    ) -> BTreeSet<crate::changelog::CommitId> {
+        let mut seen = BTreeSet::new();
+        let mut worklist = vec![commit_id];
+        while let Some(current) = worklist.pop() {
+            if !seen.insert(current) {
+                continue;
+            }
+            if let Some(node) = commit_graph.get(&current) {
+                worklist.extend(node.parents.iter().copied());
+                if let Some(base) = node.base {
+                    worklist.push(base);
+                }
+            }
+        }
+        seen
+    }
+
+    /// Expands the missing set to its full ancestor-directory closure,
+    /// resolving each directory to its version as of the repaired commit:
+    /// only candidate rows owned by one of the commit's ancestors are
+    /// admissible, and the newest such version wins. Returns the first id no
+    /// admissible candidate resolves.
+    fn resolve_missing_directory_closure(
         present: &BTreeSet<String>,
         referenced: &BTreeSet<String>,
-        source: &BTreeMap<String, crate::tracked_state::MaterializedTrackedStateRow>,
-    ) -> Result<Vec<String>, String> {
-        let mut missing = Vec::new();
+        ancestors: &BTreeSet<crate::changelog::CommitId>,
+        candidates: &BTreeMap<String, Vec<crate::tracked_state::MaterializedTrackedStateRow>>,
+        commit_graph: &BTreeMap<crate::changelog::CommitId, CommitGraphNode>,
+    ) -> Result<BTreeMap<String, crate::tracked_state::MaterializedTrackedStateRow>, String> {
+        let mut resolved = BTreeMap::new();
         let mut worklist = referenced
             .difference(present)
             .cloned()
             .collect::<Vec<_>>();
-        let mut seen = BTreeSet::new();
         while let Some(id) = worklist.pop() {
-            if !seen.insert(id.clone()) {
+            if resolved.contains_key(&id) {
                 continue;
             }
-            let Some(row) = source.get(&id) else {
+            let row = candidates
+                .get(&id)
+                .into_iter()
+                .flatten()
+                .filter(|row| ancestors.contains(&row.commit_id))
+                .max_by_key(|row| {
+                    (
+                        commit_graph.get(&row.commit_id).map(|node| node.created_at),
+                        row.commit_id,
+                    )
+                })
+                .cloned();
+            let Some(row) = row else {
                 return Err(id);
             };
-            if let Some(parent) = snapshot_text(row, "parent_id")
+            if let Some(parent) = snapshot_text(&row, "parent_id")
                 && !present.contains(&parent)
             {
                 worklist.push(parent);
             }
-            missing.push(id);
+            resolved.insert(id, row);
         }
-        missing.sort();
-        Ok(missing)
+        Ok(resolved)
     }
 
     fn push_missing_directories(
@@ -626,51 +673,64 @@ where
         .map_err(storage_error)?;
     let commit_ids = crate::tracked_state::scan_commit_state_manifest_commit_ids(&read).await?;
 
-    // The recoverable descriptor sources: directory rows visible at any
-    // branch head's tree, extended below with every audited commit tree so a
-    // directory later deleted from all heads still resolves. First writer
-    // wins — the repair needs any resolvable authoritative change record for
-    // the id, not the newest revision.
-    let heads = BranchHeadControlContext::new()
-        .reader(read.clone())
-        .scan()
-        .await?
-        .into_iter()
-        .map(|(_, control)| control.head_commit_id)
-        .collect::<BTreeSet<_>>();
-    let mut source = BTreeMap::<String, crate::tracked_state::MaterializedTrackedStateRow>::new();
-    let mut reader = TrackedStateContext::new().reader(read.clone());
-    for head in &heads {
-        let rows = reader
-            .scan_batch_at_commit(
-                &head.to_string(),
-                &TrackedStateScanRequest {
-                    filter: TrackedStateFilter {
-                        schema_keys: vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_owned()],
-                        ..TrackedStateFilter::default()
-                    },
-                    read_columns: TrackedStateReadColumns::default(),
-                    // Scans truncate silently at their limit; request one row
-                    // beyond the bound so truncation is detected, never
-                    // mistaken for a complete result.
-                    limit: Some(options.max_changes.saturating_add(1)),
-                },
-            )
-            .await?
-            .into_rows();
-        if rows.len() > options.max_changes {
-            return Err(LixError::new(
-                "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
-                format!("{operation} head tree exceeds configured row bound"),
-            ));
-        }
-        for row in rows {
-            let Some(id) = snapshot_text(&row, "id") else {
-                continue;
+    // The commit graph resolves version admissibility below: a candidate
+    // directory row may repair a commit only when its owning commit is an
+    // ancestor. Records decode with the current codec because the v6 rewrite
+    // runs earlier in this same migration step's chain.
+    let mut commit_graph = BTreeMap::new();
+    let mut cursor = read
+        .begin_scan(
+            crate::changelog::COMMIT_SPACE,
+            StorageKeyRange {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            },
+            StorageBeginScanOptions {
+                projection: CoreProjection::FullValue,
+                ..StorageBeginScanOptions::default()
+            },
+        )
+        .await
+        .map_err(storage_error)?;
+    while let Some(entries) = cursor.next_chunk().await.map_err(storage_error)? {
+        for entry in entries {
+            if commit_graph.len() > options.max_changes {
+                return Err(LixError::new(
+                    "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+                    format!(
+                        "{operation} exceeds configured commit bound: {} commits",
+                        commit_graph.len()
+                    ),
+                ));
+            }
+            let ProjectedValue::FullValue(value) = entry.value else {
+                return Err(migration_error(format!(
+                    "{operation} commit scan omitted a value"
+                )));
             };
-            source.entry(id).or_insert(row);
+            let record = crate::storage_codec::decode::<crate::changelog::CommitRecord>(
+                "commit record",
+                &value,
+            )
+            .map_err(|error| {
+                migration_error(format!(
+                    "{operation} could not decode a commit record: {error}"
+                ))
+            })?;
+            commit_graph.insert(
+                record.commit_id,
+                CommitGraphNode {
+                    created_at: record.created_at,
+                    parents: record.parent_commit_ids.clone(),
+                    base: record.base_commit_id,
+                },
+            );
         }
     }
+    drop(cursor);
+    let mut candidates =
+        BTreeMap::<String, Vec<crate::tracked_state::MaterializedTrackedStateRow>>::new();
+    let mut reader = TrackedStateContext::new().reader(read.clone());
 
     // First pass: audit every commit tree. An incomplete tree defers to the
     // second pass so its closure resolves against directory rows from every
@@ -729,7 +789,16 @@ where
             if row.schema_key == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
                 && let Some(id) = snapshot_text(&row, "id")
             {
-                source.entry(id).or_insert(row);
+                // Every distinct version of the directory row is a repair
+                // candidate; admissibility per commit is decided by
+                // ancestry when a closure resolves.
+                let versions = candidates.entry(id).or_default();
+                if !versions
+                    .iter()
+                    .any(|existing| existing.change_id == row.change_id)
+                {
+                    versions.push(row);
+                }
             }
         }
         if referenced.difference(&present).next().is_some() {
@@ -743,13 +812,21 @@ where
     let mut injected_total = 0_u64;
     for (commit_id, present, referenced) in audits {
         let commit_key = commit_id.to_string();
-        let missing = missing_directory_closure(&present, &referenced, &source)
-            .map_err(|id| {
-                migration_error(format!(
-                    "{operation} cannot resolve directory '{id}' referenced by commit \
-                     '{commit_id}' from any branch head or commit tree"
-                ))
-            })?;
+        let ancestors = commit_ancestors(commit_id, &commit_graph);
+        let missing_rows = resolve_missing_directory_closure(
+            &present,
+            &referenced,
+            &ancestors,
+            &candidates,
+            &commit_graph,
+        )
+        .map_err(|id| {
+            migration_error(format!(
+                "{operation} cannot resolve directory '{id}' referenced by commit \
+                 '{commit_id}' from any tree owned by that commit's ancestry"
+            ))
+        })?;
+        let missing = missing_rows.keys().cloned().collect::<Vec<_>>();
 
         let mut manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
             .await?
@@ -762,7 +839,7 @@ where
             crate::tracked_state::TrackedStateMutationBatchBuilder::with_row_capacity(
                 missing.len(),
             );
-        push_missing_directories(&mut injected, &missing, &source)?;
+        push_missing_directories(&mut injected, &missing, &missing_rows)?;
         let (primary, secondary) =
             crate::tracked_state::with_row_pk_index_mutations(injected.finish())?;
 
@@ -829,7 +906,7 @@ where
                     index_value_ref(row)?,
                 );
             }
-            push_missing_directories(&mut full, &missing, &source)?;
+            push_missing_directories(&mut full, &missing, &missing_rows)?;
             let result = tree
                 .apply_mutations_with_overlay(
                     &read,

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -112,12 +112,22 @@ pub(crate) async fn load_default_branch_id_from_index(
 #[derive(Clone)]
 pub(crate) struct SessionBranch {
     branch_id: Arc<RwLock<String>>,
+    // Serializes switch_branch across session clones: the checkout's
+    // boundary refresh runs after session write access drops, so without
+    // this lock a concurrent clone's switch could interleave with a
+    // failing switch's selector rollback.
+    switch_serial: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl SessionBranch {
+    pub(crate) async fn begin_switch(&self) -> tokio::sync::OwnedMutexGuard<()> {
+        Arc::clone(&self.switch_serial).lock_owned().await
+    }
+
     pub(crate) fn new(branch_id: String) -> Self {
         Self {
             branch_id: Arc::new(RwLock::new(branch_id)),
+            switch_serial: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 

--- a/packages/lix/src/session/switch_branch.rs
+++ b/packages/lix/src/session/switch_branch.rs
@@ -28,6 +28,11 @@ where
         options: SwitchBranchOptions,
     ) -> Result<SwitchBranchReceipt, LixError> {
         let branch_id = options.branch_id;
+        // One switch at a time across session clones: the selector moves
+        // before the boundary refresh below (its staleness gate keys off the
+        // observer bump), and a refresh failure rolls the selector back —
+        // both steps must not interleave with another clone's switch.
+        let _switch_serial = self.branch.begin_switch().await;
         // Keep the existing session/collaboration lease so branch deletion
         // cannot race target validation. A switch is normally session-local;
         // when the selected local branch pins an older global head, the lazy

--- a/packages/lix/src/session/switch_branch.rs
+++ b/packages/lix/src/session/switch_branch.rs
@@ -47,6 +47,7 @@ where
             )
             .await?;
         self.ensure_open()?;
+        let previous_branch_id = self.bound_branch_id()?;
         self.branch.set(branch_id.clone())?;
         self.observe_invalidation.bump();
         drop(reader);
@@ -54,8 +55,15 @@ where
         drop(write_access);
         // Refresh at the explicit checkout boundary. This keeps observers and
         // other read helpers from discovering that they need an internal write
-        // while already evaluating a stable snapshot.
-        self.refresh_active_branch_base_if_stale().await?;
+        // while already evaluating a stable snapshot. The selector must move
+        // before the bump so the refresh's staleness gate sees the switch;
+        // an error therefore restores the previous selector — a failed
+        // switch must not leave the session silently on the target branch.
+        if let Err(error) = self.refresh_active_branch_base_if_stale().await {
+            self.branch.set(previous_branch_id)?;
+            self.observe_invalidation.bump();
+            return Err(error);
+        }
 
         Ok(SwitchBranchReceipt { branch_id })
     }
@@ -229,6 +237,94 @@ mod tests {
                 && delta.scan_calls <= 20,
             "metadata-only auto-rebase must remain bounded, saw {delta:?}"
         );
+    }
+
+    /// Fails every `begin_write` while armed; reads pass through.
+    #[derive(Clone)]
+    struct WriteFailStorage {
+        inner: Memory,
+        fail_writes: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl Storage for WriteFailStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            self.inner.begin_read(options).await
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            if self.fail_writes.load(Ordering::SeqCst) {
+                return Err(StorageError::Corruption("injected write failure".into()));
+            }
+            self.inner.begin_write(options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_boundary_refresh_rolls_back_the_branch_selector() {
+        // A stale checkout's boundary refresh publishes one commit. When that
+        // write fails, switch_branch returns Err — and must leave the session
+        // on its previous branch, not silently on the target.
+        let fail_writes = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let storage = WriteFailStorage {
+            inner: Memory::new(),
+            fail_writes: Arc::clone(&fail_writes),
+        };
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize storage");
+        let engine = Engine::new(storage).await.expect("open engine");
+        let session = engine
+            .open_session_at(&receipt.main_branch_id)
+            .await
+            .expect("open pinned main session");
+        let branch = session
+            .create_branch(CreateBranchOptions {
+                id: Some("01990000-0000-7000-8000-00000000c003".to_owned()),
+                name: "refresh-rollback".to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create switch target");
+
+        fail_writes.store(true, Ordering::SeqCst);
+        let result = session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: branch.id.clone(),
+            })
+            .await;
+        fail_writes.store(false, Ordering::SeqCst);
+
+        // This setup is the bounded-refresh test's: the stale checkout needs
+        // exactly one commit, so the injected write failure must surface.
+        result.expect_err("the boundary refresh write was injected to fail");
+        assert_eq!(
+            session
+                .active_branch_id()
+                .await
+                .expect("read active branch"),
+            receipt.main_branch_id,
+            "a failed switch must leave the session on its previous branch"
+        );
+        // The session stays fully usable and can complete the switch.
+        let switched = session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: branch.id.clone(),
+            })
+            .await
+            .expect("retry succeeds once writes recover");
+        assert_eq!(switched.branch_id, branch.id);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -303,7 +303,18 @@ where
                     // checkpoint-to-head case, retain HOT_DIFF as the sparse
                     // candidate index and still resolve the final winners
                     // through the composite overlay below.
+                    let needs_global_provenance = schema.fields().iter().any(|field| {
+                        matches!(
+                            field.name().as_str(),
+                            "from_lixcol_global" | "to_lixcol_global"
+                        )
+                    });
+                    // Global provenance must come from the composite overlay
+                    // resolution: the HOT epoch diff carries effective rows
+                    // but not which side an inherited global row supplied, so
+                    // provenance projections take the cold route.
                     let direct_candidates = if !route.request.retain_payloads
+                        && !needs_global_provenance
                         && from_descriptor.base_commit_id == to_descriptor.base_commit_id
                         && let Some(branch_id) = active_branch_id.as_deref()
                         && let (Ok(from_commit), Ok(to_commit)) = (
@@ -344,12 +355,6 @@ where
                         direct_candidates,
                     )
                     .await?;
-                    let needs_global_provenance = schema.fields().iter().any(|field| {
-                        matches!(
-                            field.name().as_str(),
-                            "from_lixcol_global" | "to_lixcol_global"
-                        )
-                    });
                     let (from_global_rows, to_global_rows) = if needs_global_provenance {
                         (from_global_rows, to_global_rows)
                     } else {

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -194,6 +194,50 @@ simulation_test!(relation_diff_preserves_global_scope_on_both_sides, |sim| async
     );
 });
 
+simulation_test!(working_diff_span_reports_global_provenance, |sim| async move {
+    // Regression: the checkpoint-to-head working span with an identity-only
+    // provenance projection selected the HOT fast path, which carries no
+    // provenance sets — a local edit shadowing an inherited global row
+    // reported its global before-side as local.
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global) \
+             VALUES ('shadowed', 'global-value', TRUE)",
+            &[],
+        )
+        .await
+        .expect("global insert should succeed");
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should pin the working-diff cursor");
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('shadowed', 'local-shadow') \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            &[],
+        )
+        .await
+        .expect("active upsert should shadow the inherited global row");
+
+    assert_eq!(
+        select_rows(
+            &session,
+            "SELECT from_lixcol_global, to_lixcol_global \
+             FROM lix_diff('lix_key_value', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()) \
+             WHERE lixcol_row_pk = CAST('[\"shadowed\"]' AS JSONB)",
+        )
+        .await,
+        vec![vec![Value::Boolean(true), Value::Boolean(false)]],
+        "the shadowed row's before-side is the inherited global version",
+    );
+});
+
 simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(


### PR DESCRIPTION
Fixes the three findings from the #1645 release review, each verified against the code and covered by a discriminating regression test:

**P1 — repair injected a head's newer directory version into older commits.** The closure repair resolved missing directories first-writer-wins from branch-head trees, so a directory renamed/moved after the corrupted checkpoint would rewrite that commit's historical name and parent. The repair now collects every distinct row version from every commit tree and, per repaired commit, admits only versions whose owning commit is in that commit's ancestry — causal parents plus the composed global base lineage from `base_commit_id` (decodable because the v6 rewrite runs earlier in the same chain) — newest admissible wins. An id with no admissible version fails closed instead of guessing. The golden fixtures exercise the between-checkpoints creation case (`/brand`) and still pass, as do all 20 `sync_mode` e2e tests.

**P2 — HOT working-span diffs lost global provenance.** With an identity-only projection of `from/to_lixcol_global`, the HOT checkpoint-to-head path was selected and returned empty provenance sets — the regression test shows it reported `[NULL, false]` for a local edit shadowing an inherited global row (the global before-side vanished entirely) where the cold path reports `[true, false]`. Provenance projections now take the composite overlay route, mirroring the existing `retain_payloads` gate.

**P2 — switch_branch left the session on the target branch after a failed refresh.** The selector must move before the observer bump (the refresh's staleness gate keys off it), so an error now rolls the selector back and re-notifies observers; the strict regression test injects a write failure into the boundary refresh and asserts the session stays on its previous branch and can retry.

Full `lix --lib` (2887 passed), migration golden tests, `sync_mode` 20/20, CI-config clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)