### PR TITLE
fix(opfs): preserve sessions across owner handoffs

### DIFF
--- a/.changenotes/preserve-opfs-sessions-across-owner-handoffs.md
+++ b/.changenotes/preserve-opfs-sessions-across-owner-handoffs.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+OPFS repositories remain writable across browser-tab navigation and owner-worker handoffs.
+
+The shared storage session now survives an OPFS backend restart, so one healthy tab no longer fences another tab using the same repository generation.

--- a/packages/storage-opfs/js/owner.ts
+++ b/packages/storage-opfs/js/owner.ts
@@ -24,7 +24,10 @@ type BackendEntry = {
 };
 
 const backends = new Map<string, BackendEntry>();
-const channel = new BroadcastChannel(OPFS_RPC_CHANNEL);
+const ownerUrl = new URL(globalThis.location.href);
+const channel = new BroadcastChannel(
+	ownerUrl.searchParams.get("rpcChannel") ?? OPFS_RPC_CHANNEL,
+);
 const inFlightRequests = new Map<string, Promise<void>>();
 const completedRequests = new Map<string, number>();
 const MAX_WARM_IDLE_BACKENDS = 2;

--- a/packages/storage-opfs/js/provider.ts
+++ b/packages/storage-opfs/js/provider.ts
@@ -34,6 +34,7 @@ import {
 	configureSqliteOpfsDurability,
 	fenceSqliteOpfsDurability,
 } from "./sqlite-durability.js";
+import { OPFS_RPC_PROTOCOL_VERSION } from "./rpc.js";
 
 type SqliteValue =
 	| string
