### PR TITLE
fix(lix): retry expired transaction reads

### DIFF
--- a/.changenotes/retry-expired-transaction-reads.md
+++ b/.changenotes/retry-expired-transaction-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Concurrent browser sync no longer crashes an in-flight write when its transaction read expires.
+
+Lix now returns the transient storage error to its bounded write retry path instead of panicking while opening transaction-scoped history readers.

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -69,7 +69,7 @@ where
             let (previous_recovery, mut gc_state) =
                 transaction.checkpoint_publication_state(&branch_id).await?;
             let head_commit_id = {
-                let reader = transaction.branch_ref_reader().await;
+                let reader = transaction.branch_ref_reader().await?;
                 BranchLifecycle::new(&reader)
                     .require_existing_commit_id(
                         &branch_id,

--- a/packages/lix/src/session/create_branch.rs
+++ b/packages/lix/src/session/create_branch.rs
@@ -57,7 +57,7 @@ where
                     BranchOperation::CreateBranch,
                     BranchReferenceRole::CommitSource,
                 )?;
-                let mut commit_graph = transaction.commit_graph_reader().await;
+                let mut commit_graph = transaction.commit_graph_reader().await?;
                 let commit = BranchLifecycle::require_existing_commit(
                     &mut commit_graph,
                     from_commit_id,
@@ -68,7 +68,7 @@ where
                 commit.commit_id
             } else {
                 let active_branch_id = transaction.active_branch_id().to_string();
-                let reader = transaction.branch_ref_reader().await;
+                let reader = transaction.branch_ref_reader().await?;
                 BranchLifecycle::new(&reader)
                     .require_existing_commit_id(
                         &active_branch_id,

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1476,7 +1476,8 @@ where
             }
             let sql_for_error = sql.to_string();
             let params = params.to_vec();
-            let mut auto_commit_retries = 0;
+            let mut transaction_conflict_retries = 0;
+            let mut expired_read_retries = ExpiredReadRetryState::default();
             loop {
                 let write_access = self.begin_session_write_access().await?;
                 let sql_for_planning = sql_for_error.clone();
@@ -1514,10 +1515,18 @@ where
                     .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
                 match result {
                     Ok(result) => return Ok(result),
-                    Err(error) if consume_auto_commit_retry(&mut auto_commit_retries, &error) => {
-                        continue;
+                    Err(error) => {
+                        if retry_auto_commit(
+                            &mut transaction_conflict_retries,
+                            &mut expired_read_retries,
+                            &error,
+                        )
+                        .await
+                        {
+                            continue;
+                        }
+                        return Err(error);
                     }
-                    Err(error) => return Err(error),
                 }
             }
         }
@@ -1805,79 +1814,107 @@ where
         metadata: ExecuteStatementMetadata,
         idempotency: ExecuteIdempotency,
     ) -> Result<ExecuteResult, LixError> {
+        let mut expired_read_retries = ExpiredReadRetryState::default();
         if let IdempotencyReceiptResolution::Replay(receipt) =
-            self.resolve_idempotency_receipt(&idempotency).await?
+            self.resolve_idempotency_receipt_with_expired_read_retry(
+                &idempotency,
+                &mut expired_read_retries,
+            )
+            .await?
         {
             return receipt.into_single_result();
         }
 
-        let write_access = self.begin_session_write_access().await?;
         let sql_for_error = sql.to_string();
-        let sql_for_planning = sql_for_error.clone();
         let params = params.to_vec();
-        // The original identity is retained for post-commit recovery. The
-        // transaction closure owns its own copy because its future may outlive
-        // this call's immediate stack frame while the write lease is held.
-        let idempotency_for_commit = idempotency.clone();
-        let result = self
-            .with_write_transaction_reserved_lending(
-                write_access,
-                async move |transaction| {
-                    let previous_origin_key = transaction.replace_origin_key(options.origin_key);
-                    let result = async {
-                        let tx_plan = transaction
-                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                        let result = execute_prepared_transaction_write(
-                            transaction,
-                            tx_plan,
-                            &params,
-                            &metadata,
-                        )
-                        .await?;
-                        let result = ExecuteResult::from_sql_write_result(result);
-                        let receipt =
-                            ExecuteIdempotencyReceipt::single(&idempotency_for_commit, &result)?;
-                        transaction
-                            .stage_execute_idempotency_receipt(&idempotency_for_commit, &receipt)?;
-                        Ok(result)
-                    }
-                    .await;
-                    transaction.replace_origin_key(previous_origin_key);
-                    result
-                },
-                |_| Ok(()),
-            )
-            .await
-            .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
+        loop {
+            let write_access = self.begin_session_write_access().await?;
+            let sql_for_planning = sql_for_error.clone();
+            let statement = statement.clone();
+            let params = params.clone();
+            let options = options.clone();
+            let metadata = metadata.clone();
+            // Every retry retains the original identity. A transaction closure
+            // owns its copy because its future may outlive this call's immediate
+            // stack frame while the write lease is held.
+            let idempotency_for_commit = idempotency.clone();
+            let result = self
+                .with_write_transaction_reserved_lending(
+                    write_access,
+                    async move |transaction| {
+                        let previous_origin_key =
+                            transaction.replace_origin_key(options.origin_key);
+                        let result = async {
+                            let tx_plan = transaction
+                                .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                            let result = execute_prepared_transaction_write(
+                                transaction,
+                                tx_plan,
+                                &params,
+                                &metadata,
+                            )
+                            .await?;
+                            let result = ExecuteResult::from_sql_write_result(result);
+                            let receipt = ExecuteIdempotencyReceipt::single(
+                                &idempotency_for_commit,
+                                &result,
+                            )?;
+                            transaction.stage_execute_idempotency_receipt(
+                                &idempotency_for_commit,
+                                &receipt,
+                            )?;
+                            Ok(result)
+                        }
+                        .await;
+                        transaction.replace_origin_key(previous_origin_key);
+                        result
+                    },
+                    |_| Ok(()),
+                )
+                .await
+                .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
 
-        match result {
-            Ok(result) => Ok(result),
-            Err(error)
-                if matches!(
-                    error.code.as_str(),
-                    LixError::CODE_TRANSACTION_CONFLICT
-                        | LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
-                ) =>
-            {
-                match self.resolve_idempotency_receipt(&idempotency).await {
-                    Ok(IdempotencyReceiptResolution::Replay(receipt)) => {
-                        // `Transaction::commit` did not return normally, so
-                        // its usual invalidation path was skipped. A remote
-                        // receipt proves that this transaction did publish;
-                        // wake local observers before acknowledging recovery.
-                        self.observe_invalidation.bump();
-                        // Post-commit plugin actor publication is also
-                        // skipped on the ambiguous path. Drop private views
-                        // rather than let a stale acknowledgement poison the
-                        // next plugin-backed edit.
-                        self.file_views.clear();
-                        receipt.into_single_result()
-                    }
-                    Ok(IdempotencyReceiptResolution::Absent) => Err(error),
-                    Err(recovery_error) => Err(recovery_error),
+            match result {
+                Ok(result) => return Ok(result),
+                Err(error)
+                    if error.code == LixError::CODE_STORAGE_READ_EXPIRED
+                        && retry_expired_auto_commit(&mut expired_read_retries, &error).await =>
+                {
+                    continue;
                 }
+                Err(error)
+                    if matches!(
+                        error.code.as_str(),
+                        LixError::CODE_TRANSACTION_CONFLICT
+                            | LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+                    ) =>
+                {
+                    return match self
+                        .resolve_idempotency_receipt_with_expired_read_retry(
+                            &idempotency,
+                            &mut expired_read_retries,
+                        )
+                        .await
+                    {
+                        Ok(IdempotencyReceiptResolution::Replay(receipt)) => {
+                            // `Transaction::commit` did not return normally, so
+                            // its usual invalidation path was skipped. A remote
+                            // receipt proves that this transaction did publish;
+                            // wake local observers before acknowledging recovery.
+                            self.observe_invalidation.bump();
+                            // Post-commit plugin actor publication is also
+                            // skipped on the ambiguous path. Drop private views
+                            // rather than let a stale acknowledgement poison the
+                            // next plugin-backed edit.
+                            self.file_views.clear();
+                            receipt.into_single_result()
+                        }
+                        Ok(IdempotencyReceiptResolution::Absent) => Err(error),
+                        Err(recovery_error) => Err(recovery_error),
+                    };
+                }
+                Err(error) => return Err(error),
             }
-            Err(error) => Err(error),
         }
     }
 
@@ -1911,6 +1948,24 @@ where
         };
         Self::require_matching_idempotency_receipt(&durable, idempotency)?;
         Ok(IdempotencyReceiptResolution::Replay(durable))
+    }
+
+    async fn resolve_idempotency_receipt_with_expired_read_retry(
+        &self,
+        idempotency: &ExecuteIdempotency,
+        expired_read_retries: &mut ExpiredReadRetryState,
+    ) -> Result<IdempotencyReceiptResolution, LixError> {
+        loop {
+            match self.resolve_idempotency_receipt(idempotency).await {
+                Err(error)
+                    if error.code == LixError::CODE_STORAGE_READ_EXPIRED
+                        && retry_expired_auto_commit(expired_read_retries, &error).await =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
     }
 
     async fn load_idempotency_receipt(
@@ -2189,30 +2244,52 @@ where
                         )
                         .await;
                 };
-                if let IdempotencyReceiptResolution::Replay(receipt) =
-                    self.resolve_idempotency_receipt(&idempotency).await?
+                let mut expired_read_retries = ExpiredReadRetryState::default();
+                if let IdempotencyReceiptResolution::Replay(receipt) = self
+                    .resolve_idempotency_receipt_with_expired_read_retry(
+                        &idempotency,
+                        &mut expired_read_retries,
+                    )
+                    .await?
                 {
                     return receipt.into_results();
                 }
-                let result = self
-                    .execute_transaction_batch(
-                        statements,
-                        parsed,
-                        options,
-                        statement_metadata,
-                        Some(idempotency.clone()),
-                    )
-                    .await;
-                match result {
-                    Ok(results) => Ok(results),
-                    Err(error)
-                        if matches!(
-                            error.code.as_str(),
-                            LixError::CODE_TRANSACTION_CONFLICT
-                                | LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
-                        ) =>
-                    {
-                        match self.resolve_idempotency_receipt(&idempotency).await {
+                loop {
+                    let result = self
+                        .execute_transaction_batch(
+                            statements,
+                            parsed.clone(),
+                            options.clone(),
+                            statement_metadata.clone(),
+                            Some(idempotency.clone()),
+                        )
+                        .await;
+                    match result {
+                        Ok(results) => return Ok(results),
+                        Err(error)
+                            if error.code == LixError::CODE_STORAGE_READ_EXPIRED
+                                && retry_expired_auto_commit(
+                                    &mut expired_read_retries,
+                                    &error,
+                                )
+                                .await =>
+                        {
+                            continue;
+                        }
+                        Err(error)
+                            if matches!(
+                                error.code.as_str(),
+                                LixError::CODE_TRANSACTION_CONFLICT
+                                    | LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+                            ) =>
+                        {
+                            return match self
+                                .resolve_idempotency_receipt_with_expired_read_retry(
+                                    &idempotency,
+                                    &mut expired_read_retries,
+                                )
+                                .await
+                            {
                             Ok(IdempotencyReceiptResolution::Replay(receipt)) => {
                                 // See the single-statement recovery path:
                                 // positive receipt proof means a commit
@@ -2224,9 +2301,10 @@ where
                             }
                             Ok(IdempotencyReceiptResolution::Absent) => Err(error),
                             Err(recovery_error) => Err(recovery_error),
+                            };
                         }
+                        Err(error) => return Err(error),
                     }
-                    Err(error) => Err(error),
                 }
             }
         }
@@ -2239,7 +2317,8 @@ where
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        let mut auto_commit_retries = 0;
+        let mut transaction_conflict_retries = 0;
+        let mut expired_read_retries = ExpiredReadRetryState::default();
         loop {
             let result = self
                 .execute_transaction_batch(
@@ -2252,10 +2331,18 @@ where
                 .await;
             match result {
                 Ok(results) => return Ok(results),
-                Err(error) if consume_auto_commit_retry(&mut auto_commit_retries, &error) => {
-                    continue;
+                Err(error) => {
+                    if retry_auto_commit(
+                        &mut transaction_conflict_retries,
+                        &mut expired_read_retries,
+                        &error,
+                    )
+                    .await
+                    {
+                        continue;
+                    }
+                    return Err(error);
                 }
-                Err(error) => return Err(error),
             }
         }
     }
@@ -5544,15 +5631,37 @@ async fn retry_expired_read_with_write_quiescence(
     true
 }
 
-fn consume_auto_commit_retry(retries: &mut usize, error: &LixError) -> bool {
-    if !matches!(
-        error.code.as_str(),
-        LixError::CODE_STORAGE_READ_EXPIRED | LixError::CODE_TRANSACTION_CONFLICT
-    ) || *retries >= MAX_AUTO_COMMIT_RETRIES
+async fn retry_auto_commit(
+    conflict_retries: &mut usize,
+    expired_read_retries: &mut ExpiredReadRetryState,
+    error: &LixError,
+) -> bool {
+    if retry_expired_auto_commit(expired_read_retries, error).await {
+        return true;
+    }
+
+    if error.code != LixError::CODE_TRANSACTION_CONFLICT
+        || *conflict_retries >= MAX_AUTO_COMMIT_RETRIES
     {
         return false;
     }
-    *retries += 1;
+    *conflict_retries += 1;
+    true
+}
+
+async fn retry_expired_auto_commit(
+    expired_read_retries: &mut ExpiredReadRetryState,
+    error: &LixError,
+) -> bool {
+    let Some(delay) = expired_read_retries.next_delay(error) else {
+        return false;
+    };
+    // A cross-context owner transfer cannot finish while one WASM event-loop
+    // turn continuously tears down and reopens transactions.
+    tokio::task::yield_now().await;
+    if !delay.is_zero() {
+        crate::sync::sleep(delay).await;
+    }
     true
 }
 
@@ -5566,6 +5675,9 @@ mod tests {
     use super::*;
     use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
     use crate::row_pk::RowPk;
+    use crate::storage_adapter::{
+        MemoryRead, MemoryWrite, StorageError, StorageSessionToken,
+    };
     use crate::telemetry::{CallbackTelemetrySink, CompletedTelemetrySpan, TelemetryValue};
     use crate::transaction_types::{RawWriteBatch, TransactionJson, TransactionWriteRow};
     use crate::{
@@ -5582,6 +5694,226 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         engine.open_session().await.expect("session should open")
+    }
+
+    #[derive(Clone)]
+    struct RepeatedExpiringStorage {
+        inner: Memory,
+        schedule: Arc<StdMutex<Option<ExpirySchedule>>>,
+    }
+
+    struct ExpirySchedule {
+        reads_until_expiry: usize,
+        remaining_expiries: usize,
+    }
+
+    impl RepeatedExpiringStorage {
+        fn new() -> Self {
+            Self {
+                inner: Memory::new(),
+                schedule: Arc::new(StdMutex::new(None)),
+            }
+        }
+
+        fn expire_after_each_transaction_open(&self, count: usize) {
+            self.expire_after_reads(1, count);
+        }
+
+        fn expire_after_reads(&self, reads_until_expiry: usize, count: usize) {
+            assert!(count > 0);
+            *self.schedule.lock().expect("expiry schedule should lock") =
+                Some(ExpirySchedule {
+                    reads_until_expiry,
+                    remaining_expiries: count,
+                });
+        }
+
+        fn remaining_expiries(&self) -> usize {
+            self.schedule
+                .lock()
+                .expect("expiry schedule should lock")
+                .as_ref()
+                .map_or(0, |schedule| schedule.remaining_expiries)
+        }
+    }
+
+    impl Storage for RepeatedExpiringStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn acquire_session(&self) -> Result<StorageSessionToken, StorageError> {
+            self.inner.acquire_session().await
+        }
+
+        async fn begin_read(
+            &self,
+            options: StorageReadOptions,
+        ) -> Result<Self::Read<'_>, StorageError> {
+            let should_expire = {
+                let mut state = self.schedule.lock().expect("expiry schedule should lock");
+                match state.as_mut() {
+                    None => false,
+                    Some(schedule) if schedule.reads_until_expiry > 0 => {
+                        schedule.reads_until_expiry -= 1;
+                        false
+                    }
+                    Some(schedule) => {
+                        schedule.remaining_expiries -= 1;
+                        if schedule.remaining_expiries == 0 {
+                            *state = None;
+                        } else {
+                            schedule.reads_until_expiry = 1;
+                        }
+                        true
+                    }
+                }
+            };
+            if should_expire {
+                Err(StorageError::ReadExpired)
+            } else {
+                self.inner.begin_read(options).await
+            }
+        }
+
+        async fn begin_write(
+            &self,
+            options: StorageWriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.inner.begin_write(options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn auto_commit_retries_repeated_expired_transaction_reader_opens() {
+        let storage = RepeatedExpiringStorage::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized storage should create engine");
+        let session = engine.open_session().await.expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('retry-revert', 'value')",
+                &[],
+            )
+            .await
+            .expect("seed row should commit");
+
+        // Every attempt opens its coherent transaction read first; the next
+        // read is the tracked-state reader used to resolve lix_revert.
+        storage.expire_after_each_transaction_open(3);
+        let reverted = session
+            .execute(
+                "INSERT INTO lix_revert (relation, row_pk) \
+                 SELECT 'lix_key_value', lixcol_row_pk \
+                 FROM lix_diff(\
+                   'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
+                 ) \
+                 WHERE lixcol_row_pk = CAST('[\"retry-revert\"]' AS JSONB)",
+                &[],
+            )
+            .await
+            .expect("revert should outlast transient transaction-reader expiry");
+
+        assert_eq!(reverted.rows_affected(), 1);
+        assert_eq!(storage.remaining_expiries(), 0);
+        let live = session
+            .execute(
+                "SELECT key FROM lix_key_value WHERE key = 'retry-revert'",
+                &[],
+            )
+            .await
+            .expect("live row should read");
+        assert!(live.rows().is_empty(), "revert should remove the live row");
+        let history = session
+            .execute(
+                "SELECT COUNT(*) AS count \
+                 FROM lix_history('lix_key_value') \
+                 WHERE key = 'retry-revert'",
+                &[],
+            )
+            .await
+            .expect("history should read");
+        assert_eq!(
+            history.rows()[0].get::<i64>("count"),
+            Ok(2),
+            "three failed attempts must still publish exactly one revert"
+        );
+    }
+
+    #[tokio::test]
+    async fn idempotent_auto_commit_retries_expired_transaction_reader_opens() {
+        let storage = RepeatedExpiringStorage::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized storage should create engine");
+        let session = engine.open_session().await.expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('idempotent-revert', 'value')",
+                &[],
+            )
+            .await
+            .expect("seed row should commit");
+        let branch_id = session
+            .active_branch_id()
+            .await
+            .expect("active branch should load");
+        let idempotency = ExecuteIdempotency::new(
+            Some("retry-test".to_string()),
+            "idempotent-revert-key".to_string(),
+            [7; 32],
+        )
+        .with_branch(branch_id);
+        let sql = "INSERT INTO lix_revert (relation, row_pk) \
+                   SELECT 'lix_key_value', lixcol_row_pk \
+                   FROM lix_diff(\
+                     'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
+                   ) \
+                   WHERE lixcol_row_pk = CAST('[\"idempotent-revert\"]' AS JSONB)";
+
+        // The first read checks for a pre-existing receipt, then every attempt
+        // opens its coherent transaction read before the tracked-state reader.
+        storage.expire_after_reads(2, 3);
+        let reverted = session
+            .execute_with_kind(
+                sql,
+                &[],
+                ExecuteOptions::default(),
+                ExecuteStatementMetadata::default(),
+                "execute",
+                Some(idempotency.clone()),
+                true,
+            )
+            .await
+            .expect("idempotent revert should retry transient reader expiry");
+        assert_eq!(reverted.rows_affected(), 1);
+        assert_eq!(storage.remaining_expiries(), 0);
+        let history = session
+            .execute(
+                "SELECT COUNT(*) AS count \
+                 FROM lix_history('lix_key_value') \
+                 WHERE key = 'idempotent-revert'",
+                &[],
+            )
+            .await
+            .expect("history should read");
+        assert_eq!(
+            history.rows()[0].get::<i64>("count"),
+            Ok(2),
+            "idempotent retries must publish one revert"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/merge/branch.rs
+++ b/packages/lix/src/session/merge/branch.rs
@@ -144,7 +144,7 @@ where
                 }
 
                 let (target_head, source_head) = async {
-                    let reader = transaction.branch_ref_reader().await;
+                    let reader = transaction.branch_ref_reader().await?;
                     let lifecycle = BranchLifecycle::new(&reader);
                     let target_head = lifecycle
                         .require_existing_commit_id(
@@ -166,14 +166,14 @@ where
                 .await?;
 
                 let merge_base = async {
-                    let mut reader = transaction.commit_graph_reader().await;
+                    let mut reader = transaction.commit_graph_reader().await?;
                     reader.merge_base(&target_head, &source_head).await
                 }
                 .instrument(tracing::debug_span!(target: "lix_perf", "lix.perf.merge_base"))
                 .await?;
 
                 let analysis = async {
-                    let mut reader = transaction.tracked_state_reader().await;
+                    let mut reader = transaction.tracked_state_reader().await?;
                     analyze(
                         &mut reader,
                         MergeCommits {
@@ -187,7 +187,7 @@ where
                 .instrument(tracing::debug_span!(target: "lix_perf", "lix.perf.merge_analysis"))
                 .await?;
                 let derived_blob_files = async {
-                    let mut reader = transaction.tracked_state_reader().await;
+                    let mut reader = transaction.tracked_state_reader().await?;
                     derived_plugin_blob_conflicts(&mut reader, &analysis).await
                 }
                 .instrument(tracing::debug_span!(target: "lix_perf", "lix.perf.merge_derived_blob_detection"))
@@ -204,7 +204,7 @@ where
                     .instrument(tracing::debug_span!(target: "lix_perf", "lix.perf.merge_plugin_conflict_resolve"))
                     .await?;
                     async {
-                        let mut reader = transaction.tracked_state_reader().await;
+                        let mut reader = transaction.tracked_state_reader().await?;
                         plugin_resolution_change_stats(&mut reader, &analysis, &resolved_plugin_rows).await
                     }
                     .instrument(tracing::debug_span!(target: "lix_perf", "lix.perf.merge_plugin_resolution_stats"))
@@ -244,7 +244,7 @@ where
             }
 
             let (target_head, source_head) = async {
-                let reader = transaction.branch_ref_reader().await;
+                let reader = transaction.branch_ref_reader().await?;
                 let lifecycle = BranchLifecycle::new(&reader);
                 let target_head = lifecycle
                     .require_existing_commit_id(
@@ -269,7 +269,7 @@ where
             .await?;
 
             let merge_base = async {
-                let mut reader = transaction.commit_graph_reader().await;
+                let mut reader = transaction.commit_graph_reader().await?;
                 reader.merge_base(&target_head, &source_head).await
             }
             .instrument(tracing::debug_span!(
@@ -279,7 +279,7 @@ where
             .await?;
             let base_commit_id = merge_base;
             let analysis = async {
-                let mut reader = transaction.tracked_state_reader().await;
+                let mut reader = transaction.tracked_state_reader().await?;
                 analyze(
                     &mut reader,
                     MergeCommits {
@@ -296,7 +296,7 @@ where
             ))
             .await?;
             let derived_blob_files = async {
-                let mut reader = transaction.tracked_state_reader().await;
+                let mut reader = transaction.tracked_state_reader().await?;
                 derived_plugin_blob_conflicts(&mut reader, &analysis).await
             }
             .instrument(tracing::debug_span!(
@@ -354,7 +354,7 @@ where
             ))
             .await?;
             let plugin_resolution_stats = async {
-                let mut reader = transaction.tracked_state_reader().await;
+                let mut reader = transaction.tracked_state_reader().await?;
                 plugin_resolution_change_stats(&mut reader, &analysis, &resolved_plugin_rows).await
             }
             .instrument(tracing::debug_span!(
@@ -364,7 +364,7 @@ where
             .await?;
 
             let semantic_rows = async {
-                let mut reader = transaction.tracked_state_reader().await;
+                let mut reader = transaction.tracked_state_reader().await?;
                 materialized_plugin_merge_rows(
                     &mut reader,
                     &analysis,
@@ -454,7 +454,7 @@ where
         self.with_write_transaction_lending(async move |transaction| {
             let active_branch_id = transaction.active_branch_id().to_string();
             let target_head = {
-                let reader = transaction.branch_ref_reader().await;
+                let reader = transaction.branch_ref_reader().await?;
                 BranchLifecycle::new(&reader)
                     .require_existing_commit_id(
                         &active_branch_id,
@@ -468,11 +468,11 @@ where
             }
 
             let base_commit_id = {
-                let mut reader = transaction.commit_graph_reader().await;
+                let mut reader = transaction.commit_graph_reader().await?;
                 reader.merge_base(&target_head, &source_head).await?
             };
             let analysis = {
-                let mut reader = transaction.tracked_state_reader().await;
+                let mut reader = transaction.tracked_state_reader().await?;
                 analyze(
                     &mut reader,
                     MergeCommits {
@@ -834,7 +834,7 @@ where
     // Historical reads finish before any Component is instantiated. All
     // merge input below owns or shares immutable buffers.
     let inputs = {
-        let mut reader = transaction.tracked_state_reader().await;
+        let mut reader = transaction.tracked_state_reader().await?;
         let base_rows = reader
             .load_projected_batch_at_commit(
                 &analysis.commits.base_commit_id.to_string(),

--- a/packages/lix/src/session/undo_redo.rs
+++ b/packages/lix/src/session/undo_redo.rs
@@ -197,7 +197,7 @@ where
     let local_operation_key = semantic_key(branch_id)?;
     let marker_schemas = [UNDO_REDO_MARKER_SCHEMA_KEY.to_string()];
     let marker_delta = {
-        let mut tracked = transaction.tracked_state_reader().await;
+        let mut tracked = transaction.tracked_state_reader().await?;
         tracked
             .commit_delta_values_for_schemas(commit_id, &marker_schemas)
             .await?
@@ -290,7 +290,7 @@ where
         return Ok((SemanticState::default(), delta));
     }
     let rows = {
-        let mut tracked = transaction.tracked_state_reader().await;
+        let mut tracked = transaction.tracked_state_reader().await?;
         tracked
             .load_projected_batch_at_commit(
                 &commit_id.to_string(),
@@ -341,7 +341,7 @@ where
     let branch_pk = RowPk::uuid_from_canonical(branch_id)
         .map_err(|error| LixError::new(LixError::CODE_INVALID_PARAM, error.to_string()))?;
     let rows = {
-        let mut tracked = transaction.tracked_state_reader().await;
+        let mut tracked = transaction.tracked_state_reader().await?;
         tracked
             .load_projected_batch_at_commit(
                 &commit_id.to_string(),
@@ -407,7 +407,7 @@ async fn load_commit_delta<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let mut tracked = transaction.tracked_state_reader().await;
+    let mut tracked = transaction.tracked_state_reader().await?;
     tracked.commit_delta_members(commit_id).await
 }
 
@@ -420,7 +420,7 @@ where
 {
     transaction
         .commit_graph_reader()
-        .await
+        .await?
         .load_node(&commit_id)
         .await?
         .ok_or_else(|| {
@@ -468,7 +468,7 @@ where
     } else {
         let visible_schema_keys = transaction.visible_schema_keys()?;
         let dependency_commit = if desired_is_target { current } else { desired };
-        let mut tracked = transaction.tracked_state_reader().await;
+        let mut tracked = transaction.tracked_state_reader().await?;
         tracked
             .descriptor_dependency_closure(
                 &current.to_string(),

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8256,27 +8256,32 @@ where
     }
 
     /// Creates a branch-ref reader scoped to this write transaction.
-    pub(crate) async fn branch_ref_reader(&mut self) -> impl BranchRefReader + '_ {
+    pub(crate) async fn branch_ref_reader(
+        &mut self,
+    ) -> Result<impl BranchRefReader + '_, LixError> {
         let read = self
             .storage
             .begin_read(StorageReadOptions::default())
-            .await
-            .expect("open transaction read scope");
-        self.branch_ctx
-            .ref_reader(SharedStorageAdapterRead::new(read))
+            .await?;
+        Ok(self
+            .branch_ctx
+            .ref_reader(SharedStorageAdapterRead::new(read)))
     }
 
     /// Creates a tracked-state reader scoped to this write transaction.
     pub(crate) async fn tracked_state_reader(
         &mut self,
-    ) -> TrackedStateStoreReader<SharedStorageAdapterRead<StorageImpl::Read<'_>>> {
+    ) -> Result<
+        TrackedStateStoreReader<SharedStorageAdapterRead<StorageImpl::Read<'_>>>,
+        LixError,
+    > {
         let read = self
             .storage
             .begin_read(StorageReadOptions::default())
-            .await
-            .expect("open transaction read scope");
-        self.tracked_state
-            .reader(SharedStorageAdapterRead::new(read))
+            .await?;
+        Ok(self
+            .tracked_state
+            .reader(SharedStorageAdapterRead::new(read)))
     }
 
     /// Returns the private compaction cursor bound to this transaction's
@@ -8307,13 +8312,15 @@ where
     /// Creates a commit-graph reader scoped to this write transaction.
     pub(crate) async fn commit_graph_reader(
         &mut self,
-    ) -> CommitGraphStoreReader<SharedStorageAdapterRead<StorageImpl::Read<'_>>> {
+    ) -> Result<
+        CommitGraphStoreReader<SharedStorageAdapterRead<StorageImpl::Read<'_>>>,
+        LixError,
+    > {
         let read = self
             .storage
             .begin_read(StorageReadOptions::default())
-            .await
-            .expect("open transaction read scope");
-        CommitGraphContext::new().reader(SharedStorageAdapterRead::new(read))
+            .await?;
+        Ok(CommitGraphContext::new().reader(SharedStorageAdapterRead::new(read)))
     }
 
     /// Applies a tracked-state transition resolved from two immutable commits.
@@ -8358,7 +8365,7 @@ where
         }
 
         let (current_rows, desired_rows) = {
-            let mut tracked = self.tracked_state_reader().await;
+            let mut tracked = self.tracked_state_reader().await?;
             let current_rows = tracked
                 .load_projected_batch_at_commit(
                     &current_commit_id.to_string(),
@@ -8864,7 +8871,7 @@ where
                     "lix_apply requires a selection from exactly one lix_diff(relation, from_commit_id, to_commit_id)",
                 )
             })?;
-            let mut tracked = self.tracked_state_reader().await;
+            let mut tracked = self.tracked_state_reader().await?;
             for request in &requests {
                 entries.extend(
                     tracked
@@ -8896,7 +8903,7 @@ where
                 if let Some(direct) = direct {
                     entries.extend(direct.diff.entries);
                 } else {
-                    let mut tracked = self.tracked_state_reader().await;
+                    let mut tracked = self.tracked_state_reader().await?;
                     entries.extend(
                         tracked
                             .diff_commits(
@@ -9164,7 +9171,7 @@ where
         let diff = match direct_diff {
             Some(direct) => direct.diff,
             None => {
-                let mut tracked = self.tracked_state_reader().await;
+                let mut tracked = self.tracked_state_reader().await?;
                 tracked
                     .diff_commits(
                         &previous_checkpoint_commit_id.to_string(),
@@ -11058,7 +11065,7 @@ where
             BranchReferenceRole::Target,
         )?;
         let head_commit_id = {
-            let reader = self.branch_ref_reader().await;
+            let reader = self.branch_ref_reader().await?;
             BranchLifecycle::new(&reader)
                 .require_existing_commit_id(
                     &branch_id,
@@ -11068,7 +11075,7 @@ where
                 .await?
         };
 
-        let mut commit_graph = self.commit_graph_reader().await;
+        let mut commit_graph = self.commit_graph_reader().await?;
         BranchLifecycle::require_existing_commit(
             &mut commit_graph,
             target_commit_id,
@@ -13455,7 +13462,7 @@ fn catalog_revision_is_current(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Instant;
 
     use serde_json::json;
@@ -13466,7 +13473,10 @@ mod tests {
     use crate::branch::BranchContext;
     use crate::engine::Engine;
     use crate::functions::{DeterministicFunctionProvider, FunctionProvider};
-    use crate::storage_adapter::{Memory, StorageReadOptions};
+    use crate::storage_adapter::{
+        Memory, MemoryRead, MemoryWrite, Storage, StorageError, StorageReadOptions,
+        StorageSessionToken, StorageWriteOptions,
+    };
     use crate::tracked_state::{
         TrackedStateDiffIdentity, TrackedStateKey, TrackedStateScanRequest,
     };
@@ -13493,7 +13503,93 @@ mod tests {
         HotStateContext::new(TrackedStateContext::new(), CommitGraphContext::new())
     }
 
+    #[derive(Clone)]
+    struct OneShotExpiringStorage {
+        inner: Memory,
+        expire_next_read: Arc<AtomicBool>,
+    }
+
+    impl Storage for OneShotExpiringStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn acquire_session(&self) -> Result<StorageSessionToken, StorageError> {
+            self.inner.acquire_session().await
+        }
+
+        async fn begin_read(
+            &self,
+            options: StorageReadOptions,
+        ) -> Result<Self::Read<'_>, StorageError> {
+            if self.expire_next_read.swap(false, Ordering::SeqCst) {
+                return Err(StorageError::ReadExpired);
+            }
+            self.inner.begin_read(options).await
+        }
+
+        async fn begin_write(
+            &self,
+            options: StorageWriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.inner.begin_write(options).await
+        }
+    }
+
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[tokio::test]
+    async fn transaction_reader_open_expiry_is_returned_instead_of_panicking() {
+        let inner = Memory::new();
+        seed_visible_schema_rows(StorageAdapter::new(inner.clone())).await;
+        let expire_next_read = Arc::new(AtomicBool::new(false));
+        let storage = StorageAdapter::new(OneShotExpiringStorage {
+            inner,
+            expire_next_read: Arc::clone(&expire_next_read),
+        });
+        let opened = open_transaction(
+            &SessionBranch::new(GLOBAL_BRANCH_ID.to_string()),
+            crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            storage,
+            Arc::new(hot_state_context()),
+            Arc::new(TrackedStateContext::new()),
+            Arc::new(BinaryCasContext::new()),
+            PluginRuntimeHost::new(Arc::new(crate::plugin::runtime::UnsupportedWasmRuntime)),
+            Arc::new(BranchContext::new()),
+            Arc::new(CatalogContext::new()),
+            Arc::new(SqlPlanningCache::default()),
+            SessionFileViews::default(),
+        )
+        .await
+        .expect("transaction should open");
+        let mut transaction = opened.transaction;
+
+        expire_next_read.store(true, Ordering::SeqCst);
+        let error = match transaction.tracked_state_reader().await {
+            Ok(_) => panic!("tracked-state reader should return the expired read"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code, LixError::CODE_STORAGE_READ_EXPIRED);
+
+        expire_next_read.store(true, Ordering::SeqCst);
+        let error = match transaction.branch_ref_reader().await {
+            Ok(_) => panic!("branch-ref reader should return the expired read"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code, LixError::CODE_STORAGE_READ_EXPIRED);
+
+        expire_next_read.store(true, Ordering::SeqCst);
+        let error = match transaction.commit_graph_reader().await {
+            Ok(_) => panic!("commit-graph reader should return the expired read"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code, LixError::CODE_STORAGE_READ_EXPIRED);
+    }
 
     #[test]
     fn semantic_conflict_limits_scale_host_owned_records_but_not_bytes_or_deadline() {


### PR DESCRIPTION
## Summary

- return `LIX_STORAGE_READ_EXPIRED` from transaction reader construction instead of panicking
- retry expired transaction reads with bounded backoff across non-idempotent and idempotent auto-commit writes
- preserve idempotency identity and ambiguous-outcome receipt recovery across retries

This was uncovered by Lixray's deployed-preview sync test after the plain-object result-row migration: concurrent browser sync could expire a transaction read between opening the transaction and constructing its tracked-state reader, crashing the WASM runtime.

## Validation

- `cargo nextest run -p lix --features all-simulations` (3,393 passed)
- `cargo test -p lix --doc` (10 passed)
- `cargo clippy -p lix --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- focused expiry injection tests for constructor propagation, non-idempotent exactly-once behavior, and idempotent exactly-once behavior
