### PR TITLE
refactor(sql): unprefix diff payload columns

### DIFF
--- a/.changenotes/relation-column-naming-hard-cut.md
+++ b/.changenotes/relation-column-naming-hard-cut.md
@@ -1,0 +1,9 @@
+---
+type: minor
+---
+
+Standardized relation payload column names in `lix_diff()`.
+
+Diff queries now use `diff_type` and `row_count`; `lixcol_diff_type` and
+`lixcol_row_count` were renamed without compatibility aliases. The `lixcol_`
+prefix remains reserved for engine-owned system metadata.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -35,7 +35,7 @@ await lix.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
 ]);
 
 const working = await lix.execute(
-  `SELECT lixcol_row_pk, lixcol_diff_type, from_value, to_value
+  `SELECT lixcol_row_pk, diff_type, from_value, to_value
    FROM lix_diff(
      'lix_key_value',
      lix_latest_checkpoint_commit_id(),
@@ -44,7 +44,7 @@ const working = await lix.execute(
 );
 
 for (const row of working.rows) {
-  console.log(row.get("lixcol_diff_type"), row.get("lixcol_row_pk"));
+  console.log(row.get("diff_type"), row.get("lixcol_row_pk"));
 }
 
 await lix.createCheckpoint();
@@ -68,7 +68,7 @@ A runnable Rust version lives at
 
 | Surface | Scope | Columns |
 | :-- | :-- | :-- |
-| `lix_diff(relation, from_commit_id, to_commit_id)` | One relation across two explicit commits | `lixcol_row_pk`, `lixcol_diff_type`, `lixcol_row_count`, and paired `from_<column>` / `to_<column>` relation columns |
+| `lix_diff(relation, from_commit_id, to_commit_id)` | One relation across two explicit commits | `lixcol_row_pk`, `diff_type`, `row_count`, and paired `from_<column>` / `to_<column>` relation columns |
 | `lix_checkpoint` | Repository-global checkpoint markers | `id`, `commit_id`, and standard `lixcol_*` columns |
 | `lix_commit` | Repository-global commit graph | `id`, `parent_commit_ids`, and standard `lixcol_*` columns |
 | `lix_history('lix_checkpoint'[, commit_id])` | Global checkpoint-row authorship history | Checkpoint columns and standard history `lixcol_*` columns |
@@ -91,7 +91,7 @@ when the branch has no checkpoint. Pair it with the active head to inspect
 working changes in one query, including before the first checkpoint:
 
 ```sql
-SELECT lixcol_row_pk, lixcol_diff_type
+SELECT lixcol_row_pk, diff_type
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -17,7 +17,7 @@ import { openLix } from "@lix-js/sdk";
 
 const lix = await openLix();
 const changedFiles = await lix.execute(
-  `SELECT lixcol_row_pk, lixcol_diff_type, from_path, to_path, lixcol_row_count
+  `SELECT lixcol_row_pk, diff_type, from_path, to_path, row_count
    FROM lix_diff(
      'lix_file',
      lix_latest_checkpoint_commit_id(),
@@ -27,7 +27,7 @@ const changedFiles = await lix.execute(
 );
 
 for (const row of changedFiles.rows) {
-  console.log(row.get("lixcol_diff_type"), row.get("to_path") ?? row.get("from_path"));
+  console.log(row.get("diff_type"), row.get("to_path") ?? row.get("from_path"));
 }
 
 const reverted = await lix.execute(
@@ -57,10 +57,10 @@ for a new branch.
 
 ## Diff rows
 
-Every relation diff exposes `lixcol_row_pk`, `lixcol_diff_type`,
-`lixcol_row_count`, and a
+Every relation diff exposes `lixcol_row_pk`, `diff_type`,
+`row_count`, and a
 `from_<column>` / `to_<column>` pair for each column of the compared relation.
-`lixcol_diff_type` is `added`, `modified`, or `removed`. Added rows have empty `from_`
+`diff_type` is `added`, `modified`, or `removed`. Added rows have empty `from_`
 values; removed rows have empty `to_` values. Use
 `coalesce(to_path, from_path)` when displaying a path that also covers removed
 or renamed files.
@@ -70,11 +70,11 @@ reconstructing historical file bytes would turn lightweight diff reads into blob
 materialization. Query `lix_history('lix_file', commit_id)` when file bytes are
 required.
 
-`lixcol_row_count` is `1` for a changed schema row. For a file it counts the underlying
+`row_count` is `1` for a changed schema row. For a file it counts the underlying
 descriptor and content rows contributing to the aggregate:
 
 ```sql
-SELECT count(*) AS changed_files, sum(lixcol_row_count) AS changed_rows
+SELECT count(*) AS changed_files, sum(row_count) AS changed_rows
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -63,7 +63,7 @@ no checkpoint, it returns `lix_root_commit_id()`. Use both branch-scoped
 accessors to read working changes in one query:
 
 ```sql
-SELECT lixcol_row_pk, lixcol_diff_type
+SELECT lixcol_row_pk, diff_type
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -53,17 +53,21 @@ For branch-scoped working changes, use `lix_latest_checkpoint_commit_id()` and
 latest-checkpoint accessor returns the repository root when the active branch
 has no checkpoint.
 
-The `lixcol_` segment is reserved for engine-owned system metadata on read
-surfaces. Relation payload uses ordinary names: for example, `lix_diff()` uses
-`diff_type` and `row_count`. Registered user schemas reject column names
-beginning with `lixcol_` or containing `_lixcol_`; this keeps system metadata
-mechanically distinguishable even after `from_`/`to_` side prefixing.
+The rule is: `lixcol_` prefixes only engine-owned system metadata, while
+relation-specific payload always uses ordinary names such as `diff_type`,
+`row_count`, `from_path`, and `to_path`. Registered user schemas reject column
+names beginning with `lixcol_` or containing `_lixcol_`; this keeps system
+metadata mechanically distinguishable even after `from_`/`to_` side prefixing.
 
 ## The executable column contract
 
 The SQL engine is backed by DataFusion. Query `information_schema.columns` for
 the executable public contract instead of inferring types from Arrow or JSON
 Schema names:
+
+Column-resolution errors retain DataFusion's discovery guidance: close misses
+get a `Did you mean ...` suggestion, while other misses include the complete
+`Valid fields are ...` listing.
 
 ```sql
 SELECT column_name, data_type, is_nullable, column_default,

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -42,7 +42,7 @@ case-fold, or Unicode-normalize paths. Filesystem adapters diagnose names that
 the target host cannot represent.
 
 The checkpoint and diff relations are read-only. `lix_diff()` exposes
-`lixcol_row_pk`, `lixcol_diff_type`, `lixcol_row_count`, and paired
+`lixcol_row_pk`, `diff_type`, `row_count`, and paired
 `from_<column>` / `to_<column>` relation
 columns. Pass `(relation, row_pk)` to the `lix_revert`, `lix_apply`, and
 `lix_create_checkpoint` command sinks. See [Checkpoints](./checkpoints.md) and
@@ -53,10 +53,11 @@ For branch-scoped working changes, use `lix_latest_checkpoint_commit_id()` and
 latest-checkpoint accessor returns the repository root when the active branch
 has no checkpoint.
 
-The `lixcol_` segment is reserved for engine-made columns on read surfaces.
-Registered user schemas reject column names beginning with `lixcol_` or
-containing `_lixcol_`; this keeps engine columns mechanically distinguishable
-even after `from_`/`to_` side prefixing.
+The `lixcol_` segment is reserved for engine-owned system metadata on read
+surfaces. Relation payload uses ordinary names: for example, `lix_diff()` uses
+`diff_type` and `row_count`. Registered user schemas reject column names
+beginning with `lixcol_` or containing `_lixcol_`; this keeps system metadata
+mechanically distinguishable even after `from_`/`to_` side prefixing.
 
 ## The executable column contract
 

--- a/packages/e2e/benches/tracked_state_crud/sql_session.rs
+++ b/packages/e2e/benches/tracked_state_crud/sql_session.rs
@@ -784,7 +784,7 @@ where
             &format!(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('tracked_crud_insert', '{before}', '{after}') \
-                 WHERE lixcol_diff_type = 'added'"
+                 WHERE diff_type = 'added'"
             ),
         )
         .await;

--- a/packages/e2e/benches/tracked_working_diff.rs
+++ b/packages/e2e/benches/tracked_working_diff.rs
@@ -51,7 +51,7 @@ const DEFAULT_UNRELATED_HISTORY_WIDTH: usize = 1;
 const UNRELATED_HISTORY_STORAGE_BATCH: usize = 100_000;
 const INSERT_BATCH_SIZE: usize = 500;
 const MERGE_PREVIEW_SOURCE_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000901";
-const WORKING_DIFF_SQL: &str = "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
+const WORKING_DIFF_SQL: &str = "SELECT lixcol_row_pk, diff_type, row_count \
     FROM lix_diff('working_diff_row', $1, lix_active_branch_commit_id()) \
     ORDER BY lixcol_row_pk";
 

--- a/packages/e2e/benches/working_diff_file_scope.rs
+++ b/packages/e2e/benches/working_diff_file_scope.rs
@@ -212,23 +212,23 @@ async fn run<StorageImpl>(
         .get::<String>("commit_id")
         .expect("benchmark checkpoint ID");
     let file_sql = format!(
-        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
+        "SELECT lixcol_row_pk, diff_type, row_count \
          FROM lix_diff('lix_file', '{checkpoint}', lix_active_branch_commit_id()) \
          WHERE lixcol_row_pk ->> 0 = $1"
     );
     let full_sql = format!(
-        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
+        "SELECT lixcol_row_pk, diff_type, row_count \
          FROM lix_diff('lix_file', '{checkpoint}', lix_active_branch_commit_id())"
     );
     let file_schema_sql = format!(
-        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
+        "SELECT lixcol_row_pk, diff_type, row_count \
          FROM lix_diff('{SCHEMA_KEY}', '{checkpoint}', lix_active_branch_commit_id()) \
          WHERE to_lixcol_file_id = $1"
     );
     // Finite identity + file id: takes the existing bypass and resolves as a
     // point read. This is the floor a seekable file-scoped read aims at.
     let point_sql = format!(
-        "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count \
+        "SELECT lixcol_row_pk, diff_type, row_count \
          FROM lix_diff('{SCHEMA_KEY}', '{checkpoint}', lix_active_branch_commit_id()) \
          WHERE lixcol_row_pk = CAST($1 AS JSONB)"
     );

--- a/packages/e2e/examples/branch_merge_benchmark.rs
+++ b/packages/e2e/examples/branch_merge_benchmark.rs
@@ -894,7 +894,7 @@ where
     let expected_diff = map_diff_oracle(&base, &target_before_preview);
     let diff_measure = measure_async(|| async {
         lix.execute(
-            "SELECT lixcol_row_pk, lixcol_diff_type, from_id, to_id \
+            "SELECT lixcol_row_pk, diff_type, from_id, to_id \
              FROM lix_diff('branch_bench_row', $1, $2) ORDER BY lixcol_row_pk",
             &[
                 Value::Text(preview.base_commit_id.clone()),
@@ -920,7 +920,7 @@ where
                 .expect("single-string diff identity")
                 .to_owned();
             let kind = row
-                .get::<String>("lixcol_diff_type")
+                .get::<String>("diff_type")
                 .expect("diff type");
             let side_id = |column| match row.value(column).expect("diff side identity column") {
                 Value::Null => None,

--- a/packages/e2e/tests/corruption_recovery_qualification.rs
+++ b/packages/e2e/tests/corruption_recovery_qualification.rs
@@ -300,7 +300,7 @@ async fn qualify_tracked_tree_chunk<B: DurableBackend>() {
     assert_eq!(healthy.rows().len(), 8, "healthy tracked tree row count");
     let healthy_diff = lix
         .execute(
-            "SELECT 'lix_key_value' AS schema_key, lixcol_diff_type \
+            "SELECT 'lix_key_value' AS schema_key, diff_type \
              FROM lix_diff('lix_key_value', $1, $2)",
             &[
                 Value::Text(checkpoint_head.clone()),
@@ -329,7 +329,7 @@ async fn qualify_tracked_tree_chunk<B: DurableBackend>() {
         Ok(lix) => {
             let result = lix
                 .execute(
-                    "SELECT 'lix_key_value' AS schema_key, lixcol_diff_type \
+                    "SELECT 'lix_key_value' AS schema_key, diff_type \
                      FROM lix_diff('lix_key_value', $1, $2)",
                     &[Value::Text(checkpoint_head), Value::Text(updated_head)],
                 )

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -5545,7 +5545,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
     .unwrap();
     let selected_diff_count = lix
         .execute(
-            "SELECT coalesce(sum(lixcol_row_count), 0) AS count \
+            "SELECT coalesce(sum(row_count), 0) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
              WHERE lixcol_row_pk ->> 0 = $1",
             &[

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -1786,7 +1786,7 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
     // with both sides' paths resolved through their own commit trees.
     let span = replica
         .execute(
-            "SELECT lixcol_diff_type, coalesce(to_path, from_path) AS path
+            "SELECT diff_type, coalesce(to_path, from_path) AS path
              FROM lix_diff('lix_file', $1, $2)
              ORDER BY coalesce(to_path, from_path)",
             &[
@@ -1801,7 +1801,7 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
         .iter()
         .map(|row| {
             (
-                row.get::<String>("lixcol_diff_type").expect("diff type"),
+                row.get::<String>("diff_type").expect("diff type"),
                 row.get::<String>("path").expect("path"),
             )
         })

--- a/packages/lix/benches/diff_commands.rs
+++ b/packages/lix/benches/diff_commands.rs
@@ -108,7 +108,7 @@ async fn profile_sample(rows: usize, sample: usize) {
         execute(
             &session,
             &format!(
-                "SELECT COUNT(*) AS change_count, SUM(lixcol_row_count) AS atom_count \
+                "SELECT COUNT(*) AS change_count, SUM(row_count) AS atom_count \
                  FROM {WORKING_SOURCE}"
             ),
         )

--- a/packages/lix/examples/checkpoints.rs
+++ b/packages/lix/examples/checkpoints.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), LixError> {
 
     let working_diffs = lix
         .execute(
-            "SELECT lixcol_row_pk, lixcol_diff_type, from_value, to_value
+            "SELECT lixcol_row_pk, diff_type, from_value, to_value
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())
              ORDER BY lixcol_row_pk",
             &[Value::Text(initial_checkpoint.commit_id)],
@@ -27,7 +27,7 @@ async fn main() -> Result<(), LixError> {
     for row in working_diffs.rows() {
         // Row::get<T> performs typed extraction from ExecuteResult.
         let row_pk = row.get::<serde_json::Value>("lixcol_row_pk")?;
-        let diff_type = row.get::<String>("lixcol_diff_type")?;
+        let diff_type = row.get::<String>("diff_type")?;
         println!("{diff_type} lix_key_value {row_pk}");
     }
     let checkpoint = lix.create_checkpoint().await?;

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1739,7 +1739,7 @@ mod tests {
         let broad = session
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     json_pointer_diff_relation(&session).await
                 ),
                 &[],
@@ -1758,7 +1758,7 @@ mod tests {
                     row.get::<serde_json::Value>("lixcol_row_pk")
                         .expect("row_pk should decode")
                         .to_string(),
-                    row.get::<String>("lixcol_diff_type")
+                    row.get::<String>("diff_type")
                         .expect("diff_type should decode"),
                 )
             })
@@ -1790,7 +1790,7 @@ mod tests {
             let finite = session
                 .execute(
                     &format!(
-                        "SELECT lixcol_row_pk, lixcol_diff_type FROM {} \
+                        "SELECT lixcol_row_pk, diff_type FROM {} \
                          WHERE lixcol_row_pk = CAST($1 AS JSONB) ORDER BY lixcol_row_pk",
                         json_pointer_diff_relation(&session).await
                     ),
@@ -1810,7 +1810,7 @@ mod tests {
                         row.get::<serde_json::Value>("lixcol_row_pk")
                             .expect("row_pk should decode")
                             .to_string(),
-                        row.get::<String>("lixcol_diff_type")
+                        row.get::<String>("diff_type")
                             .expect("diff_type should decode"),
                     )
                 })
@@ -1965,7 +1965,7 @@ mod tests {
                         // `file_id` is nullable; a NULL surfaces as a decode
                         // error through the typed accessor.
                         row.get::<String>("file_id").ok(),
-                        row.get::<String>("lixcol_diff_type")
+                        row.get::<String>("diff_type")
                             .expect("diff_type should decode"),
                     )
                 })
@@ -1976,7 +1976,7 @@ mod tests {
         let relation = json_pointer_diff_relation(&session).await;
         let columns = format!(
             "SELECT lixcol_row_pk, \
-             COALESCE(to_lixcol_file_id, from_lixcol_file_id) AS file_id, lixcol_diff_type \
+             COALESCE(to_lixcol_file_id, from_lixcol_file_id) AS file_id, diff_type \
              FROM {relation}"
         );
 

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -6875,7 +6875,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('rootless_ordered_insert_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'added'",
+                 WHERE diff_type = 'added'",
                 &[
                     Value::Text(baseline.commit_id.to_string()),
                     Value::Text(head.commit_id.to_string()),
@@ -6958,7 +6958,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('rootless_ordered_insert_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'modified'",
+                 WHERE diff_type = 'modified'",
                 &[
                     Value::Text(head.commit_id.to_string()),
                     Value::Text(descendant.commit_id.to_string()),
@@ -7140,7 +7140,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('rootless_ordered_insert_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'modified'",
+                 WHERE diff_type = 'modified'",
                 &[
                     Value::Text(reseed_head.commit_id.to_string()),
                     Value::Text(rooted_fence.to_string()),
@@ -7392,7 +7392,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('columnar_lifecycle_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'added'",
+                 WHERE diff_type = 'added'",
                 &[
                     Value::Text(before_insert.to_string()),
                     Value::Text(inserted_head.to_string()),
@@ -7560,7 +7560,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('columnar_lifecycle_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'modified'",
+                 WHERE diff_type = 'modified'",
                 &[
                     Value::Text(checkpoint.commit_id.to_string()),
                     Value::Text(merged_head.to_string()),
@@ -7703,7 +7703,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('ordered_packed_update_probe', lix_root_commit_id(), lix_active_branch_commit_id()) \
-                 WHERE lixcol_diff_type = 'added'",
+                 WHERE diff_type = 'added'",
                 &[],
             )
             .await
@@ -7854,7 +7854,7 @@ mod tests {
             .execute(
                 "SELECT count(*) AS count \
                  FROM lix_diff('packed_replacement_working_diff_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'modified'",
+                 WHERE diff_type = 'modified'",
                 &[
                     Value::Text(checkpoint_commit_id.clone()),
                     Value::Text(head_commit_id.clone()),
@@ -9693,7 +9693,7 @@ mod tests {
                 .execute(
                     "SELECT COUNT(*) AS entries \
                      FROM lix_diff('packed_replacement_probe', $1, $2) \
-                     WHERE lixcol_diff_type = 'modified'",
+                     WHERE diff_type = 'modified'",
                     &[Value::Text(before.clone()), Value::Text(after.clone())],
                 )
                 .await
@@ -9861,7 +9861,7 @@ mod tests {
             .execute(
                 "SELECT COUNT(*) AS entries \
                  FROM lix_diff('packed_replacement_probe', $1, $2) \
-                 WHERE lixcol_diff_type = 'modified'",
+                 WHERE diff_type = 'modified'",
                 &[
                     Value::Text(second_commit_id.clone()),
                     Value::Text(merged_commit_id.clone()),

--- a/packages/lix/src/sql2/catalog/mod.rs
+++ b/packages/lix/src/sql2/catalog/mod.rs
@@ -9,8 +9,8 @@ pub(crate) use registry::PublicCatalog;
 pub(crate) use schema::{PublicColumn, PublicColumnInsertPolicy};
 pub(crate) use schema_surface::{
     SchemaColumnType, SchemaIndexedColumn, SchemaSurfaceShape, SchemaSurfaceSpec,
-    derive_schema_surface_spec_from_schema, row_visible_fields, schema_exposed_as_history_surface,
-    schema_exposed_as_schema_surface, schema_surface_schema,
+    TRACKED_ROW_SYSTEM_COLUMN_NAMES, derive_schema_surface_spec_from_schema, row_visible_fields,
+    schema_exposed_as_history_surface, schema_exposed_as_schema_surface, schema_surface_schema,
 };
 pub(crate) use surface::{
     PublicHistoryContract, PublicHistoryKind, PublicRelationKind, PublicScalarFunctionContract,

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -677,10 +677,103 @@ fn history_columns<const N: usize>(columns: [(&str, bool); N]) -> Vec<PublicColu
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use serde_json::json;
 
-    use super::PublicCatalog;
+    use super::{PublicCatalog, PublicSurfaceKind};
     use crate::LixError;
+    use crate::sql2::catalog::TRACKED_ROW_SYSTEM_COLUMN_NAMES;
+    use crate::sql2::history_route::{
+        HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT,
+        HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH,
+        HISTORY_COL_FILE_ID, HISTORY_COL_IS_DELETED, HISTORY_COL_METADATA,
+        HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_ORIGIN_KEY, HISTORY_COL_ROW_PK,
+        HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SOURCE_CHANGES,
+    };
+
+    #[test]
+    fn lixcol_names_are_reserved_for_system_metadata() {
+        let catalog = PublicCatalog::fixed_system();
+        let tracked = TRACKED_ROW_SYSTEM_COLUMN_NAMES
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+
+        for surface in catalog.surfaces() {
+            let lixcol_columns = surface
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .filter(|name| name.contains("lixcol_"))
+                .collect::<Vec<_>>();
+            let lixcol_names = lixcol_columns.iter().copied().collect::<BTreeSet<_>>();
+            assert_eq!(
+                lixcol_columns.len(),
+                lixcol_names.len(),
+                "surface '{}' must not duplicate system columns",
+                surface.name
+            );
+            match &surface.kind {
+                PublicSurfaceKind::SchemaBase { .. }
+                | PublicSurfaceKind::File
+                | PublicSurfaceKind::Directory => assert_eq!(
+                    lixcol_names, tracked,
+                    "tracked relation '{}' must expose exactly the canonical bookkeeping set",
+                    surface.name
+                ),
+                _ => assert!(
+                    lixcol_names.is_empty(),
+                    "non-state surface '{}' must not expose lixcol payload",
+                    surface.name
+                ),
+            }
+        }
+
+        let history_system = [
+            HISTORY_COL_ROW_PK,
+            HISTORY_COL_SCHEMA_KEY,
+            HISTORY_COL_FILE_ID,
+            HISTORY_COL_METADATA,
+            HISTORY_COL_CHANGE_ID,
+            HISTORY_COL_CHANGE_CREATED_AT,
+            HISTORY_COL_SOURCE_CHANGES,
+            HISTORY_COL_ORIGIN_KEY,
+            HISTORY_COL_OBSERVED_COMMIT_ID,
+            HISTORY_COL_COMMIT_CREATED_AT,
+            HISTORY_COL_AS_OF_COMMIT_ID,
+            HISTORY_COL_DEPTH,
+            HISTORY_COL_IS_DELETED,
+        ];
+        assert!(
+            history_system
+                .iter()
+                .all(|name| name.starts_with("lixcol_")),
+            "history metadata must retain the collision-safe system prefix"
+        );
+        let allowed_history = history_system.into_iter().collect::<BTreeSet<_>>();
+        for history in catalog.history_relations() {
+            let lixcol_columns = history
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .filter(|name| name.contains("lixcol_"))
+                .collect::<Vec<_>>();
+            let lixcol_names = lixcol_columns.iter().copied().collect::<BTreeSet<_>>();
+            assert_eq!(
+                lixcol_columns.len(),
+                lixcol_names.len(),
+                "history for '{}' must not duplicate system columns",
+                history.relation_name
+            );
+            for name in lixcol_names {
+                assert!(
+                    allowed_history.contains(name),
+                    "history for '{}' exposes non-system lixcol column '{name}'",
+                    history.relation_name
+                );
+            }
+        }
+    }
 
     #[test]
     fn catalog_rejects_legacy_runtime_schema_in_reserved_lix_namespace() {

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -20,6 +20,24 @@ pub(crate) enum SchemaSurfaceShape {
     History,
 }
 
+/// Engine-owned bookkeeping shared by every tracked row state projection.
+///
+/// Relation payload must never use these names or introduce another
+/// `lixcol_` segment. Derived surfaces may preserve these names directly or
+/// through a structural side prefix such as `from_lixcol_created_at`.
+pub(crate) const TRACKED_ROW_SYSTEM_COLUMN_NAMES: [&str; 10] = [
+    "lixcol_row_pk",
+    "lixcol_schema_key",
+    "lixcol_file_id",
+    "lixcol_metadata",
+    "lixcol_created_at",
+    "lixcol_updated_at",
+    "lixcol_global",
+    "lixcol_change_id",
+    "lixcol_commit_id",
+    "lixcol_untracked",
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SchemaColumnType {
     String,

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -178,7 +178,7 @@ impl DiffRelation {
         })?;
         let mut fields = vec![
             json_field("lixcol_row_pk", false),
-            Field::new("lixcol_diff_type", DataType::Utf8, false),
+            Field::new("diff_type", DataType::Utf8, false),
         ];
         for column in surface.columns.iter().filter(|column| column.is_public()) {
             let field = source_schema
@@ -200,7 +200,7 @@ impl DiffRelation {
                 );
             }
         }
-        fields.push(Field::new("lixcol_row_count", DataType::Int64, false));
+        fields.push(Field::new("row_count", DataType::Int64, false));
         Ok(Self {
             kind,
             schema: Arc::new(Schema::new(fields)),
@@ -1273,7 +1273,7 @@ where
             row_pk,
             diff_type: diff_type(kind),
             row_count: i64::try_from(group.row_count).map_err(|_| {
-                DataFusionError::Execution("lix_diff lixcol_row_count exceeds INT8".to_string())
+                DataFusionError::Execution("lix_diff row_count exceeds INT8".to_string())
             })?,
             from,
             to,
@@ -1520,10 +1520,10 @@ fn diff_column_array(field: &Field, rows: &[DiffSqlRow]) -> Result<ArrayRef> {
                 })
                 .collect::<Result<Vec<_>>>()?,
         ))),
-        "lixcol_diff_type" => Ok(Arc::new(StringArray::from_iter_values(
+        "diff_type" => Ok(Arc::new(StringArray::from_iter_values(
             rows.iter().map(|row| row.diff_type),
         ))),
-        "lixcol_row_count" => Ok(Arc::new(Int64Array::from_iter_values(
+        "row_count" => Ok(Arc::new(Int64Array::from_iter_values(
             rows.iter().map(|row| row.row_count),
         ))),
         name => {
@@ -1682,14 +1682,16 @@ mod tests {
             &names[..6],
             &[
                 "lixcol_row_pk",
-                "lixcol_diff_type",
+                "diff_type",
                 "from_key",
                 "to_key",
                 "from_value",
                 "to_value"
             ]
         );
-        assert_eq!(names.last(), Some(&"lixcol_row_count"));
+        assert_eq!(names.last(), Some(&"row_count"));
+        assert!(!names.contains(&"lixcol_diff_type"));
+        assert!(!names.contains(&"lixcol_row_count"));
         assert!(!names.contains(&"diff_id"));
         assert!(!names.contains(&"before_change_id"));
         assert!(!names.contains(&"after_change_id"));
@@ -1703,6 +1705,17 @@ mod tests {
         assert!(field_is_json(
             relation.schema.field_with_name("from_value").unwrap()
         ));
+
+        for name in names.into_iter().filter(|name| name.contains("lixcol_")) {
+            let system_name = name
+                .strip_prefix("from_")
+                .or_else(|| name.strip_prefix("to_"))
+                .unwrap_or(name);
+            assert!(
+                crate::sql2::catalog::TRACKED_ROW_SYSTEM_COLUMN_NAMES.contains(&system_name),
+                "diff exposes relation payload with a lixcol name: {name}"
+            );
+        }
     }
 
     #[test]
@@ -1719,7 +1732,7 @@ mod tests {
         let relation = DiffRelation::from_catalog(PublicCatalog::fixed_system(), "lix_key_value")
             .expect("key/value relation is registered");
         let projection = Schema::new(vec![Field::new(
-            "lixcol_row_count",
+            "row_count",
             DataType::Int64,
             false,
         )]);

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -10742,7 +10742,7 @@ mod tests {
         );
         let peer_diff = peer
             .execute(
-                "SELECT lixcol_row_pk, lixcol_diff_type \
+                "SELECT lixcol_row_pk, diff_type \
                  FROM lix_diff('lix_file', $1, lix_active_branch_commit_id())",
                 &[Value::Text(pushed_checkpoint.to_owned())],
             )
@@ -10827,7 +10827,7 @@ mod tests {
 
         let diff = replica
             .execute(
-                "SELECT lixcol_diff_type FROM lix_diff('lix_file', $1, $2)",
+                "SELECT diff_type FROM lix_diff('lix_file', $1, $2)",
                 &[Value::Text(checkpoint), Value::Text(head)],
             )
             .await
@@ -10835,7 +10835,7 @@ mod tests {
         assert_eq!(diff.rows().len(), 1);
         assert_eq!(
             diff.rows()[0]
-                .get::<String>("lixcol_diff_type")
+                .get::<String>("diff_type")
                 .expect("diff type should decode"),
             "modified",
         );

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -1656,7 +1656,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT lixcol_diff_type, lixcol_row_pk FROM __LIX_RELATION_DIFF__",
+                "SELECT diff_type, lixcol_row_pk FROM __LIX_RELATION_DIFF__",
             )
             .await,
             &[],
@@ -1666,7 +1666,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
     assert_eq!(remaining.rows().len(), 1);
     assert_eq!(
         remaining.rows()[0]
-            .get::<String>("lixcol_diff_type")
+            .get::<String>("diff_type")
             .unwrap(),
         "removed"
     );
@@ -1685,7 +1685,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
                     &replica.lix,
                     "lix_key_value",
                     "SELECT COUNT(*) AS count FROM __LIX_RELATION_DIFF__ \
-                     WHERE lixcol_diff_type = 'removed'",
+                     WHERE diff_type = 'removed'",
                 )
                 .await,
                 &[],

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -810,7 +810,7 @@ simulation_test!(
         let working_diffs = main
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2013,7 +2013,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_diff_type, from_value, to_value FROM {} \
+                    "SELECT diff_type, from_value, to_value FROM {} \
                      WHERE lixcol_row_pk = CAST('[\"branch-baseline\"]' AS JSONB)",
                     key_value_diff_relation(&draft).await
                 ),
@@ -2132,7 +2132,7 @@ simulation_test!(
         let rows = main
             .execute(
                 &format!(
-                    "SELECT lixcol_diff_type, from_value FROM {} \
+                    "SELECT diff_type, from_value FROM {} \
                      WHERE lixcol_row_pk = CAST('[\"merge-baseline\"]' AS JSONB)",
                     key_value_diff_relation(&main).await
                 ),
@@ -2185,7 +2185,7 @@ simulation_test!(
         let narrow = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_diff_type, from_value FROM {} \
+                    "SELECT diff_type, from_value FROM {} \
                      WHERE lixcol_row_pk = CAST('[\"branch-delete\"]' AS JSONB)",
                     key_value_diff_relation(&draft).await
                 ),
@@ -2208,7 +2208,7 @@ simulation_test!(
         let broad = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2288,7 +2288,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2370,7 +2370,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2432,7 +2432,7 @@ simulation_test!(
         let rows = main
             .execute(
                 &format!(
-                    "SELECT lixcol_diff_type, from_value FROM {} \
+                    "SELECT diff_type, from_value FROM {} \
                      WHERE lixcol_row_pk = CAST('[\"switch-baseline\"]' AS JSONB)",
                     key_value_diff_relation(&main).await
                 ),

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -98,7 +98,7 @@ simulation_test!(
         let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = raw_session
             .observe(
-                "SELECT lixcol_row_pk, lixcol_diff_type \
+                "SELECT lixcol_row_pk, diff_type \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -33,7 +33,7 @@ async fn checkpoints_example_sql_contract() {
         .expect("active head commit ID should decode");
     let working_diffs = lix
         .execute(
-            "SELECT lixcol_row_pk, lixcol_diff_type
+            "SELECT lixcol_row_pk, diff_type
              FROM lix_diff('lix_key_value', $1, $2)
              ORDER BY lixcol_row_pk",
             &[Value::Text(root_commit_id), Value::Text(head_commit_id)],
@@ -49,7 +49,7 @@ async fn checkpoints_example_sql_contract() {
     );
     assert_eq!(
         working_diffs.rows()[0]
-            .get::<String>("lixcol_diff_type")
+            .get::<String>("diff_type")
             .expect("diff_type is text"),
         "added"
     );
@@ -152,7 +152,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -166,7 +166,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} \
+                    "SELECT lixcol_row_pk, diff_type FROM {} \
                      WHERE lixcol_row_pk = CAST('[\"checkpoint-key\"]' AS JSONB)",
                     key_value_diff_relation(&session).await
                 ),
@@ -518,7 +518,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk, lixcol_diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -539,7 +539,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_diff_type FROM {} \
+                    "SELECT diff_type FROM {} \
                      WHERE lixcol_row_pk = CAST('[\"working-removed\"]' AS JSONB)",
                     key_value_diff_relation(&session).await
                 ),

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -32,7 +32,7 @@ simulation_test!(
         let working = select_rows(
             &session,
             &format!(
-                "SELECT lixcol_row_pk, lixcol_diff_type FROM lix_diff('lix_key_value', '{baseline}', '{original_head}') ORDER BY lixcol_row_pk"
+                "SELECT lixcol_row_pk, diff_type FROM lix_diff('lix_key_value', '{baseline}', '{original_head}') ORDER BY lixcol_row_pk"
             ),
         )
         .await;
@@ -309,7 +309,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_diff_type FROM lix_diff('lix_key_value', '{checkpoint_id}', '{head}') \
+                    "SELECT diff_type FROM lix_diff('lix_key_value', '{checkpoint_id}', '{head}') \
                      WHERE lixcol_row_pk = CAST('[\"recycled\"]' AS JSONB)"
                 ),
             )

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -599,5 +599,27 @@ simulation_test!(relation_diff_fences_machinery_from_user_column_names, |sim| as
             "error should identify retired column {retired}: {}",
             error.message
         );
+        assert!(
+            error.message.contains("Did you mean"),
+            "renamed diff columns should preserve DataFusion's near-match guidance: {}",
+            error.message
+        );
     }
+
+    let error = session
+        .execute(
+            &format!(
+                "SELECT not_a_diff_column FROM lix_diff('diff_name_collision', '{baseline}', '{head}')"
+            ),
+            &[],
+        )
+        .await
+        .expect_err("unknown diff column must not exist");
+    assert!(
+        error.message.contains("Valid fields are")
+            && error.message.contains("diff_type")
+            && error.message.contains("row_count"),
+        "unknown diff columns should preserve DataFusion's discoverable field listing: {}",
+        error.message
+    );
 });

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -29,7 +29,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_row_pk, lixcol_diff_type, from_key, to_key, from_value, to_value, lixcol_row_count \
+                "SELECT lixcol_row_pk, diff_type, from_key, to_key, from_value, to_value, row_count \
                  FROM lix_diff('lix_key_value', '{baseline}', '{inserted}')"
             ),
         )
@@ -49,7 +49,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_key, to_key, from_value, to_value \
+                "SELECT diff_type, from_key, to_key, from_value, to_value \
                  FROM lix_diff('lix_key_value', '{inserted}', '{baseline}')"
             ),
         )
@@ -103,7 +103,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_value, to_value, lixcol_row_count \
+                "SELECT diff_type, from_value, to_value, row_count \
                  FROM lix_diff('lix_key_value', '{inserted}', '{updated}') \
                  WHERE lixcol_row_pk = CAST('[\"note\"]' AS JSONB)"
             ),
@@ -262,7 +262,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
     let added = select_rows(
         &session,
         &format!(
-            "SELECT lixcol_row_pk, lixcol_diff_type, from_path, to_path, lixcol_row_count \
+            "SELECT lixcol_row_pk, diff_type, from_path, to_path, row_count \
              FROM lix_diff('lix_file', '{baseline}', '{inserted}')"
         ),
     )
@@ -276,7 +276,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path, lixcol_row_count \
+                "SELECT diff_type, from_path, to_path, row_count \
                  FROM lix_diff('lix_file', '{inserted}', '{baseline}')"
             ),
         )
@@ -312,7 +312,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT count(*), sum(lixcol_row_count) \
+                "SELECT count(*), sum(row_count) \
                  FROM lix_diff('lix_file', '{baseline}', '{inserted}')"
             ),
         )
@@ -335,7 +335,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path FROM lix_diff('lix_file', '{inserted}', '{renamed}')"
+                "SELECT diff_type, from_path, to_path FROM lix_diff('lix_file', '{inserted}', '{renamed}')"
             ),
         )
         .await,
@@ -360,7 +360,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path FROM lix_diff('lix_file', '{renamed}', '{removed}')"
+                "SELECT diff_type, from_path, to_path FROM lix_diff('lix_file', '{renamed}', '{removed}')"
             ),
         )
         .await,
@@ -374,7 +374,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path \
+                "SELECT diff_type, from_path, to_path \
                  FROM lix_diff('lix_file', '{removed}', '{renamed}')"
             ),
         )
@@ -410,7 +410,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path, lixcol_row_count \
+                "SELECT diff_type, from_path, to_path, row_count \
                  FROM lix_diff('lix_directory', '{baseline}', '{inserted}')"
             ),
         )
@@ -437,7 +437,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path \
+                "SELECT diff_type, from_path, to_path \
                  FROM lix_diff('lix_directory', '{inserted}', '{renamed}')"
             ),
         )
@@ -463,7 +463,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_diff_type, from_path, to_path \
+                "SELECT diff_type, from_path, to_path \
                  FROM lix_diff('lix_directory', '{renamed}', '{removed}')"
             ),
         )
@@ -562,7 +562,7 @@ simulation_test!(relation_diff_fences_machinery_from_user_column_names, |sim| as
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_row_pk, lixcol_diff_type, lixcol_row_count, \
+                "SELECT lixcol_row_pk, diff_type, row_count, \
                  from_diff_type, to_diff_type, from_row_count, to_row_count, \
                  from_depth, to_depth, from_from_path, to_from_path \
                  FROM lix_diff('diff_name_collision', '{baseline}', '{head}')"
@@ -584,7 +584,7 @@ simulation_test!(relation_diff_fences_machinery_from_user_column_names, |sim| as
         ]]
     );
 
-    for retired in ["row_pk", "diff_type", "row_count"] {
+    for retired in ["lixcol_diff_type", "lixcol_row_count"] {
         let error = session
             .execute(
                 &format!(

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -141,8 +141,8 @@ simulation_test!(
              WHERE function_name = 'lix_diff' \
                AND source_relation IN ('lix_file', 'lix_key_value') \
                AND result_column IN (\
-                 'lixcol_row_pk', 'lixcol_diff_type', 'from_path', 'to_path', \
-                 'from_value', 'to_value', 'lixcol_row_count'\
+                 'lixcol_row_pk', 'diff_type', 'from_path', 'to_path', \
+                 'from_value', 'to_value', 'row_count'\
                ) \
              ORDER BY source_relation, ordinal_position",
                 &[],
@@ -162,7 +162,7 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_file".to_string()),
-                    Value::Text("lixcol_diff_type".to_string()),
+                    Value::Text("diff_type".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
@@ -183,7 +183,7 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_file".to_string()),
-                    Value::Text("lixcol_row_count".to_string()),
+                    Value::Text("row_count".to_string()),
                     Value::Text("BIGINT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
@@ -197,7 +197,7 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
-                    Value::Text("lixcol_diff_type".to_string()),
+                    Value::Text("diff_type".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
@@ -218,7 +218,7 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
-                    Value::Text("lixcol_row_count".to_string()),
+                    Value::Text("row_count".to_string()),
                     Value::Text("BIGINT".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -247,7 +247,7 @@ simulation_test!(
             super::select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_diff_type, to_id \
+                    "SELECT diff_type, to_id \
                      FROM lix_diff('lix_file', '{baseline}', '{renamed_head}') \
                      WHERE lixcol_row_pk ->> 0 = '{file_id}'"
                 ),
@@ -263,7 +263,7 @@ simulation_test!(
             super::select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_diff_type, to_id \
+                    "SELECT diff_type, to_id \
                      FROM lix_diff('lix_file', '{baseline}', '{renamed_head}') \
                      WHERE lixcol_row_pk ->> 0 = '{file_id}'"
                 ),

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -676,7 +676,7 @@ simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim|
     assert_ne!(refreshed_head_id, local_commit_id);
     let effective_diff = local
         .execute(
-            "SELECT to_key, lixcol_diff_type, to_lixcol_global \
+            "SELECT to_key, diff_type, to_lixcol_global \
              FROM lix_diff('lix_key_value', $1, $2) \
              WHERE COALESCE(to_key, from_key) IN \
                  ('global-only', 'later-global', 'overridden', 'suppressed') \

--- a/packages/lix/tests/integration/version_control_model_fuzz.rs
+++ b/packages/lix/tests/integration/version_control_model_fuzz.rs
@@ -708,7 +708,7 @@ async fn assert_working_diff(
         .unwrap_or_else(|error| panic!("{label}: checkpoint ID should be text: {error:?}"));
     let rows = session
         .execute(
-            "SELECT lixcol_row_pk, lixcol_diff_type \
+            "SELECT lixcol_row_pk, diff_type \
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id()) \
              ORDER BY lixcol_row_pk",
             &[Value::Text(checkpoint)],
@@ -733,7 +733,7 @@ async fn assert_working_diff(
             continue;
         }
         let diff_type = row
-            .get::<String>("lixcol_diff_type")
+            .get::<String>("diff_type")
             .unwrap_or_else(|error| panic!("{label}: diff_type should be text: {error:?}"));
         actual.push((key.to_string(), diff_type));
     }


### PR DESCRIPTION
## Summary
- hard-cut lix_diff payload columns from lixcol_diff_type/lixcol_row_count to diff_type/row_count
- update every in-repo query, test, benchmark, example, and documentation consumer with no compatibility aliases
- codify the lixcol invariant: tracked-row and history system metadata stays fenced, while relation payload remains ordinary
- add catalog and provider guards against unknown or duplicate lixcol system fields

## Design note
History metadata and lixcol_row_pk intentionally retain the system prefix. Removing it would collide with valid relation payload columns such as depth, row_pk, and is_deleted; the Excalidraw schema already contains is_deleted. Diff payload is collision-safe because source columns are side-qualified as from_*/to_*.

## Validation
- cargo test -p lix --lib --features all-simulations (3348 passed, 26 ignored)
- cargo test -p lix --doc (10 passed)
- cargo test -p lix --lib relation_diff_ (11 passed after rebase)
- cargo test -p lix --lib lixcol_names_are_reserved_for_system_metadata
- cargo clippy -p lix --lib --features all-simulations -- -D warnings
- cargo check --manifest-path packages/e2e/Cargo.toml --all-targets
- cargo fmt --all -- --check
- git diff --check

Three independent sub-agent reviews completed; all findings were addressed and final reviews are clean.