### PR TITLE
feat(lix): populate diagnostic error payloads

### DIFF
--- a/packages/lix/src/common/error.rs
+++ b/packages/lix/src/common/error.rs
@@ -266,6 +266,70 @@ impl LixError {
         }))
     }
 
+    /// A row could not be normalized because its schema is outside the
+    /// transaction's visible commit graph and durability scope.
+    pub fn schema_not_visible(
+        schema_key: impl Into<String>,
+        entity_commit_id: Option<impl Into<String>>,
+        base_commit_id: Option<impl Into<String>>,
+        branch_id: impl Into<String>,
+        untracked: bool,
+    ) -> Self {
+        let schema_key = schema_key.into();
+        let entity_commit_id = entity_commit_id.map(Into::into);
+        let base_commit_id = base_commit_id.map(Into::into);
+        let branch_id = branch_id.into();
+        let scope = format!("branch:{branch_id}");
+        let hint = match (entity_commit_id.as_deref(), base_commit_id.as_deref()) {
+            (Some(entity_commit_id), Some(base_commit_id)) if entity_commit_id != base_commit_id => {
+                format!(
+                    "The entity comes from commit {entity_commit_id}, but schema '{schema_key}' is not visible from this transaction's base commit {base_commit_id} in {scope} ({} lane). This usually indicates that the entity commit is not an ancestor of the transaction base, or that the schema was registered in a different branch or durability scope.",
+                    if untracked { "untracked" } else { "tracked" }
+                )
+            }
+            (_, Some(base_commit_id)) => format!(
+                "Schema '{schema_key}' is not visible from this transaction's base commit {base_commit_id} in {scope} ({} lane). This usually indicates that the schema was registered in a different branch or durability scope.",
+                if untracked { "untracked" } else { "tracked" }
+            ),
+            _ => format!(
+                "Schema '{schema_key}' is not visible in {scope} ({} lane). This usually indicates that the schema was registered in a different branch or durability scope.",
+                if untracked { "untracked" } else { "tracked" }
+            ),
+        };
+        let mut details = serde_json::Map::from_iter([
+            ("schema_key".to_string(), JsonValue::String(schema_key.clone())),
+            ("scope".to_string(), JsonValue::String(scope)),
+            (
+                "durability".to_string(),
+                JsonValue::String(if untracked { "untracked" } else { "tracked" }.to_string()),
+            ),
+        ]);
+        if let Some(entity_commit_id) = entity_commit_id {
+            details.insert(
+                "entity_commit_id".to_string(),
+                JsonValue::String(entity_commit_id),
+            );
+        }
+        if let Some(base_commit_id) = base_commit_id {
+            details.insert(
+                "base_commit_id".to_string(),
+                JsonValue::String(base_commit_id),
+            );
+        }
+        Self::new(
+            Self::CODE_SCHEMA_DEFINITION,
+            format!("schema '{schema_key}' is not visible to this transaction"),
+        )
+        .with_details(JsonValue::Object(details))
+        .with_hint(hint)
+    }
+
+    /// Construct an internal invariant failure with the entity coordinates
+    /// needed to turn the surfaced error into an actionable bug report.
+    pub fn internal_invariant(message: impl Into<String>, entities: JsonValue) -> Self {
+        Self::new(Self::CODE_INTERNAL_ERROR, message).with_details(entities)
+    }
+
     pub fn ambiguous_merge_base(
         left_commit_id: impl Into<String>,
         right_commit_id: impl Into<String>,

--- a/packages/lix/src/filesystem/path_index.rs
+++ b/packages/lix/src/filesystem/path_index.rs
@@ -879,9 +879,16 @@ impl FilesystemPathIndex {
         kind: FilesystemPathKind,
     ) -> Result<FilesystemPathEntry, LixError> {
         let snapshot = row.snapshot_content.as_deref().ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
+            LixError::internal_invariant(
                 "descriptor delta has no snapshot",
+                serde_json::json!({
+                    "schema_key": row.schema_key,
+                    "change_id": row.change_id.map(|value| value.to_string()),
+                    "commit_id": row.commit_id.map(|value| value.to_string()),
+                    "descriptor_id": key.descriptor_id(),
+                    "file_id": key.file_id(),
+                    "scope": format!("branch:{}", key.branch_id()),
+                }),
             )
         })?;
         let (parent_id, name) = match kind {

--- a/packages/lix/src/hot_state/derived.rs
+++ b/packages/lix/src/hot_state/derived.rs
@@ -455,12 +455,15 @@ fn validate_commit_point_identity(
     if record.commit_id == requested_commit_id {
         return Ok(());
     }
-    Err(LixError::new(
-        LixError::CODE_INTERNAL_ERROR,
+    Err(LixError::internal_invariant(
         format!(
             "commit point lookup for {requested_commit_id} decoded record {}",
             record.commit_id
         ),
+        serde_json::json!({
+            "requested_commit_id": requested_commit_id.to_string(),
+            "commit_id": record.commit_id.to_string(),
+        }),
     ))
 }
 

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -600,12 +600,18 @@ where
 }
 
 fn current_state_duplicate_delta_error(delta: &CurrentStateDeltaRef<'_>) -> LixError {
-    LixError::new(
-        LixError::CODE_INTERNAL_ERROR,
+    LixError::internal_invariant(
         format!(
             "current-state commit contains duplicate mutation for schema '{}' row_pk '{:?}' file_id '{:?}'",
             delta.schema_key, delta.row_pk, delta.file_id
         ),
+        serde_json::json!({
+            "schema_key": delta.schema_key,
+            "row_pk": delta.row_pk.as_typed_json_array_value().ok(),
+            "file_id": delta.file_id,
+            "change_id": delta.change_id.map(|value| value.to_string()),
+            "commit_id": delta.commit_id.map(|value| value.to_string()),
+        }),
     )
 }
 

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -1832,13 +1832,19 @@ where
                 {
                     continue;
                 }
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
+                return Err(LixError::internal_invariant(
                     format!(
                         "tracked-state diff row '{}' does not match commit '{}' delta index",
                         row.change_id(),
                         commit_id
                     ),
+                    serde_json::json!({
+                        "change_id": row.change_id().to_string(),
+                        "commit_id": commit_id.to_string(),
+                        "schema_key": row.schema_key(),
+                        "row_pk": row.row_pk().as_typed_json_array_value().ok(),
+                        "file_id": row.file_id(),
+                    }),
                 ));
             }
         }
@@ -5100,11 +5106,13 @@ pub(crate) struct TrackedStateWriteReport {
 }
 
 fn missing_commit_root_error(commit_id: &str) -> LixError {
-    LixError::new(
-        LixError::CODE_INTERNAL_ERROR,
+    LixError::internal_invariant(
         format!(
             "tracked_state rooted commit authority is missing snapshot metadata for commit '{commit_id}'"
         ),
+        serde_json::json!({
+            "commit_id": commit_id,
+        }),
     )
 }
 
@@ -8527,6 +8535,19 @@ mod tests {
         assert!(
             error.message.contains("missing from owning commit"),
             "unexpected error: {error}"
+        );
+        let details = error
+            .details
+            .as_ref()
+            .expect("internal invariant should retain entity coordinates");
+        assert_eq!(details["change_id"], row.change_id.to_string());
+        assert_eq!(details["commit_id"], commit_id.to_string());
+        assert_eq!(details["schema_key"], row.schema_key);
+        assert_eq!(
+            details["row_pk"],
+            row.row_pk
+                .as_typed_json_array_value()
+                .expect("test row PK should encode")
         );
     }
 

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -458,11 +458,17 @@ where
         };
         for ((key, change_id, updated_at), record) in expected.into_iter().zip(loaded) {
             let record = record.or_else(|| snapshot_records.remove(&change_id)).ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
+                LixError::internal_invariant(
                     format!(
                         "tracked-state row references change '{change_id}' that is missing from owning commit '{commit_id}'"
                     ),
+                    serde_json::json!({
+                        "change_id": change_id.to_string(),
+                        "commit_id": commit_id.to_string(),
+                        "schema_key": key.schema_key,
+                        "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                        "file_id": key.file_id,
+                    }),
                 )
             })?;
             #[cfg(feature = "storage-benches")]