@@ -63,7 +64,8 @@ type BrowserNavigator = {
 
 const SQLITE_VFS_NAME_PREFIX = "lix-opfs-sahpool-";
 const OPFS_LOCK_PREFIX = "lix:opfs-sqlite:";
-const OPFS_PROTOCOL_LOCK_PREFIX = "lix:opfs-owner:rpc-v2:";
+const OPFS_PROTOCOL_LOCK_PREFIX =
+	`lix:opfs-owner:rpc-v${OPFS_RPC_PROTOCOL_VERSION}:`;
 const SQLITE_VFS_DIRECTORY = "/lix/sqlite-sahpool";
 // Keep point reads comfortably below SQLite's conservative 999-variable
 // ceiling while collapsing hundreds of JS/Wasm bind-step-reset crossings into
@@ -79,7 +81,13 @@ CREATE TABLE IF NOT EXISTS lix_entries (
   value BLOB NOT NULL,
   PRIMARY KEY (space, key)
 ) WITHOUT ROWID;
+CREATE TABLE IF NOT EXISTS lix_storage_metadata (
+  key TEXT NOT NULL PRIMARY KEY,
+  value TEXT NOT NULL
+) WITHOUT ROWID;
 `;
+
+const STORAGE_SESSION_METADATA_KEY = "session-token";
 
 let sqliteModule: Promise<SqliteInit> | undefined;
 const pools = new Map<string, Promise<SAHPoolUtil>>();
@@ -103,10 +111,12 @@ export class OpfsBackend implements LixStorageProvider {
 		database: OpfsSAHPoolDatabase,
 		pool: SAHPoolUtil,
 		releaseLock: () => Promise<void>,
+		sessionToken: string | undefined,
 	) {
 		this.#database = database;
 		this.#pool = pool;
 		this.#releaseLock = releaseLock;
+		this.#sessionToken = sessionToken;
 	}
 
 	static async open(
@@ -129,7 +139,11 @@ export class OpfsBackend implements LixStorageProvider {
 			database = new pool.OpfsSAHPoolDb("/repository.sqlite3");
 			configureSqliteOpfsDurability(database);
 			database.exec(SQLITE_SCHEMA);
-			return new OpfsBackend(database, pool, releaseLock);
+			const sessionToken = database.selectValue(
+				"SELECT value FROM lix_storage_metadata WHERE key = ?",
+				[STORAGE_SESSION_METADATA_KEY],
+			) as string | undefined;
+			return new OpfsBackend(database, pool, releaseLock, sessionToken);
 		} catch (error) {
 			try {
 				database?.close();
@@ -144,7 +158,14 @@ export class OpfsBackend implements LixStorageProvider {
 
 	async acquireSession(): Promise<string> {
 		this.#assertOpen();
-		this.#sessionToken ??= mintSessionToken();
+		if (this.#sessionToken === undefined) {
+			const token = mintSessionToken();
+			this.#database.exec({
+				sql: "INSERT INTO lix_storage_metadata(key, value) VALUES (?, ?)",
+				bind: [STORAGE_SESSION_METADATA_KEY, token],
+			});
+			this.#sessionToken = token;
+		}
 		return this.#sessionToken;
 	}
 

--- a/packages/storage-opfs/js/rpc.ts
+++ b/packages/storage-opfs/js/rpc.ts
@@ -9,13 +9,13 @@ import type {
 import type { OpfsWritePayload } from "./buffered-write.js";
 
 /** Internal protocol shared by the package-owned owner worker and its clients. */
-export const OPFS_RPC_PROTOCOL_VERSION = 2 as const;
+export const OPFS_RPC_PROTOCOL_VERSION = 3 as const;
 export const OPFS_RPC_CHANNEL =
 	`lix-js:storage-opfs:rpc:v${OPFS_RPC_PROTOCOL_VERSION}`;
 
 export type OpfsRpcRequest = {
 	kind: "request";
-	protocolVersion: 2;
+	protocolVersion: typeof OPFS_RPC_PROTOCOL_VERSION;
 	requestId: string;
 	clientId: string;
 	storageName: string;

--- a/packages/storage-opfs/tests/opfs-session-handoff.worker.ts
+++ b/packages/storage-opfs/tests/opfs-session-handoff.worker.ts
@@ -1,0 +1,75 @@
+import type { LixStorageSpace } from "@lix-js/sdk";
+
+// The direct entry is the browser-safe bundle of provider.ts (including Wasm).
+// @ts-expect-error esbuild intentionally replaces the declaration-emitting output.
+import { OpfsBackend as BundledOpfsBackend } from "../dist/direct.js";
+
+const OpfsBackend = BundledOpfsBackend as typeof import("../js/provider.js").OpfsBackend;
+
+type Request = {
+	name: string;
+	phase: "acquire" | "reopen";
+	expectedToken?: string;
+};
+
+self.onmessage = async (event: MessageEvent<Request>) => {
+	let backend: Awaited<ReturnType<typeof OpfsBackend.open>> | undefined;
+	try {
+		backend = await OpfsBackend.open(event.data.name);
+		if (event.data.phase === "acquire") {
+			const token = await backend.acquireSession();
+			await backend.close();
+			backend = undefined;
+			postMessage({
+				ok: true,
+				result: { token },
+			});
+			return;
+		}
+
+		let tokenlessFenced = false;
+		try {
+			await backend.beginWrite({
+				awaitDurable: false,
+				preconditions: [],
+				batchCapacityHintBytes: 2,
+			});
+		} catch (error) {
+			tokenlessFenced =
+				(error as { code?: string }).code === "LIX_STORAGE_FENCED";
+		}
+		const token = await backend.acquireSession();
+		if (token !== event.data.expectedToken) {
+			throw new Error("owner handoff changed the storage session token");
+		}
+		const space: LixStorageSpace = {
+			id: 46,
+			name: "session-handoff",
+			valueSemantics: "mutable",
+			valueIntegrity: "backendVerified",
+		};
+		const write = await backend.beginWrite({
+			awaitDurable: false,
+			preconditions: [],
+			batchCapacityHintBytes: 2,
+			sessionToken: token,
+		});
+		await write.putMany(space, [
+			{ key: new Uint8Array([1]), value: new Uint8Array([2]) },
+		]);
+		await write.commit();
+		await backend.close();
+		backend = undefined;
+		postMessage({
+			ok: true,
+			result: { token, tokenlessFenced, writeCommitted: true },
+		});
+	} catch (error) {
+		postMessage({
+			ok: false,
+			message: error instanceof Error ? error.message : String(error),
+		});
+	} finally {
+		await backend?.close();
+	}
+};

--- a/packages/storage-opfs/tests/opfs-storage.browser.test.ts
+++ b/packages/storage-opfs/tests/opfs-storage.browser.test.ts
@@ -9,6 +9,7 @@ import { expect, test } from "vitest";
 import { OpfsStorageClient } from "../js/client.js";
 import {
 	OPFS_RPC_CHANNEL,
+	OPFS_RPC_PROTOCOL_VERSION,
 	type OpfsChannelMessage,
 	type OpfsRpcRequest,
 	type OpfsRpcResponse,
@@ -195,6 +196,106 @@ test("joins one storage session generation across provider clients", async () =>
 		await Promise.all([first.close(), second.close()]);
 	}
 });
+
+test("preserves the storage session across an owner handoff", async () => {
+	const name = `lix-opfs-session-handoff:${crypto.randomUUID()}`;
+	const first = await runSessionHandoffWorker({ name, phase: "acquire" });
+	const second = await runSessionHandoffWorker({
+		name,
+		phase: "reopen",
+		expectedToken: first.token,
+	});
+	expect(second).toEqual({
+		token: first.token,
+		tokenlessFenced: true,
+		writeCommitted: true,
+	});
+});
+
+test("keeps a live client writable after its owner worker is replaced", async () => {
+	const name = `lix-opfs-live-session-handoff:${crypto.randomUUID()}`;
+	const channelName = `lix-opfs-live-session-channel:${crypto.randomUUID()}`;
+	const ownerUrl = new URL("../dist/owner.js", import.meta.url);
+	ownerUrl.searchParams.set("rpcChannel", channelName);
+	let owner = new Worker(ownerUrl, { type: "module" });
+	const client = await OpfsStorageClient.open(name, channelName);
+	const space: LixStorageSpace = {
+		id: 47,
+		name: "live-session-handoff",
+		valueSemantics: "mutable",
+		valueIntegrity: "backendVerified",
+	};
+	try {
+		const token = await client.acquireSession();
+		owner.terminate();
+		await expect
+			.poll(async () => {
+				const locks = await navigator.locks.query();
+				return locks.held?.some((lock) => lock.name?.endsWith(name)) ?? false;
+			})
+			.toBe(false);
+
+		owner = new Worker(ownerUrl, { type: "module" });
+		const write = await client.beginWrite({
+			awaitDurable: false,
+			preconditions: [],
+			batchCapacityHintBytes: 2,
+			sessionToken: token,
+		});
+		await write.putMany(space, [
+			{ key: new Uint8Array([1]), value: new Uint8Array([2]) },
+		]);
+		await write.commit();
+
+		const read = await client.beginRead({
+			consistency: "latest",
+			durability: "visible",
+			sessionToken: token,
+		});
+		expect(
+			await read.getMany([
+				{
+					space,
+					keys: [new Uint8Array([1])],
+					options: { projection: "fullValue" },
+				},
+			]),
+		).toEqual([{ kind: "fullValue", value: new Uint8Array([2]) }]);
+	} finally {
+		await client.close();
+		owner.terminate();
+	}
+});
+
+async function runSessionHandoffWorker(request: {
+	name: string;
+	phase: "acquire" | "reopen";
+	expectedToken?: string;
+}): Promise<{
+	token: string;
+	tokenlessFenced?: boolean;
+	writeCommitted?: boolean;
+}> {
+	const worker = new Worker(
+		new URL("./opfs-session-handoff.worker.ts", import.meta.url),
+		{ type: "module" },
+	);
+	try {
+		return await new Promise((resolve, reject) => {
+			worker.onmessage = (event) => {
+				const response = event.data as
+					| { ok: true; result: Awaited<ReturnType<typeof runSessionHandoffWorker>> }
+					| { ok: false; message: string };
+				if (response.ok) resolve(response.result);
+				else reject(new Error(response.message));
+			};
+			worker.onerror = (event) => reject(new Error(event.message));
+			worker.postMessage(request);
+		});
+	} finally {
+		worker.terminate();
+	}
+}
 
 test("fences a tokenless write prepared before session acquisition", async () => {
 	const provider = await openProvider(
@@ -426,7 +527,7 @@ test("does not replay a request after its owner response completes", async () =>
 	const channel = new BroadcastChannel(OPFS_RPC_CHANNEL);
 	const request: OpfsRpcRequest = {
 		kind: "request",
-		protocolVersion: 2,
+		protocolVersion: OPFS_RPC_PROTOCOL_VERSION,
 		requestId: crypto.randomUUID(),
 		clientId: crypto.randomUUID(),
 		storageName,


### PR DESCRIPTION
## Summary

- persist the OPFS storage-session capability in adapter-owned SQLite metadata
- restore the same capability when the package-owned owner worker hands the repository to a successor
- keep tokenless legacy operations fenced after a handoff
- add a two-worker browser regression test covering the actual backend/Web Lock lifecycle

## Why

PR #1649 made storage sessions mandatory so migrations can fence stale handles. A deployed LixRay multi-tab test exposed that the OPFS token was scoped to an owner-worker instance instead of the storage generation. Navigating the owner tab restarted the backend, minted a new token, and incorrectly fenced healthy peer tabs.

## Validation

- OPFS browser suite: 38/38
- OPFS typecheck
- package dry-run validation
- packed Vite production smoke

Follow-up required by opral/lixray#298.