### PR TITLE
feat(snapshot): export from protocol owners

### DIFF
--- a/.changenotes/protocol-snapshot-export.md
+++ b/.changenotes/protocol-snapshot-export.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Allow a `LixServerProtocol` owner to stream a coherent snapshot without opening a second engine for the same storage.

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -1655,6 +1655,15 @@ where
         }
     }
 
+    /// Configures a deterministic, stream-first snapshot export of the
+    /// repository owned by this protocol server.
+    ///
+    /// The export shares the server's existing storage session, so hosts do
+    /// not need to open a second engine behind a live protocol runtime.
+    pub fn export_snapshot(&self) -> crate::snapshot::SnapshotExportBuilder<S> {
+        crate::snapshot::SnapshotExportBuilder::new(self.inner.engine.storage())
+    }
+
     /// Returns whether this server can be dropped without invalidating a live
     /// remote session.
     ///

--- a/packages/lix/src/snapshot/mod.rs
+++ b/packages/lix/src/snapshot/mod.rs
@@ -94,6 +94,52 @@ mod tests {
         assert_eq!(roundtrip, bytes);
     }
 
+    #[cfg(feature = "server-protocol")]
+    #[tokio::test]
+    async fn protocol_owner_exports_without_opening_a_second_engine() {
+        let storage = Memory::new();
+        let source = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("open source Lix");
+        source
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('protocol-snapshot', 'complete')",
+                &[],
+            )
+            .await
+            .expect("seed snapshot state");
+        source.close().await.expect("close source Lix");
+
+        let server = open_lix()
+            .with_storage(storage)
+            .serve()
+            .await
+            .expect("serve source Lix");
+        let mut bytes = Vec::new();
+        server
+            .export_snapshot()
+            .write_to(&mut bytes)
+            .await
+            .expect("export from protocol owner");
+
+        let restored = open_lix()
+            .from_snapshot(Cursor::new(bytes))
+            .await
+            .expect("restore protocol snapshot");
+        let result = restored
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'protocol-snapshot'",
+                &[],
+            )
+            .await
+            .expect("query restored state");
+        assert_eq!(result.rows().len(), 1);
+
+        restored.close().await.expect("close restored Lix");
+        server.close().await.expect("close protocol server");
+    }
+
     #[tokio::test]
     async fn restore_rejects_nonempty_storage_without_changing_it() {
         let mut bytes = Vec::new();


### PR DESCRIPTION
## Summary

- expose the existing stream-first snapshot builder from `LixServerProtocol`
- reuse the protocol owner storage session instead of opening a second engine
- cover export and restore from a served Lix

This is the narrow host integration needed for LixRay backup streaming after #1652.

## Verification

- `cargo test -p lix --features server-protocol protocol_owner_exports_without_opening_a_second_engine`
- `cargo clippy -p lix --all-targets --features server-protocol -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`