### PR TITLE
fix(observe): bound retries and retain semantic errors

### DIFF
--- a/packages/lix/src/observe_coordinator.rs
+++ b/packages/lix/src/observe_coordinator.rs
@@ -10,6 +10,46 @@ use crate::{ExecuteResult, LixError, Value};
 const MAX_CACHED_GENERATIONS_PER_QUERY: usize = 4;
 const MAX_WEAK_QUERY_ENTRIES_BEFORE_PRUNE: usize = 1024;
 
+/// Determines whether an observation failure is part of the query's stable
+/// meaning or belongs to a resumable runtime boundary.
+///
+/// Keep this classification conservative: only deterministic SQL shape and
+/// binding failures are terminal. Unknown/internal failures stay transient so
+/// an observation is never permanently poisoned by an implementation or
+/// storage fault.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ObserveErrorDisposition {
+    SemanticTerminal,
+    SessionState,
+    TransportRecoverable,
+    Closed,
+    Transient,
+}
+
+pub(crate) fn observe_error_disposition(error: &LixError) -> ObserveErrorDisposition {
+    match error.code.as_str() {
+        LixError::CODE_PARSE_ERROR
+        | LixError::CODE_UDF_NOT_FOUND
+        | LixError::CODE_TYPE_MISMATCH
+        | LixError::CODE_INVALID_JSON_PATH
+        | LixError::CODE_DIALECT_UNSUPPORTED
+        | LixError::CODE_BINDING_ERROR
+        | LixError::CODE_INVALID_PARAM
+        | LixError::CODE_TABLE_NOT_FOUND
+        | LixError::CODE_COLUMN_NOT_FOUND
+        | LixError::CODE_UNSUPPORTED_SQL
+        | LixError::CODE_UNSUPPORTED_SQL_RUNTIME_PLAN => ObserveErrorDisposition::SemanticTerminal,
+        LixError::CODE_INVALID_SESSION_STATE | "LIX_INVALID_TRANSACTION_STATE" => {
+            ObserveErrorDisposition::SessionState
+        }
+        "LIX_REMOTE_UNAVAILABLE" => ObserveErrorDisposition::TransportRecoverable,
+        LixError::CODE_CLOSED | LixError::CODE_STORAGE_FENCED | LixError::CODE_STORAGE_CLOSED => {
+            ObserveErrorDisposition::Closed
+        }
+        _ => ObserveErrorDisposition::Transient,
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum ObserveSessionScope {
     Branch(String),
@@ -177,7 +217,7 @@ impl ObserveQueryState {
             {
                 let mut inner = self.lock();
                 if let Some(cached) = inner.cached.get(&generation) {
-                    return Ok(cached.evaluation(generation));
+                    return cached.evaluation(generation);
                 }
 
                 if inner.in_flight.insert(generation) {
@@ -195,6 +235,12 @@ impl ObserveQueryState {
         let guard = InFlightGuard::new(self, generation, compare_results);
         match evaluate().await {
             Ok(rows) => Ok(guard.finish_success(rows)),
+            Err(error)
+                if observe_error_disposition(&error)
+                    == ObserveErrorDisposition::SemanticTerminal =>
+            {
+                Err(guard.finish_terminal_error(error))
+            }
             Err(error) => {
                 guard.finish_without_cache();
                 Err(error)
@@ -233,21 +279,38 @@ struct ObserveQueryStateInner {
 }
 
 #[derive(Clone, Debug)]
-struct CachedObserveResult {
-    rows: ExecuteResult,
-    compared_generation: Option<u64>,
-    matches_compared_generation: bool,
+enum CachedObserveResult {
+    Success {
+        rows: ExecuteResult,
+        compared_generation: Option<u64>,
+        matches_compared_generation: bool,
+    },
+    SemanticTerminal(LixError),
 }
 
 impl CachedObserveResult {
-    fn evaluation(&self, generation: u64) -> ObserveQueryEvaluation {
-        ObserveQueryEvaluation {
-            rows: self.rows.clone(),
-            shared_content: Some(ObserveSharedContent {
-                generation,
-                compared_generation: self.compared_generation,
-                matches_compared_generation: self.matches_compared_generation,
+    fn rows(&self) -> Option<&ExecuteResult> {
+        match self {
+            Self::Success { rows, .. } => Some(rows),
+            Self::SemanticTerminal(_) => None,
+        }
+    }
+
+    fn evaluation(&self, generation: u64) -> Result<ObserveQueryEvaluation, LixError> {
+        match self {
+            Self::Success {
+                rows,
+                compared_generation,
+                matches_compared_generation,
+            } => Ok(ObserveQueryEvaluation {
+                rows: rows.clone(),
+                shared_content: Some(ObserveSharedContent {
+                    generation,
+                    compared_generation: *compared_generation,
+                    matches_compared_generation: *matches_compared_generation,
+                }),
             }),
+            Self::SemanticTerminal(error) => Err(error.clone()),
         }
     }
 }
@@ -270,57 +333,90 @@ impl<'a> InFlightGuard<'a> {
     }
 
     fn finish_success(mut self, rows: ExecuteResult) -> ObserveQueryEvaluation {
-        self.finish(Some(rows))
-            .expect("successful observe evaluation must produce a cached result")
-    }
-
-    fn finish_without_cache(mut self) {
-        let _ = self.finish(None);
-    }
-
-    fn finish(&mut self, rows: Option<ExecuteResult>) -> Option<ObserveQueryEvaluation> {
         if !self.active {
-            return None;
+            unreachable!("observe evaluation guard can only finish once");
         }
         self.active = false;
         let mut inner = self.state.lock();
         inner.in_flight.remove(&self.generation);
-        let evaluation = rows.map(|rows| {
-            let (compared_generation, matches_compared_generation) = if self.compare_results {
-                inner
-                    .cached
-                    .range(..self.generation)
-                    .next_back()
-                    .map(|(generation, cached)| (Some(*generation), cached.rows == rows))
-                    .unwrap_or((None, false))
-            } else {
-                (None, false)
-            };
-            let cached = CachedObserveResult {
-                rows,
-                compared_generation,
-                matches_compared_generation,
-            };
-            let evaluation = cached.evaluation(self.generation);
-            inner.cached.insert(self.generation, cached);
-            while inner.cached.len() > MAX_CACHED_GENERATIONS_PER_QUERY {
-                let Some(oldest_generation) = inner.cached.first_key_value().map(|(key, _)| *key)
-                else {
-                    break;
-                };
-                inner.cached.remove(&oldest_generation);
-            }
-            evaluation
-        });
-        inner.change_sequence = inner.change_sequence.saturating_add(1);
+        let (compared_generation, matches_compared_generation) = if self.compare_results {
+            inner
+                .cached
+                .range(..self.generation)
+                .rev()
+                .find_map(|(generation, cached)| {
+                    cached
+                        .rows()
+                        .map(|cached_rows| (Some(*generation), cached_rows == &rows))
+                })
+                .unwrap_or((None, false))
+        } else {
+            (None, false)
+        };
+        let cached = CachedObserveResult::Success {
+            rows,
+            compared_generation,
+            matches_compared_generation,
+        };
+        let evaluation = cached
+            .evaluation(self.generation)
+            .expect("successful observe evaluation must produce rows");
+        Self::insert_cached(&mut inner, self.generation, cached);
         self.state.send_change(inner.change_sequence);
         evaluation
+    }
+
+    fn finish_terminal_error(mut self, error: LixError) -> LixError {
+        if !self.active {
+            return error;
+        }
+        self.active = false;
+        let mut inner = self.state.lock();
+        inner.in_flight.remove(&self.generation);
+        Self::insert_cached(
+            &mut inner,
+            self.generation,
+            CachedObserveResult::SemanticTerminal(error.clone()),
+        );
+        self.state.send_change(inner.change_sequence);
+        error
+    }
+
+    fn finish_without_cache(mut self) {
+        self.finish_in_flight();
+    }
+
+    fn finish_in_flight(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+        let mut inner = self.state.lock();
+        inner.in_flight.remove(&self.generation);
+        inner.change_sequence = inner.change_sequence.saturating_add(1);
+        self.state.send_change(inner.change_sequence);
+    }
+
+    fn insert_cached(
+        inner: &mut ObserveQueryStateInner,
+        generation: u64,
+        cached: CachedObserveResult,
+    ) {
+        inner.cached.insert(generation, cached);
+        while inner.cached.len() > MAX_CACHED_GENERATIONS_PER_QUERY {
+            let Some(oldest_generation) = inner.cached.first_key_value().map(|(key, _)| *key)
+            else {
+                break;
+            };
+            inner.cached.remove(&oldest_generation);
+        }
+        inner.change_sequence = inner.change_sequence.saturating_add(1);
     }
 }
 
 impl Drop for InFlightGuard<'_> {
     fn drop(&mut self) {
-        let _ = self.finish(None);
+        self.finish_in_flight();
     }
 }
 
@@ -331,9 +427,12 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use tokio::sync::oneshot;
+    use tokio::sync::{Barrier, oneshot};
 
-    use super::{ObserveQueryEvaluation, ObserveQueryState, ObserveSharedContent};
+    use super::{
+        ObserveErrorDisposition, ObserveQueryEvaluation, ObserveQueryState, ObserveSharedContent,
+        observe_error_disposition,
+    };
     use crate::{ExecuteResult, Value};
 
     fn blob_result(byte: u8) -> ExecuteResult {
@@ -411,6 +510,129 @@ mod tests {
             attempts.load(Ordering::SeqCst),
             2,
             "failed evaluations must not be cached for followers"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluate_caches_semantic_errors_for_generation() {
+        let state = ObserveQueryState::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let first_attempts = Arc::clone(&attempts);
+        let first = state
+            .evaluate(1, false, || async move {
+                first_attempts.fetch_add(1, Ordering::SeqCst);
+                Err(crate::LixError::new(
+                    crate::LixError::CODE_COLUMN_NOT_FOUND,
+                    "missing column",
+                ))
+            })
+            .await
+            .expect_err("semantic evaluation should fail");
+
+        let second_attempts = Arc::clone(&attempts);
+        let second = state
+            .evaluate(1, false, || async move {
+                second_attempts.fetch_add(1, Ordering::SeqCst);
+                Ok(ExecuteResult::from_rows_affected(0))
+            })
+            .await
+            .expect_err("same generation should reuse the semantic error");
+
+        assert_eq!(first, second);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_followers_share_semantic_error_without_reevaluating() {
+        let state = Arc::new(ObserveQueryState::new());
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let follower_barrier = Arc::new(Barrier::new(2));
+
+        let leader_state = Arc::clone(&state);
+        let leader_attempts = Arc::clone(&attempts);
+        let leader = tokio::spawn(async move {
+            leader_state
+                .evaluate(1, false, || async move {
+                    leader_attempts.fetch_add(1, Ordering::SeqCst);
+                    let _ = started_tx.send(());
+                    let _ = release_rx.await;
+                    Err(crate::LixError::new(
+                        crate::LixError::CODE_TABLE_NOT_FOUND,
+                        "missing table",
+                    ))
+                })
+                .await
+        });
+        started_rx.await.expect("leader should start");
+
+        let follower_state = Arc::clone(&state);
+        let follower_attempts = Arc::clone(&attempts);
+        let follower_started = Arc::clone(&follower_barrier);
+        let follower = tokio::spawn(async move {
+            follower_started.wait().await;
+            follower_state
+                .evaluate(1, false, || async move {
+                    follower_attempts.fetch_add(1, Ordering::SeqCst);
+                    Ok(ExecuteResult::from_rows_affected(0))
+                })
+                .await
+        });
+        follower_barrier.wait().await;
+        tokio::task::yield_now().await;
+        assert!(
+            !follower.is_finished(),
+            "follower should wait for the leader"
+        );
+        release_tx.send(()).expect("leader should still be waiting");
+
+        let leader_error = leader
+            .await
+            .expect("leader task should finish")
+            .expect_err("leader should surface semantic error");
+        let follower_error = follower
+            .await
+            .expect("follower task should finish")
+            .expect_err("follower should share semantic error");
+        assert_eq!(leader_error, follower_error);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn error_disposition_keeps_runtime_boundaries_resumable() {
+        assert_eq!(
+            observe_error_disposition(&crate::LixError::new(
+                crate::LixError::CODE_COLUMN_NOT_FOUND,
+                "missing column",
+            )),
+            ObserveErrorDisposition::SemanticTerminal
+        );
+        assert_eq!(
+            observe_error_disposition(&crate::LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                "transaction active",
+            )),
+            ObserveErrorDisposition::SessionState
+        );
+        assert_eq!(
+            observe_error_disposition(&crate::LixError::new("LIX_REMOTE_UNAVAILABLE", "offline",)),
+            ObserveErrorDisposition::TransportRecoverable
+        );
+        assert_eq!(
+            observe_error_disposition(&crate::LixError::new(
+                crate::LixError::CODE_CLOSED,
+                "closed",
+            )),
+            ObserveErrorDisposition::Closed
+        );
+        assert_eq!(
+            observe_error_disposition(&crate::LixError::new(
+                crate::LixError::CODE_UNKNOWN,
+                "unknown",
+            )),
+            ObserveErrorDisposition::Transient
         );
     }
 

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -3,8 +3,8 @@ use std::{future::Future, sync::Arc};
 use tokio::sync::watch;
 
 use crate::observe_coordinator::{
-    ObserveQueryEvaluation, ObserveQueryKey, ObserveQueryState, ObserveSessionScope,
-    ObserveSharedContent,
+    ObserveErrorDisposition, ObserveQueryEvaluation, ObserveQueryKey, ObserveQueryState,
+    ObserveSessionScope, ObserveSharedContent, observe_error_disposition,
 };
 use crate::observe_invalidation::ObserveInvalidationEvent;
 use crate::storage_adapter::Memory;
@@ -12,6 +12,8 @@ use crate::storage_adapter::Storage;
 use crate::{ExecuteResult, LixError, Value, sql2};
 
 use super::SessionContext;
+
+const TRANSIENT_EVALUATION_RETRY_LIMIT: usize = 3;
 
 #[derive(Debug, Clone)]
 struct ObserveQuery {
@@ -56,6 +58,7 @@ where
     last_rows: Option<ExecuteResult>,
     last_shared_content: Option<ObserveSharedContent>,
     sync_demand_tx: Option<tokio::sync::mpsc::Sender<crate::sync::SyncDemand>>,
+    terminal_error: Option<(ObserveSessionScope, LixError)>,
     closed: bool,
 }
 
@@ -85,10 +88,21 @@ where
             self.close();
             return Ok(None);
         }
+        if let Some((scope, error)) = &self.terminal_error {
+            if *scope == self.session.observe_scope() {
+                return Err(error.clone());
+            }
+            // Branch scope is part of an observation's query identity. A
+            // terminal SQL error from the previous branch must not poison the
+            // cursor after its existing branch-migration path takes effect.
+            self.terminal_error = None;
+        }
         if self.last_rows.is_none() {
-            let Some((mutation_sequence, evaluation)) =
-                Box::pin(self.evaluate_stable_snapshot()).await?
-            else {
+            let stable_snapshot = Box::pin(self.evaluate_stable_snapshot()).await;
+            let Some((mutation_sequence, evaluation)) = (match stable_snapshot {
+                Ok(snapshot) => snapshot,
+                Err(error) => return Err(self.retain_terminal_error(error)),
+            }) else {
                 return Ok(None);
             };
             let rows = evaluation.rows;
@@ -118,9 +132,11 @@ where
                 return Ok(None);
             }
 
-            let Some((mutation_sequence, evaluation)) =
-                Box::pin(self.evaluate_stable_snapshot()).await?
-            else {
+            let stable_snapshot = Box::pin(self.evaluate_stable_snapshot()).await;
+            let Some((mutation_sequence, evaluation)) = (match stable_snapshot {
+                Ok(snapshot) => snapshot,
+                Err(error) => return Err(self.retain_terminal_error(error)),
+            }) else {
                 return Ok(None);
             };
             let changed =
@@ -143,6 +159,13 @@ where
     pub fn close(&mut self) {
         self.closed = true;
         self.receiver.take();
+    }
+
+    fn retain_terminal_error(&mut self, error: LixError) -> LixError {
+        if observe_error_disposition(&error) == ObserveErrorDisposition::SemanticTerminal {
+            self.terminal_error = Some((self.session.observe_scope(), error.clone()));
+        }
+        error
     }
 
     fn acknowledge_delivered_file_views(&self, rows: &ExecuteResult) {
@@ -177,12 +200,14 @@ where
     async fn evaluate_stable_snapshot(
         &mut self,
     ) -> Result<Option<(u64, ObserveQueryEvaluation)>, LixError> {
+        let mut transient_retries = 0usize;
         loop {
             let operation_guard = self.session.begin_waitable_session_operation().await?;
             self.session
                 .observe_invalidation
                 .ensure_external_watcher(self.session.storage.clone())
                 .await?;
+            let before_scope = self.session.observe_scope();
             let before = self.invalidation_generation()?;
             drop(operation_guard);
             // Keep shared-query leadership across demand hydration, while the
@@ -206,6 +231,8 @@ where
                 self.close();
                 return Ok(None);
             }
+            let after_scope = self.session.observe_scope();
+            let after = self.invalidation_generation()?;
             let rows = match rows {
                 Ok(rows) => rows,
                 Err(error) if error.code == LixError::CODE_CLOSED => {
@@ -215,26 +242,38 @@ where
                 Err(error)
                     if matches!(
                         error.code.as_str(),
-                        LixError::CODE_STORAGE_READ_EXPIRED
-                            | LixError::CODE_TRANSACTION_CONFLICT
+                        LixError::CODE_STORAGE_READ_EXPIRED | LixError::CODE_TRANSACTION_CONFLICT
                     ) =>
                 {
                     // A concurrent commit invalidated this evaluation — an
                     // expired coherent read past its bounded in-execute
                     // retries, or a conflicting base-refresh write. That
                     // commit also bumps the invalidation generation, so the
-                    // loop's own response is the right one: yield to the
-                    // committing side and re-evaluate on a fresh snapshot.
-                    // A long-lived observation must never surface a
-                    // retryable transient as a stream error.
+                    // loop's own response is the right one when the observed
+                    // generation or branch moved. Some adapters can report a
+                    // transient without publishing an invalidation, so cap
+                    // same-snapshot retries to avoid an unbounded hot loop.
+                    if before == after && before_scope == after_scope {
+                        transient_retries += 1;
+                        if transient_retries > TRANSIENT_EVALUATION_RETRY_LIMIT {
+                            return Err(error);
+                        }
+                    } else {
+                        transient_retries = 0;
+                    }
                     drop(operation_guard);
                     tokio::task::yield_now().await;
                     continue;
                 }
-                Err(error) => return Err(error),
+                Err(error) => {
+                    if before == after && before_scope == after_scope {
+                        return Err(error);
+                    }
+                    drop(operation_guard);
+                    continue;
+                }
             };
-            let after = self.invalidation_generation()?;
-            if before == after {
+            if before == after && before_scope == after_scope {
                 return Ok(Some((after, rows)));
             }
             drop(operation_guard);
@@ -349,6 +388,7 @@ where
             last_rows: None,
             last_shared_content: None,
             sync_demand_tx: None,
+            terminal_error: None,
             closed: false,
         })
     }
@@ -441,7 +481,10 @@ mod tests {
         // The insert left the base stale; expire the refresh's next read.
         expire_reads.store(1, Ordering::SeqCst);
         let rows = session
-            .execute("SELECT value FROM lix_key_value WHERE key = 'observed'", &[])
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'observed'",
+                &[],
+            )
             .await
             .expect("a transient expired refresh read must not fail the execute");
         assert_eq!(rows.rows().len(), 1);
@@ -463,7 +506,10 @@ mod tests {
             .await
             .expect("open pinned main session");
         let mut events = session
-            .observe("SELECT value FROM lix_key_value WHERE key = 'observed'", &[])
+            .observe(
+                "SELECT value FROM lix_key_value WHERE key = 'observed'",
+                &[],
+            )
             .expect("observation opens");
         events.next().await.expect("initial evaluation");
         session
@@ -482,6 +528,38 @@ mod tests {
             .expect("a retryable expired read must re-evaluate, never error the stream")
             .expect("insert event exists");
         assert_eq!(event.rows.rows().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn persistent_expired_reads_surface_after_bounded_observe_retries() {
+        let expire_reads = Arc::new(AtomicU64::new(0));
+        let storage = ExpiringStorage {
+            inner: Memory::new(),
+            expire_reads: Arc::clone(&expire_reads),
+        };
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize storage");
+        let engine = Engine::new(storage).await.expect("open engine");
+        let session = engine
+            .open_session_at(&receipt.main_branch_id)
+            .await
+            .expect("open pinned main session");
+        let mut events = session
+            .observe("SELECT value FROM lix_key_value", &[])
+            .expect("observation opens");
+
+        expire_reads.store(1_000, Ordering::SeqCst);
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), events.next())
+            .await
+            .expect("persistent adapter failure must not loop forever")
+            .expect_err("persistent expired reads must surface");
+
+        assert_eq!(error.code, LixError::CODE_STORAGE_READ_EXPIRED);
+        assert!(
+            expire_reads.load(Ordering::SeqCst) > 900,
+            "observe must use a bounded number of adapter reads"
+        );
     }
 }
 

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -866,6 +866,17 @@ simulation_test!(
             .rollback()
             .await
             .expect("transaction should roll back");
+
+        writer_session
+            .execute(
+                "UPDATE lix_key_value SET value = 'v1' \
+                 WHERE key = 'observe-active-transaction-cache'",
+                &[],
+            )
+            .await
+            .expect("writer update should commit after rollback");
+        let resumed = next_event(&mut blocked_events, "observer after rollback").await;
+        assert_key_value_row(&resumed, "observe-active-transaction-cache", "v1");
     }
 );
 
@@ -883,6 +894,72 @@ simulation_test!(observe_close_makes_next_return_none, |sim| async move {
         .expect("closed observe next should not error");
     assert!(closed.is_none());
 });
+
+simulation_test!(observe_semantic_error_is_sticky, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, _) = open_default_session(&sim, &engine).await;
+    let mut events = raw_session
+        .observe("SELECT missing_column FROM lix_key_value", &[])
+        .expect("semantic planning error should surface from next");
+
+    let first = events
+        .next()
+        .await
+        .expect_err("initial evaluation should reject the missing column");
+    assert_eq!(first.code, lix::LixError::CODE_COLUMN_NOT_FOUND);
+
+    raw_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('sticky-error', 'invalidate')",
+            &[],
+        )
+        .await
+        .expect("unrelated mutation should commit");
+
+    let second = tokio::time::timeout(NEXT_TIMEOUT, events.next())
+        .await
+        .expect("sticky semantic error should resolve immediately")
+        .expect_err("semantic error should remain terminal after invalidation");
+    assert_eq!(second, first);
+});
+
+simulation_test!(
+    observe_semantic_error_is_scoped_to_branch,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
+        let draft = session
+            .create_branch(lix::CreateBranchOptions {
+                id: None,
+                name: "observe-semantic-error-draft".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create draft branch");
+        let mut events = raw_session
+            .observe("SELECT missing_column FROM lix_key_value", &[])
+            .expect("semantic planning error should surface from next");
+
+        let first = events
+            .next()
+            .await
+            .expect_err("main-branch evaluation should fail");
+        assert_eq!(first.code, lix::LixError::CODE_COLUMN_NOT_FOUND);
+
+        session
+            .switch_branch(lix::SwitchBranchOptions {
+                branch_id: draft.id,
+            })
+            .await
+            .expect("switch observed session to draft");
+        let second = events
+            .next()
+            .await
+            .expect_err("draft-branch evaluation should run and fail independently");
+        assert_eq!(second.code, lix::LixError::CODE_COLUMN_NOT_FOUND);
+        assert_eq!(second.message, first.message);
+    }
+);
 
 simulation_test!(observe_rejects_closed_session, |sim| async move {
     let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Summary

- keep the public pull-driven `observe()` API while making deterministic SQL errors sticky per branch/query generation
- share semantic failures across identical concurrent observers without re-evaluation
- keep session/transport boundaries resumable and cap same-snapshot transient retries to prevent retry storms
- verify branch scoping, concurrent followers, closed/fenced storage, and persistent adapter failures

## Validation

- `cargo test -p lix --features all-simulations`
- `cargo test -p lix --doc`
- `cargo test -p lix expired_read --lib`
- `git diff --check`

Independent sub-agent review: approved.