@@ -474,11 +480,17 @@ where
                 || record.snapshot.is_none()
                 || record.created_at != updated_at
             {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
+                return Err(LixError::internal_invariant(
                     format!(
                         "tracked-state row '{change_id}' does not match its authoritative payload in commit '{commit_id}'"
                     ),
+                    serde_json::json!({
+                        "change_id": change_id.to_string(),
+                        "commit_id": commit_id.to_string(),
+                        "schema_key": key.schema_key,
+                        "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                        "file_id": key.file_id,
+                    }),
                 ));
             }
             records.push(record);
@@ -545,6 +557,7 @@ where
                     row_pk: &key.row_pk,
                 },
                 value.change_id,
+                value.commit_id,
             )?
         };
         let ordinal = rows.rows.len();
@@ -594,7 +607,7 @@ where
         let (snapshot_content, metadata, snapshot) = if value.deleted {
             (None, None, None)
         } else {
-            shared_payload_fields(&payloads, key, value.change_id)?
+            shared_payload_fields(&payloads, key, value.change_id, value.commit_id)?
         };
         let ordinal = rows.rows.len();
         rows.push_ref(key, value, snapshot_content, metadata);
@@ -612,6 +625,7 @@ fn shared_payload_fields(
     payloads: &HashMap<ChangeId, MaterializedChangePayload>,
     key: TrackedStateKeyRef<'_>,
     change_id: ChangeId,
+    commit_id: CommitId,
 ) -> Result<
     (
         Option<SharedStr>,
@@ -621,11 +635,17 @@ fn shared_payload_fields(
     LixError,
 > {
     let payload = payloads.get(&change_id).ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
+        LixError::internal_invariant(
             format!(
                 "tracked-state row references ChangeRecord '{change_id}' that was not materialized"
             ),
+            serde_json::json!({
+                "change_id": change_id.to_string(),
+                "commit_id": commit_id.to_string(),
+                "schema_key": key.schema_key,
+                "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                "file_id": key.file_id,
+            }),
         )
     })?;
     if let Some(identity) = payload.identity.as_ref()
@@ -633,11 +653,17 @@ fn shared_payload_fields(
             || identity.row_pk != *key.row_pk
             || identity.file_id.as_deref() != key.file_id)
     {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
+        return Err(LixError::internal_invariant(
             format!(
                 "tracked-state row identity does not match referenced ChangeRecord '{change_id}'"
             ),
+            serde_json::json!({
+                "change_id": change_id.to_string(),
+                "commit_id": commit_id.to_string(),
+                "schema_key": key.schema_key,
+                "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                "file_id": key.file_id,
+            }),
         ));
     }
     Ok((
@@ -1208,17 +1234,18 @@ mod tests {
     #[test]
     fn repeated_payload_uses_share_the_materialized_json_buffer() {
         let (change_id, key, payloads, source) = fixture("message");
+        let commit_id = CommitId::for_test_label("payload-owner");
 
         let key_ref = TrackedStateKeyRef {
             schema_key: key.schema_key.as_str(),
             file_id: key.file_id.as_deref(),
             row_pk: &key.row_pk,
         };
-        let first = shared_payload_fields(&payloads, key_ref, change_id)
+        let first = shared_payload_fields(&payloads, key_ref, change_id, commit_id)
             .expect("first payload use")
             .0
             .expect("snapshot");
-        let second = shared_payload_fields(&payloads, key_ref, change_id)
+        let second = shared_payload_fields(&payloads, key_ref, change_id, commit_id)
             .expect("second payload use")
             .0
             .expect("snapshot");
@@ -1230,6 +1257,7 @@ mod tests {
     #[test]
     fn payload_identity_mismatch_is_rejected() {
         let (change_id, key, payloads, _) = fixture("wrong-schema");
+        let commit_id = CommitId::for_test_label("payload-owner");
 
         let error = shared_payload_fields(
             &payloads,
@@ -1239,12 +1267,23 @@ mod tests {
                 row_pk: &key.row_pk,
             },
             change_id,
+            commit_id,
         )
         .expect_err("mismatched identity must fail");
         assert!(
             error
                 .to_string()
                 .contains("identity does not match referenced ChangeRecord")
+        );
+        let details = error.details.expect("invariant should retain entity IDs");
+        assert_eq!(details["change_id"], change_id.to_string());
+        assert_eq!(details["commit_id"], commit_id.to_string());
+        assert_eq!(details["schema_key"], key.schema_key);
+        assert_eq!(
+            details["row_pk"],
+            key.row_pk
+                .as_typed_json_array_value()
+                .expect("test row PK should encode")
         );
     }
 }

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -6713,6 +6713,21 @@ where
 
     async fn prepare_transaction_rows_with_homogeneous(
         &mut self,
+        rows: RawWriteBatch,
+        allow_homogeneous: bool,
+    ) -> Result<PreparedStateBatch, LixError> {
+        let opening_read = self.opening_read();
+        match self
+            .prepare_transaction_rows_with_homogeneous_inner(rows, allow_homogeneous)
+            .await
+        {
+            Ok(prepared) => Ok(prepared),
+            Err(error) => Err(Self::enrich_schema_visibility_error(opening_read, error).await),
+        }
+    }
+
+    async fn prepare_transaction_rows_with_homogeneous_inner(
+        &mut self,
         mut rows: RawWriteBatch,
         allow_homogeneous: bool,
     ) -> Result<PreparedStateBatch, LixError> {
@@ -6780,6 +6795,7 @@ where
                     catalog,
                     functions.clone(),
                     &mut default_timestamp,
+                    None,
                 )?;
                 scalar_facts.push(plan_prepared_row_scalars(
                     rows.row(index),
@@ -6873,6 +6889,7 @@ where
                     catalog,
                     functions.clone(),
                     &mut default_timestamp,
+                    None,
                 )?;
                 normalized_facts[index] = Some(normalized);
             }
@@ -6919,6 +6936,107 @@ where
             .record_transition_counters(typed_validation_counters);
         self.current_timestamp = default_timestamp;
         Ok(prepared_rows)
+    }
+
+    async fn enrich_schema_visibility_error(
+        opening_read: SharedStorageAdapterRead<StorageImpl::Read<'static>>,
+        mut error: LixError,
+    ) -> LixError {
+        if error.code != LixError::CODE_SCHEMA_DEFINITION {
+            return error;
+        }
+        let Some(details) = error.details.as_mut().and_then(JsonValue::as_object_mut) else {
+            return error;
+        };
+        let Some(schema_key) = details
+            .get("schema_key")
+            .and_then(JsonValue::as_str)
+            .map(str::to_owned)
+        else {
+            return error;
+        };
+        let scope = details
+            .get("scope")
+            .and_then(JsonValue::as_str)
+            .map(str::to_owned)
+            .unwrap_or_else(|| "this transaction's scope".to_string());
+        let Some(branch_id) = scope.strip_prefix("branch:") else {
+            return error;
+        };
+        let base_commit_id = match BranchHeadControlContext::new()
+            .reader(opening_read.clone())
+            .load(branch_id)
+            .await
+        {
+            Ok(Some(control)) => Some(control.head_commit_id),
+            Ok(None) | Err(_) => None,
+        };
+        if let Some(base_commit_id) = base_commit_id {
+            details.insert(
+                "base_commit_id".to_string(),
+                JsonValue::String(base_commit_id.to_string()),
+            );
+        }
+        let Some(entity_commit_id) = details
+            .get("entity_commit_id")
+            .and_then(JsonValue::as_str)
+            .or_else(|| details.get("base_commit_id").and_then(JsonValue::as_str))
+            .and_then(|value| CommitId::parse_lix(value, "schema visibility entity commit").ok())
+        else {
+            return error;
+        };
+        let mut tracked_state = TrackedStateContext::new().reader(opening_read.clone());
+        let registrations = match tracked_state
+            .load_projected_batch_at_commit(
+                &entity_commit_id.to_string(),
+                &[TrackedStateKey {
+                    schema_key: REGISTERED_SCHEMA_KEY.to_string(),
+                    file_id: None,
+                    row_pk: RowPk::single(schema_key.as_str()),
+                }],
+                &ChangeRecordProjection::identity_only(),
+            )
+            .await
+        {
+            Ok(registrations) => registrations,
+            Err(_) => return error,
+        };
+        let Some(registration_commit_id) = registrations.row(0).map(|row| row.commit_id()) else {
+            return error;
+        };
+        details.insert(
+            "commit_id".to_string(),
+            JsonValue::String(registration_commit_id.to_string()),
+        );
+        let Some(base_commit_id) = base_commit_id else {
+            error.hint = Some(format!(
+                "Schema '{schema_key}' is registered at commit {registration_commit_id}, but it is not visible in {scope}. This usually indicates that the schema was registered in a different branch or durability scope."
+            ));
+            return error;
+        };
+        let mut graph = CommitGraphContext::new().reader(opening_read);
+        let registration_is_ancestor = match graph.reachable_nodes(&base_commit_id).await {
+            Ok(nodes) => Some(
+                nodes
+                    .iter()
+                    .any(|node| node.commit.commit_id == registration_commit_id),
+            ),
+            Err(_) => None,
+        };
+        error.hint = Some(if registration_is_ancestor == Some(true) {
+            format!(
+                "Schema '{schema_key}' is registered at commit {registration_commit_id}, which is an ancestor of this transaction's base commit {base_commit_id}, but it is absent from {scope}'s transaction catalog. This can indicate a later schema removal, a durability-scope mismatch, or an internal catalog inconsistency."
+            )
+        } else if registration_is_ancestor == Some(false) {
+            format!(
+                "Schema '{schema_key}' is registered at commit {registration_commit_id}, but that commit is not an ancestor of this transaction's base commit {base_commit_id}. This usually indicates that an entity from another branch was staged without first merging or rebasing its schema registration into {scope}."
+            )
+        } else {
+            format!(
+                "Schema '{schema_key}' is registered at commit {registration_commit_id}, but its ancestry relative to this transaction's base commit {base_commit_id} could not be verified. Retry the transaction; if the error persists, inspect the commit graph and {scope}'s schema registration."
+            )
+        });
+        error
     }
 
     /// Validates the drained write set and, on the way through, hands the
@@ -15353,6 +15471,182 @@ fallback={large_fallback} decoded={large_decoded}"
                 .contains("schema 'missing_schema' is not visible"),
             "error should explain missing schema visibility: {error:?}"
         );
+        let details = error
+            .details
+            .as_ref()
+            .expect("visibility error should be structured");
+        assert_eq!(details["schema_key"], "missing_schema");
+        assert_eq!(details["scope"], format!("branch:{GLOBAL_BRANCH_ID}"));
+        assert_eq!(
+            details["base_commit_id"],
+            CommitId::for_test_label(SCHEMA_FIXTURE_COMMIT_ID).to_string()
+        );
+        assert!(details.get("commit_id").is_none());
+        assert!(error.hint().is_some(), "visibility error should include a hint");
+    }
+
+    #[tokio::test]
+    async fn schema_visibility_enrichment_resolves_registration_commit() {
+        let storage = Memory::new();
+        let (_hot_state, _binary_cas, _branch_ref, _runtime_functions, transaction) =
+            open_test_transaction(&storage).await;
+        let fixture_commit_id = CommitId::for_test_label(SCHEMA_FIXTURE_COMMIT_ID);
+        let error = LixError::schema_not_visible(
+            "lix_file_descriptor",
+            Some(fixture_commit_id.to_string()),
+            None::<String>,
+            GLOBAL_BRANCH_ID,
+            false,
+        );
+
+        let error = Transaction::<Memory>::enrich_schema_visibility_error(
+            transaction.opening_read(),
+            error,
+        )
+        .await;
+
+        let details = error
+            .details
+            .as_ref()
+            .expect("enriched visibility error should be structured");
+        assert_eq!(details["schema_key"], "lix_file_descriptor");
+        assert_eq!(details["commit_id"], fixture_commit_id.to_string());
+        assert_eq!(details["entity_commit_id"], fixture_commit_id.to_string());
+        assert_eq!(details["base_commit_id"], fixture_commit_id.to_string());
+        assert_eq!(details["scope"], format!("branch:{GLOBAL_BRANCH_ID}"));
+        let hint = error.hint().expect("enriched error should include a hint");
+        assert!(hint.contains("is registered at commit"), "{hint}");
+        assert!(hint.contains(&fixture_commit_id.to_string()), "{hint}");
+    }
+
+    #[tokio::test]
+    async fn stage_rows_reports_divergent_schema_registration_commit() {
+        const BASE_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000101";
+        const SCHEMA_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000102";
+        const BASE_COMMIT_ID: &str = "01920000-0000-7000-8000-000000000103";
+        const SCHEMA_REGISTRATION_COMMIT_ID: &str = "01920000-0000-7000-8000-000000000104";
+        const ENTITY_COMMIT_ID: &str = "01920000-0000-7000-8000-000000000105";
+        const SCHEMA_KEY: &str = "divergent_schema";
+
+        let storage = Memory::new();
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        seed_visible_schema_rows_for_branch(
+            storage_adapter.clone(),
+            BASE_BRANCH_ID,
+            BASE_COMMIT_ID,
+        )
+        .await;
+        let custom_schema = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": SCHEMA_KEY,
+            "columns": [{ "name": "id", "type": "text", "nullable": false }],
+            "primary_key": ["id"]
+        });
+        let schema_registration = crate::tracked_state::MaterializedTrackedStateRow {
+            row_pk: crate::schema::registered_schema_row_pk(SCHEMA_KEY)
+                .expect("registered schema identity should derive"),
+            schema_key: "lix_registered_schema".to_string(),
+            file_id: None,
+            snapshot_content: Some(
+                json!({ "schema_key": SCHEMA_KEY, "value": custom_schema })
+                    .to_string()
+                    .into(),
+            ),
+            decoded_snapshot: None,
+            metadata: None,
+            deleted: false,
+            created_at: "1970-01-01T00:00:00.000Z".to_string(),
+            updated_at: "1970-01-01T00:00:00.000Z".to_string(),
+            change_id: ChangeId::for_test_label("divergent-schema-registration"),
+            commit_id: CommitId::for_test_label(SCHEMA_REGISTRATION_COMMIT_ID),
+        };
+        crate::test_support::seed_branch_head_with_rows(
+            storage_adapter.clone(),
+            SCHEMA_BRANCH_ID,
+            SCHEMA_REGISTRATION_COMMIT_ID,
+            std::slice::from_ref(&schema_registration),
+        )
+        .await;
+        let mut entity_read = storage_adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("entity commit read should open");
+        let mut entity_writes = StorageWriteSet::new();
+        crate::test_support::stage_tracked_root_from_materialized(
+            &mut entity_read,
+            &mut entity_writes,
+            &TrackedStateContext::new(),
+            ENTITY_COMMIT_ID,
+            Some(SCHEMA_REGISTRATION_COMMIT_ID),
+            &[],
+        )
+        .await
+        .expect("entity commit should retain its parent schema registration");
+        storage_adapter
+            .commit_write_set(
+                entity_writes,
+                StorageWriteOptions::default(),
+            )
+            .await
+            .expect("entity commit should persist");
+
+        let opened = open_transaction(
+            &SessionBranch::new(BASE_BRANCH_ID.to_string()),
+            crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            storage_adapter,
+            Arc::new(hot_state_context()),
+            Arc::new(TrackedStateContext::new()),
+            Arc::new(BinaryCasContext::new()),
+            PluginRuntimeHost::new(Arc::new(crate::plugin::runtime::UnsupportedWasmRuntime)),
+            Arc::new(BranchContext::new()),
+            Arc::new(CatalogContext::new()),
+            Arc::new(SqlPlanningCache::default()),
+            SessionFileViews::default(),
+        )
+        .await
+        .expect("base-branch transaction should open");
+        let mut transaction = opened.transaction;
+        let mut row = key_value_stage_row("divergent-row", "value", false);
+        row.schema_key = SCHEMA_KEY.into();
+        row.snapshot = Some(TransactionJson::from_value_for_test(
+            json!({ "id": "divergent-row" }),
+        ));
+        row.global = false;
+        row.branch_id = BASE_BRANCH_ID.into();
+        row.commit_id = Some(CommitId::for_test_label(ENTITY_COMMIT_ID).to_string());
+
+        let error = transaction
+            .stage_rows(raw_write_rows(vec![row]))
+            .await
+            .expect_err("a schema registered only on a divergent branch must not be visible");
+
+        assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
+        let details = error
+            .details
+            .as_ref()
+            .expect("divergent visibility error should be structured");
+        assert_eq!(details["schema_key"], SCHEMA_KEY);
+        assert_eq!(details["scope"], format!("branch:{BASE_BRANCH_ID}"));
+        assert_eq!(
+            details["commit_id"],
+            CommitId::for_test_label(SCHEMA_REGISTRATION_COMMIT_ID).to_string()
+        );
+        assert_eq!(
+            details["entity_commit_id"],
+            CommitId::for_test_label(ENTITY_COMMIT_ID).to_string()
+        );
+        assert_eq!(
+            details["base_commit_id"],
+            CommitId::for_test_label(BASE_COMMIT_ID).to_string()
+        );
+        let hint = error.hint().expect("divergent visibility error should have a hint");
+        assert!(hint.contains("not an ancestor"), "{hint}");
+        assert!(
+            hint.contains(
+                &CommitId::for_test_label(SCHEMA_REGISTRATION_COMMIT_ID).to_string()
+            ),
+            "{hint}"
+        );
     }
 
     #[tokio::test]
@@ -15731,8 +16025,10 @@ fallback={large_fallback} decoded={large_decoded}"
         )
     }
 
-    async fn seed_visible_schema_rows(storage: StorageAdapter) {
-        let rows = crate::schema::seed_schema_definitions()
+    fn visible_schema_fixture_rows(
+        commit_id: &str,
+    ) -> Vec<crate::tracked_state::MaterializedTrackedStateRow> {
+        crate::schema::seed_schema_definitions()
             .into_iter()
             .map(|schema| {
                 let key = crate::schema::schema_key_from_definition(schema)
@@ -15757,15 +16053,32 @@ fallback={large_fallback} decoded={large_decoded}"
                         "schema-fixture-{}",
                         key.schema_key
                     )),
-                    commit_id: CommitId::for_test_label(SCHEMA_FIXTURE_COMMIT_ID),
+                    commit_id: CommitId::for_test_label(commit_id),
                 }
             })
-            .collect::<Vec<_>>();
+            .collect()
+    }
+
+    async fn seed_visible_schema_rows_for_branch(
+        storage: StorageAdapter,
+        branch_id: &str,
+        commit_id: &str,
+    ) {
+        let rows = visible_schema_fixture_rows(commit_id);
         crate::test_support::seed_branch_head_with_rows(
+            storage,
+            branch_id,
+            commit_id,
+            &rows,
+        )
+        .await;
+    }
+
+    async fn seed_visible_schema_rows(storage: StorageAdapter) {
+        seed_visible_schema_rows_for_branch(
             storage,
             GLOBAL_BRANCH_ID,
             SCHEMA_FIXTURE_COMMIT_ID,
-            &rows,
         )
         .await;
     }

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -7015,12 +7015,20 @@ where
             return error;
         };
         let mut graph = CommitGraphContext::new().reader(opening_read);
-        let registration_is_ancestor = match graph.reachable_nodes(&base_commit_id).await {
-            Ok(nodes) => Some(
-                nodes
+        const DIAGNOSTIC_ANCESTRY_LIMIT: usize = 1_024;
+        let registration_is_ancestor = match graph
+            .reachable_nodes_limited(&base_commit_id, DIAGNOSTIC_ANCESTRY_LIMIT)
+            .await
+        {
+            Ok(nodes)
+                if nodes
                     .iter()
-                    .any(|node| node.commit.commit_id == registration_commit_id),
-            ),
+                    .any(|node| node.commit.commit_id == registration_commit_id) =>
+            {
+                Some(true)
+            }
+            Ok(nodes) if nodes.len() < DIAGNOSTIC_ANCESTRY_LIMIT => Some(false),
+            Ok(_) => None,
             Err(_) => None,
         };
         error.hint = Some(if registration_is_ancestor == Some(true) {

--- a/packages/lix/src/transaction/normalization.rs
+++ b/packages/lix/src/transaction/normalization.rs
@@ -52,6 +52,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
     schema_catalog: &mut TransactionCatalog,
     functions: FunctionProviderHandle,
     default_timestamp: &mut Option<crate::common::LixTimestamp>,
+    transaction_base_commit_id: Option<&str>,
 ) -> Result<NormalizedRowFacts, LixError> {
     populate_registered_schema_snapshot(rows, row_index)?;
     let row = rows.row(row_index);
@@ -61,12 +62,12 @@ pub(crate) fn normalize_raw_write_row_in_place(
     let Some((schema_plan_id, schema_plan)) =
         schema_catalog.snapshot().plan_for_key(&row.schema_key)
     else {
-        return Err(LixError::new(
-            LixError::CODE_SCHEMA_DEFINITION,
-            format!(
-                "schema '{}' is not visible to this transaction",
-                row.schema_key
-            ),
+        return Err(LixError::schema_not_visible(
+            row.schema_key.as_str(),
+            row.commit_id,
+            transaction_base_commit_id,
+            row.schema_scope_branch_id(),
+            row.untracked,
         ));
     };
 
@@ -105,9 +106,15 @@ pub(crate) fn normalize_raw_write_row_in_place(
         }
         if typed.boundary_validation_certified() {
             let Some(staged_row_pk) = rows.row(row_index).row_pk else {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
+                return Err(LixError::internal_invariant(
                     "boundary-certified typed row lost its durable primary key before transaction normalization",
+                    serde_json::json!({
+                        "schema_key": schema_key,
+                        "commit_id": rows.row(row_index).commit_id,
+                        "file_id": rows.row(row_index).file_id,
+                        "scope": format!("branch:{}", rows.row(row_index).schema_scope_branch_id()),
+                        "durability": if rows.row(row_index).untracked { "untracked" } else { "tracked" },
+                    }),
                 ));
             };
             if !staged_row_pk.matches_schema_values(&typed.row_pk) {
@@ -247,9 +254,15 @@ pub(crate) fn normalize_raw_write_row_in_place(
         && row.schema_key != REGISTERED_SCHEMA_KEY
     {
         if row.row_pk.is_none() {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
+            return Err(LixError::internal_invariant(
                 "certified replacement row is missing its proven row identity",
+                serde_json::json!({
+                    "schema_key": row.schema_key,
+                    "commit_id": row.commit_id,
+                    "file_id": row.file_id,
+                    "scope": format!("branch:{}", row.schema_scope_branch_id()),
+                    "durability": if row.untracked { "untracked" } else { "tracked" },
+                }),
             ));
         }
         let typed =
@@ -497,9 +510,14 @@ fn ensure_internal_control_schema(
     }
     let schema = crate::schema::seed_schema_definition(&row.schema_key)
         .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
+            LixError::internal_invariant(
                 "compile-time internal control schema is missing",
+                serde_json::json!({
+                    "schema_key": row.schema_key,
+                    "commit_id": row.commit_id,
+                    "scope": format!("branch:{}", row.schema_scope_branch_id()),
+                    "durability": if row.untracked { "untracked" } else { "tracked" },
+                }),
             )
         })?
         .clone();
@@ -696,6 +714,46 @@ mod tests {
     use crate::schema::seed_schema_definition;
 
     #[test]
+    fn missing_schema_reports_entity_commit_and_transaction_scope() {
+        let mut catalog = catalog_with(Vec::new());
+        let mut rows = RawWriteBatch::with_capacity(1);
+        rows.push(TransactionWriteRow {
+            schema_key: "lix_file_descriptor".into(),
+            commit_id: Some("01a04058-entity".to_string()),
+            branch_id: "main".into(),
+            global: false,
+            ..base_stage_row()
+        });
+        let mut default_timestamp = None;
+
+        let error = normalize_raw_write_row_in_place(
+            &mut rows,
+            0,
+            &mut catalog,
+            functions(),
+            &mut default_timestamp,
+            Some("01a04058-base"),
+        )
+        .expect_err("missing schema should fail normalization");
+
+        assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
+        assert_eq!(
+            error.details,
+            Some(serde_json::json!({
+                "schema_key": "lix_file_descriptor",
+                "entity_commit_id": "01a04058-entity",
+                "base_commit_id": "01a04058-base",
+                "scope": "branch:main",
+                "durability": "tracked",
+            }))
+        );
+        let hint = error.hint().expect("visibility error should be actionable");
+        assert!(hint.contains("01a04058-entity"), "{hint}");
+        assert!(hint.contains("01a04058-base"), "{hint}");
+        assert!(hint.contains("not an ancestor"), "{hint}");
+    }
+
+    #[test]
     fn normalization_derives_row_pk_from_primary_key() {
         let mut catalog = catalog_with(vec![schema_with_default_id()]);
         let row = TransactionWriteRow {
@@ -879,6 +937,7 @@ mod tests {
             &mut catalog,
             functions(),
             &mut default_timestamp,
+            None,
         )
         .expect_err("typed envelope identity mismatch must fail");
 
@@ -929,6 +988,7 @@ mod tests {
             &mut catalog,
             functions(),
             &mut default_timestamp,
+            None,
         )
         .expect("typed defaults normalize");
 
@@ -1283,7 +1343,14 @@ mod tests {
         let mut rows = RawWriteBatch::with_capacity(1);
         rows.push(row);
         let mut default_timestamp = None;
-        normalize_raw_write_row_in_place(&mut rows, 0, catalog, functions, &mut default_timestamp)?;
+        normalize_raw_write_row_in_place(
+            &mut rows,
+            0,
+            catalog,
+            functions,
+            &mut default_timestamp,
+            None,
+        )?;
         Ok(rows.into_rows().pop().expect("single normalized test row"))
     }
 


### PR DESCRIPTION
## Summary

- populate schema-visibility errors with structured schema, registration/entity/base commit, branch scope, and durability details
- derive actionable hints from the pinned transaction base and commit graph without making unverified ancestry claims
- attach structured entity coordinates to internal invariant failures in transaction, tracked-state, hot-state, and filesystem paths
- add end-to-end divergent-branch coverage that distinguishes the schema registration commit from the entity and transaction base commits

## Validation

- cargo nextest run -p lix --features all-simulations (3,390 passed)
- cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings
- cargo test -p lix --doc
- cargo fmt --all -- --check
- three independent sub-agent reviews: correctness, API/transport, and tests; all findings addressed